### PR TITLE
Altering python app so that it behaves more like a regular python call

### DIFF
--- a/apps/python/python-1.py
+++ b/apps/python/python-1.py
@@ -52,7 +52,6 @@ class python( Gaffer.Application ) :
 					name = "file",
 					description = "The python script to execute",
 					defaultValue = "",
-					extensions = "py",
 					allowEmptyString = False,
 					check = IECore.FileNameParameter.CheckType.MustExist,
 				),

--- a/apps/python/python-1.py
+++ b/apps/python/python-1.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import traceback
+import sys
 import IECore
 import Gaffer
 
@@ -75,14 +76,40 @@ class python( Gaffer.Application ) :
 		
 	def _run( self, args ) :
 
-		try :
-			execfile( args["file"].value, { "argv" : args["arguments"] } )
-			return 0
-		except SystemExit as e :
-			# don't print traceback when a sys.exit was called, but return the exit code as the result
-			return e.code
-		except :
-			traceback.print_exc()
-			return 1
+		# trying to set the sys.argv to the same values as we would expect from a python call
+		#
+		# the gaffer python command line syntax is expected to be:
+		# gaffer python -file <script path> [-arguments <arguments>]
+		#
+		# given the limitations of the gaffer python app command line syntax, we can assume that the equivalent python command syntax would be:
+		# python <script path> [<arguments>]
+		#
+		# python removes the "python" command from the start of the sys.argv list, making the first argument the script path
+		# sys.argv should therefore be:
+		# [<script path>] + [<arguments>]
+		#
+		# sys.argv is assumed to be the source of information for python argument parsing methods (argparse, getopt, ...)
+		#
+		# NOTE: this is not thread-safe
+		# we could make it thread safe by using a mechanism similar to the one used by gaffer/python/Gaffer/OutputRedirection.py
+		# but using that method, a generic python code could break if it was actually trying to alter a global sys.argv from a thread
+		# however, since changing sys.argv is quite rare, and calling "gaffer python app" from a Thread is also a very unlikely scenario
+		# we'll just leave it thread-unsafe for the moment
+
+		origSysArgv = sys.argv
+		try:
+			sys.argv = [ args[ "file" ].value ] + list( args[ "arguments" ] )
+			try :
+				execfile( args["file"].value, { "argv" : args["arguments"] } )
+				return 0
+			except SystemExit as e :
+				# don't print traceback when a sys.exit was called, but return the exit code as the result
+				return e.code
+			except :
+				traceback.print_exc()
+				return 1
+		finally:
+			# restore sys.argv
+			sys.argv = origSysArgv
 
 IECore.registerRunTimeTyped( python )

--- a/apps/python/python-1.py
+++ b/apps/python/python-1.py
@@ -78,6 +78,9 @@ class python( Gaffer.Application ) :
 		try :
 			execfile( args["file"].value, { "argv" : args["arguments"] } )
 			return 0
+		except SystemExit as e :
+			# don't print traceback when a sys.exit was called, but return the exit code as the result
+			return e.code
 		except :
 			traceback.print_exc()
 			return 1


### PR DESCRIPTION
In order to be able to easily make a python script capable of importing gaffer it is important variables like sys.argv have the same value regardless of whether they were called from  "python" or from "gaffer python".
We also want things like return values from the script to be preserved, and that the output from one or the other be similar.

My proposal here is to get rid of the traceback print out, as that was interfering with sys.exit calls, and replacing the return value with "1". That is the behaviour we get if we use python directly.

Also, I'm suggesting we "hack" the sys.argv variable value so that it matches what we'd get from a call to python, as explained in the code:
```python
		# trying to set the sys.argv to the same values as we would expect from a python call
		#
		# the expected gaffer python command line syntax is expected to be:
		#     gaffer python -file <script path> [-arguments <arguments>]
		#
		# given the limitations of the gaffer python app, we can assume that the equivalent python command syntax would be:
		#     python <script path> [<arguments>]
		#
		# python removes the "python" command from the start of the sys.argv list, making the first argument the script path
		# sys.argv should therefore be:
		#     [<script path>] + [<arguments>]
		#
		# sys.argv is assumed to be the base source of information for python argument parsing methods (argparse, getopt, ...)
```

This is changing the existing behaviour of the gaffer python app, but I'm not aware of any uses, so maybe it would be ok to not preserve full backward compatibility. But if that is an issue, we could create a different app with the changes I'm suggesting (possibly internal to IE).
Note that I'm still passing the argv variable (with an IECore.StringVectorData) as before, as that is not part of regular python.

There is another change that we may consider, which is to alter the `__name__` python variable.
When running python with a script, you get that set to `__main__`. Using the gaffer python app we get `__builtin__`. Maybe we should set it to `__main__`? But changing existing code to support both is not difficult, and there could be reasons to keep it as `__builtin__` that I'm not aware of.
