### PR TITLE
NodeGraph error reporting

### DIFF
--- a/include/Gaffer/Node.h
+++ b/include/Gaffer/Node.h
@@ -1,7 +1,7 @@
 //////////////////////////////////////////////////////////////////////////
 //
 //  Copyright (c) 2011-2012, John Haddon. All rights reserved.
-//  Copyright (c) 2012-2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2012-2014, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -130,6 +130,28 @@ class Node : public GraphComponent
 		/// Accepts only Nodes.
 		virtual bool acceptsParent( const GraphComponent *potentialParent ) const;
 
+		/// Signal type for communicating errors. The plug argument is the
+		/// plug being processed when the error occurred. The source argument
+		/// specifies the original source of the error, since it may be being
+		/// propagated downstream from an original upstream error. The error
+		/// argument is a description of the problem.
+		typedef boost::signal<void ( const Plug *plug, const Plug *source, const std::string &error )> ErrorSignal;
+		/// Signal emitted when an error occurs while processing this node.
+		/// This is intended to allow UI elements to display errors that occur
+		/// during processing triggered by other parts of the UI.
+		///
+		/// Note that C++ exceptions are still the primary mechanism for error handling
+		/// within Gaffer - the existence of this signal does nothing to change
+		/// that. The signal merely allows passive observers of the graph to be
+		/// notified of errors during processing - clients which invoke such
+		/// processing must still use C++ exception handling to deal directly with
+		/// any errors which occur.
+		///
+		/// \threading Since node graph processing may occur on any thread, it is
+		/// important to note that this signal may also be emitted on any thread.
+		ErrorSignal &errorSignal();
+		const ErrorSignal &errorSignal() const;
+
 	protected :
 
 		/// May be overridden to restrict the inputs that plugs on this node will
@@ -160,6 +182,7 @@ class Node : public GraphComponent
 		UnaryPlugSignal m_plugInputChangedSignal;
 		UnaryPlugSignal m_plugFlagsChangedSignal;
 		UnaryPlugSignal m_plugDirtiedSignal;
+		ErrorSignal m_errorSignal;
 
 };
 

--- a/include/GafferUI/Gadget.h
+++ b/include/GafferUI/Gadget.h
@@ -248,6 +248,9 @@ class Gadget : public Gaffer::GraphComponent
 		static IdleSignal &idleSignal();
 		//@}
 
+		typedef boost::function<void ()> UIThreadFunction;
+		static void executeOnUIThread( UIThreadFunction function );
+
 	protected :
 
 		/// The subclass specific part of render(). The public render() method
@@ -300,7 +303,14 @@ class Gadget : public Gaffer::GraphComponent
 		// when absolutely necessary (when slots are connected).
 		static IdleSignal &idleSignalAccessedSignal();
 		friend void GafferUIBindings::bindGadget();
-
+		// Used to implement executeOnUIThread(). When Gadget::executeOnUIThread()
+		// is called, it emits this signal to request that EventLoop.py arranges
+		// to call the passed function on the UI thread.
+		/// \todo I suspect that soon we'll have a Qt dependency in the C++
+		/// half of GafferUI, at which point it'd make more sense to implement
+		/// EventLoop in C++ rather than to implement this in such an awkward way.
+		typedef boost::signal<void ( UIThreadFunction )> ExecuteOnUIThreadSignal;
+		static ExecuteOnUIThreadSignal &executeOnUIThreadSignal();
 };
 
 typedef Gaffer::FilteredChildIterator<Gaffer::TypePredicate<Gadget> > GadgetIterator;

--- a/include/GafferUI/StandardNodeGadget.h
+++ b/include/GafferUI/StandardNodeGadget.h
@@ -147,7 +147,7 @@ class StandardNodeGadget : public NodeGadget
 
 		IE_CORE_FORWARDDECLARE( ErrorGadget );
 		ErrorGadget *errorGadget( bool createIfMissing = true );
-		void error( Gaffer::ConstPlugPtr plug, Gaffer::ConstPlugPtr source, const std::string &message );
+		void error( const Gaffer::Plug *plug, const Gaffer::Plug *source, const std::string &message );
 		void displayError( Gaffer::ConstPlugPtr plug, const std::string &message );
 
 		const LinearContainer::Orientation m_orientation;

--- a/include/GafferUI/StandardNodeGadget.h
+++ b/include/GafferUI/StandardNodeGadget.h
@@ -100,7 +100,6 @@ class StandardNodeGadget : public NodeGadget
 		void setLabelsVisibleOnHover( bool labelsVisible );
 		bool getLabelsVisibleOnHover() const;
 
-		virtual bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const;
 		virtual Imath::Box3f bound() const;
 
 	protected :
@@ -145,6 +144,11 @@ class StandardNodeGadget : public NodeGadget
 
 		bool updateUserColor();
 		void updatePadding();
+
+		IE_CORE_FORWARDDECLARE( ErrorGadget );
+		ErrorGadget *errorGadget( bool createIfMissing = true );
+		void error( Gaffer::ConstPlugPtr plug, Gaffer::ConstPlugPtr source, const std::string &message );
+		void displayError( Gaffer::ConstPlugPtr plug, const std::string &message );
 
 		const LinearContainer::Orientation m_orientation;
 		bool m_nodeEnabled;

--- a/python/GafferSceneTest/SceneReaderTest.py
+++ b/python/GafferSceneTest/SceneReaderTest.py
@@ -501,6 +501,25 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( sets["wood"].value.paths(), [ "/planeGroup/plane" ] )
 		self.assertEqual( sets["something"].value.paths(), [ "/planeGroup/plane" ] )
 
+	def testInvalidFiles( self ) :
+
+		reader = GafferScene.SceneReader()
+		reader["fileName"].setValue( "iDontExist.scc" )
+
+		for i in range( 0, 10 ) :
+			self.assertRaises( RuntimeError, GafferSceneTest.traverseScene, reader["out"], Gaffer.Context() )
+
+	def testInvalidPaths( self ) :
+
+		self.writeAnimatedSCC()
+
+		reader = GafferScene.SceneReader()
+		reader["fileName"].setValue( self.__testFile )
+		reader["refreshCount"].setValue( self.uniqueInt( self.__testFile ) )
+
+		for i in range( 0, 10 ) :
+			self.assertRaises( RuntimeError, reader["out"].object, "/this/object/does/not/exist" )
+
 	def tearDown( self ) :
 
 		if os.path.exists( self.__testFile ) :

--- a/python/GafferTest/ComputeNodeTest.py
+++ b/python/GafferTest/ComputeNodeTest.py
@@ -368,5 +368,66 @@ class ComputeNodeTest( GafferTest.TestCase ) :
 		self.assertEqual( n["out"].getValue(), a["sum"].getValue() )
 		self.assertEqual( n["out"].hash(), a["sum"].hash() )
 
+	def testErrorSignal( self ) :
+
+		b = GafferTest.BadNode()
+		a = GafferTest.AddNode()
+		a["op1"].setInput( b["out3"] )
+
+		cs = GafferTest.CapturingSlot( b.errorSignal() )
+
+		self.assertRaises( RuntimeError, b["out1"].getValue )
+		self.assertEqual( len( cs ), 1 )
+		self.assertTrue( cs[0][0].isSame( b["out1"] ) )
+		self.assertTrue( cs[0][1].isSame( b["out1"] ) )
+		self.assertTrue( isinstance( cs[0][2], str ) )
+
+		self.assertRaises( RuntimeError, a["sum"].getValue )
+		self.assertEqual( len( cs ), 2 )
+		self.assertTrue( cs[1][0].isSame( b["out3"] ) )
+		self.assertTrue( cs[1][1].isSame( b["out3"] ) )
+		self.assertTrue( isinstance( cs[1][2], str ) )
+
+	def testErrorSignalledOnIntermediateNodes( self ) :
+
+		nodes = [ GafferTest.BadNode() ]
+		for i in range( 0, 10 ) :
+
+			nodes.append( GafferTest.AddNode() )
+			nodes[-1]["op1"].setInput(
+				nodes[-2]["sum"] if i != 0 else nodes[-2]["out3"]
+			)
+
+		slots = [ GafferTest.CapturingSlot( n.errorSignal() ) for n in nodes ]
+
+		self.assertRaises( RuntimeError, nodes[-1]["sum"].getValue )
+		for i, slot in enumerate( slots ) :
+			self.assertEqual( len( slot ), 1 )
+			self.assertTrue( slot[0][0].isSame( nodes[i]["out3"] if i == 0 else nodes[i]["sum"] ) )
+			self.assertTrue( slot[0][1].isSame( nodes[0]["out3"] ) )
+
+	def testErrorSignalledAtScopeTransitions( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["b"] = Gaffer.Box()
+		s["b"]["b"] = GafferTest.BadNode()
+		s["b"]["a"] = GafferTest.AddNode()
+		s["b"]["a"]["op1"].setInput( s["b"]["b"]["out3"] )
+
+		css = GafferTest.CapturingSlot( s.errorSignal() )
+		csb = GafferTest.CapturingSlot( s["b"].errorSignal() )
+		csbb = GafferTest.CapturingSlot( s["b"]["b"].errorSignal() )
+
+		p = s["b"].promotePlug( s["b"]["a"]["sum"], asUserPlug = False )
+
+		self.assertRaises( RuntimeError, p.getValue )
+		self.assertEqual( len( css ), 0 )
+		self.assertEqual( len( csb ), 1 )
+		self.assertTrue( csb[0][0].isSame( p ) )
+		self.assertTrue( csb[0][1].isSame( s["b"]["b"]["out3"] ) )
+		self.assertEqual( len( csbb ), 1 )
+		self.assertTrue( csbb[0][0].isSame( s["b"]["b"]["out3"] ) )
+		self.assertTrue( csbb[0][1].isSame( s["b"]["b"]["out3"] ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUI/EventLoop.py
+++ b/python/GafferUI/EventLoop.py
@@ -228,6 +228,8 @@ class EventLoop() :
 	@classmethod
 	def __ensureIdleTimer( cls ) :
 
+		assert( QtCore.QThread.currentThread() == EventLoop.__qtApplication.thread() )
+
 		if cls.__idleTimer is None :
 			cls.__idleTimer = QtCore.QTimer( cls.__qtApplication )
 			cls.__idleTimer.timeout.connect( cls.__qtIdleCallback )
@@ -239,6 +241,8 @@ class EventLoop() :
 	# doesn't support classmethods as slots.
 	@staticmethod
 	def __qtIdleCallback() :
+
+		assert( QtCore.QThread.currentThread() == EventLoop.__qtApplication.thread() )
 
 		GafferUI.Gadget.idleSignal()()
 
@@ -258,6 +262,10 @@ class EventLoop() :
 
 	@classmethod
 	def _gadgetIdleSignalAccessed( cls ) :
+
+		# It would be an error to access the idle signal from anything but the main
+		# thread, because it would imply multiple threads fighting over the same signal.
+		assert( QtCore.QThread.currentThread() == EventLoop.__qtApplication.thread() )
 
 		cls.__ensureIdleTimer()
 

--- a/python/GafferUI/EventLoop.py
+++ b/python/GafferUI/EventLoop.py
@@ -269,6 +269,11 @@ class EventLoop() :
 
 		cls.__ensureIdleTimer()
 
+	@classmethod
+	def _gadgetExecuteOnUIThread( cls, callable ) :
+
+		cls.executeOnUIThread( callable )
+
 	def __pumpThreadFn( self ) :
 
 		import maya.utils
@@ -283,6 +288,7 @@ class EventLoop() :
 			self.__qtEventLoop.processEvents()
 
 _gadgetIdleSignalAccessedConnection = GafferUI.Gadget._idleSignalAccessedSignal().connect( EventLoop._gadgetIdleSignalAccessed )
+_gadgetExecuteOnUIThreadConnection = GafferUI.Gadget._executeOnUIThreadSignal().connect( EventLoop._gadgetExecuteOnUIThread )
 
 class _UIThreadExecutor( QtCore.QObject ) :
 

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -52,18 +52,18 @@
      inkscape:pageopacity="1"
      inkscape:pageshadow="2"
      inkscape:zoom="1"
-     inkscape:cx="169.64372"
-     inkscape:cy="809.72834"
+     inkscape:cx="178.08936"
+     inkscape:cy="852.44886"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
-     inkscape:window-width="1088"
-     inkscape:window-height="859"
-     inkscape:window-x="281"
+     inkscape:window-width="1374"
+     inkscape:window-height="814"
+     inkscape:window-x="66"
      inkscape:window-y="0"
      inkscape:window-maximized="0"
      inkscape:snap-global="true"
-     inkscape:snap-nodes="true"
+     inkscape:snap-nodes="false"
      inkscape:snap-bbox="true"
      inkscape:object-nodes="true"
      inkscape:snap-object-midpoints="false"
@@ -2374,6 +2374,49 @@
 	 width="25"
 	 id="rect4100"
 	 style="opacity:0.35344831;fill:none;stroke:none" />
+    </g>
+    <g
+       style="font-size:20.02241135px;font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none;font-family:Apple LiSung;-inkscape-font-specification:Apple LiSung Light"
+       id="g3328"
+       transform="matrix(4.0808246,0,0,4.0808246,-116.25082,-136.58974)" />
+    <g
+       id="g3330"
+       style="font-size:20.02241135px;font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.22524261;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;font-family:Apple LiSung;-inkscape-font-specification:Apple LiSung Light"
+       transform="matrix(4.0808246,0,0,4.0808246,-132.57411,-134.63351)" />
+    <g
+       id="forExport:gadgetError"
+       inkscape:label="#g4105"
+       transform="translate(20,0)">
+      <rect
+	 y="316.36218"
+	 x="9"
+	 height="117"
+	 width="132"
+	 id="rect3334"
+	 style="fill:none;stroke:none" />
+      <g
+	 transform="matrix(1.0229949,0,0,1.0572693,-4.4222807,-17.752239)"
+	 id="g3329">
+	<path
+	   style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#bb2b2b;fill-opacity:1;fill-rule:nonzero;stroke:#313131;stroke-width:4.80773449;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+	   d="m 76.999384,319.35707 c -2.590589,0.20118 -5.044144,1.72235 -6.376289,3.9533 l -53.05072,87.73773 c -2.965943,4.93049 1.260118,12.38371 7.013918,12.37 l 106.101437,0 c 5.75384,0.0122 9.9799,-7.43951 7.01392,-12.37 L 84.65093,323.31037 c -1.55002,-2.59663 -4.636837,-4.19146 -7.651546,-3.9533 z"
+	   id="fsdffsd"
+	   inkscape:connector-curvature="0"
+	   sodipodi:nodetypes="cccccccc"
+	   inkscape:label="#path3123" />
+	<path
+	   d="M 77.28782,388.36112 76.634158,380.0269 C 76.416242,377.79358 75.871538,373.57201 75,367.36218 c -0.817091,-6.26427 -1.225631,-9.91388 -1.225623,-10.94889 -8e-6,-4.30323 1.361792,-6.45489 4.0854,-6.45493 2.723583,4e-5 4.085378,2.09722 4.085399,6.29153 -2.1e-5,0.43579 -0.02734,0.92606 -0.0817,1.47073 -0.05448,0.49031 -0.08174,0.89884 -0.0817,1.22563 l -3.431733,29.41487 -1.062206,0 z m -3.513422,10.29519 c -8e-6,-2.77806 1.389027,-4.16709 4.167105,-4.16709 2.778054,0 4.167089,1.33455 4.167106,4.00365 -1.7e-5,2.66915 -1.389052,4.0037 -4.167106,4.0037 -2.778078,0 -4.167113,-1.28007 -4.167105,-3.84026"
+	   style="font-size:20.02241135px;font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#f9f9f9;fill-opacity:1;stroke:#313131;stroke-width:5.76928091;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;font-family:Apple LiSung;-inkscape-font-specification:Apple LiSung Light"
+	   id="path3336"
+	   inkscape:connector-curvature="0"
+	   sodipodi:nodetypes="cccsccccccccscsc" />
+	<path
+	   sodipodi:nodetypes="cccsccccccccscsc"
+	   inkscape:connector-curvature="0"
+	   id="path3338"
+	   style="font-size:20.02241135px;font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#f9f9f9;fill-opacity:1;stroke:none;font-family:Apple LiSung;-inkscape-font-specification:Apple LiSung Light"
+	   d="M 77.28782,388.36112 76.634158,380.0269 C 76.416242,377.79358 75.871538,373.57201 75,367.36218 c -0.817091,-6.26427 -1.225631,-9.91388 -1.225623,-10.94889 -8e-6,-4.30323 1.361792,-6.45489 4.0854,-6.45493 2.723583,4e-5 4.085378,2.09722 4.085399,6.29153 -2.1e-5,0.43579 -0.02734,0.92606 -0.0817,1.47073 -0.05448,0.49031 -0.08174,0.89884 -0.0817,1.22563 l -3.431733,29.41487 -1.062206,0 z m -3.513422,10.29519 c -8e-6,-2.77806 1.389027,-4.16709 4.167105,-4.16709 2.778054,0 4.167089,1.33455 4.167106,4.00365 -1.7e-5,2.66915 -1.389052,4.0037 -4.167106,4.0037 -2.778078,0 -4.167113,-1.28007 -4.167105,-3.84026" />
+      </g>
     </g>
   </g>
 </svg>

--- a/src/Gaffer/Node.cpp
+++ b/src/Gaffer/Node.cpp
@@ -116,6 +116,16 @@ bool Node::acceptsParent( const GraphComponent *potentialParent ) const
 	return potentialParent->isInstanceOf( (IECore::TypeId)NodeTypeId );
 }
 
+Node::ErrorSignal &Node::errorSignal()
+{
+	return m_errorSignal;
+}
+
+const Node::ErrorSignal &Node::errorSignal() const
+{
+	return m_errorSignal;
+}
+
 bool Node::acceptsInput( const Plug *plug, const Plug *inputPlug ) const
 {
 	return true;

--- a/src/GafferBindings/NodeBinding.cpp
+++ b/src/GafferBindings/NodeBinding.cpp
@@ -40,15 +40,16 @@
 #include "Gaffer/ScriptNode.h"
 
 #include "GafferBindings/NodeBinding.h"
-#include "GafferBindings/ValuePlugBinding.h"
 #include "GafferBindings/SignalBinding.h"
-#include "GafferBindings/RawConstructor.h"
-#include "GafferBindings/CatchingSlotCaller.h"
 #include "GafferBindings/MetadataBinding.h"
 
 using namespace boost::python;
-using namespace GafferBindings;
+using namespace IECorePython;
 using namespace Gaffer;
+using namespace GafferBindings;
+
+namespace
+{
 
 struct UnaryPlugSlotCaller
 {
@@ -83,10 +84,7 @@ struct BinaryPlugSlotCaller
 	}
 };
 
-static ScriptNodePtr scriptNode( Node &node )
-{
-	return node.scriptNode();
-}
+} // namespace
 
 void NodeSerialiser::moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules ) const
 {
@@ -123,7 +121,7 @@ void GafferBindings::bindNode()
 	typedef NodeWrapper<Node> Wrapper;
 
 	scope s = NodeClass<Node, Wrapper>()
-		.def( "scriptNode", &scriptNode )
+		.def( "scriptNode", (ScriptNode *(Node::*)())&Node::scriptNode, return_value_policy<CastToIntrusivePtr>() )
 		.def( "plugSetSignal", &Node::plugSetSignal, return_internal_reference<1>() )
 		.def( "plugInputChangedSignal", &Node::plugInputChangedSignal, return_internal_reference<1>() )
 		.def( "plugFlagsChangedSignal", &Node::plugFlagsChangedSignal, return_internal_reference<1>() )

--- a/src/GafferScene/SceneReader.cpp
+++ b/src/GafferScene/SceneReader.cpp
@@ -525,15 +525,17 @@ ConstSceneInterfacePtr SceneReader::scene( const ScenePath &path ) const
 		}
 		else
 		{
-			lastScene.path = path;
 			lastScene.pathScene = lastScene.fileNameScene->scene( path );
+			lastScene.path = path;
 			return lastScene.pathScene;
 		}
 	}
 
-	lastScene.fileName = fileName;
 	lastScene.fileNameScene = SharedSceneInterfaces::get( fileName );
-	lastScene.path = path;
+	lastScene.fileName = fileName;
+
 	lastScene.pathScene = lastScene.fileNameScene->scene( path );
+	lastScene.path = path;
+
 	return lastScene.pathScene;
 }

--- a/src/GafferUI/Gadget.cpp
+++ b/src/GafferUI/Gadget.cpp
@@ -376,6 +376,17 @@ Gadget::IdleSignal &Gadget::idleSignalAccessedSignal()
 	return g_idleSignalAccessedSignal;
 }
 
+void Gadget::executeOnUIThread( UIThreadFunction function )
+{
+	executeOnUIThreadSignal()( function );
+}
+
+Gadget::ExecuteOnUIThreadSignal &Gadget::executeOnUIThreadSignal()
+{
+	static ExecuteOnUIThreadSignal g_executeOnUIThreadSignal;
+	return g_executeOnUIThreadSignal;
+}
+
 void Gadget::styleChanged()
 {
 	renderRequestSignal()( this );

--- a/src/GafferUI/ImageGadget.cpp
+++ b/src/GafferUI/ImageGadget.cpp
@@ -135,6 +135,7 @@ void ImageGadget::doRender( const Style *style ) const
 		style->renderImage( b, texture );
 	}
 
+	Gadget::doRender( style );
 }
 
 Imath::Box3f ImageGadget::bound() const

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -802,12 +802,20 @@ StandardNodeGadget::ErrorGadget *StandardNodeGadget::errorGadget( bool createIfM
 	return g.get();
 }
 
-void StandardNodeGadget::error( ConstPlugPtr plug, ConstPlugPtr source, const std::string &message )
+void StandardNodeGadget::error( const Gaffer::Plug *plug, const Gaffer::Plug *source, const std::string &message )
 {
+	if( !node()->isAncestorOf( source ) )
+	{
+		// We only want to display errors that occurred directly on this node (or an internal
+		// node), rather than upstream errors that are merely being propagated downstream to
+		// us.
+		return;
+	}
+
 	// We could be on any thread at this point, so we
 	// use an idle callback to do the work of displaying the error
 	// on the main thread.
-	executeOnUIThread( boost::bind( &StandardNodeGadget::displayError, this, plug, message ) );
+	executeOnUIThread( boost::bind( &StandardNodeGadget::displayError, this, ConstPlugPtr( plug ), message ) );
 }
 
 void StandardNodeGadget::displayError( ConstPlugPtr plug, const std::string &message )

--- a/src/GafferUI/StandardStyle.cpp
+++ b/src/GafferUI/StandardStyle.cpp
@@ -455,6 +455,13 @@ void StandardStyle::renderImage( const Imath::Box2f &box, const IECoreGL::Textur
 	glActiveTexture( GL_TEXTURE0 );
 	texture->bind();
 
+	/// \todo It feels like it might be better to do this at texture creation time.
+	glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR );
+	glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR );
+	glTexParameterf( GL_TEXTURE_2D, GL_TEXTURE_LOD_BIAS, -1.0 );
+	glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER );
+	glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER );
+
 	glUniform1i( g_bezierParameter, 0 );
 	glUniform1i( g_borderParameter, 0 );
 	glUniform1i( g_edgeAntiAliasingParameter, 0 );

--- a/src/GafferUIBindings/GadgetBinding.cpp
+++ b/src/GafferUIBindings/GadgetBinding.cpp
@@ -143,6 +143,23 @@ struct KeySlotCaller
 	}
 };
 
+struct ExecuteOnUIThreadSlotCaller
+{
+	boost::signals::detail::unusable operator()( boost::python::object slot, Gadget::UIThreadFunction function )
+	{
+		object pythonFunction = make_function( function, default_call_policies(), boost::mpl::vector<void>() );
+		try
+		{
+			slot( pythonFunction );
+		}
+		catch( const error_already_set &e )
+		{
+			translatePythonException();
+		}
+		return boost::signals::detail::unusable();
+	}
+};
+
 StylePtr getStyle( Gadget &g )
 {
 	return const_cast<Style *>( g.getStyle() );
@@ -204,6 +221,8 @@ void GafferUIBindings::bindGadget()
 		.staticmethod( "idleSignal" )
 		.def( "_idleSignalAccessedSignal", &Gadget::idleSignalAccessedSignal, return_value_policy<reference_existing_object>() )
 		.staticmethod( "_idleSignalAccessedSignal" )
+		.def( "_executeOnUIThreadSignal", &Gadget::executeOnUIThreadSignal, return_value_policy<reference_existing_object>() )
+		.staticmethod( "_executeOnUIThreadSignal" )
 		.def( "select", &Gadget::select ).staticmethod( "select" )
 	;
 
@@ -214,5 +233,6 @@ void GafferUIBindings::bindGadget()
 	SignalBinder<Gadget::DragDropSignal, DefaultSignalCaller<Gadget::DragDropSignal>, DragDropSlotCaller>::bind( "DragDropSignal" );
 	SignalBinder<Gadget::EnterLeaveSignal, DefaultSignalCaller<Gadget::EnterLeaveSignal>, EnterLeaveSlotCaller>::bind( "EnterLeaveSignal" );
 	SignalBinder<Gadget::IdleSignal>::bind( "IdleSignal" );
+	SignalBinder<Gadget::ExecuteOnUIThreadSignal, DefaultSignalCaller<Gadget::EnterLeaveSignal>, ExecuteOnUIThreadSlotCaller>::bind( "ExecuteOnUIThreadSignal" );
 
 }


### PR DESCRIPTION
Here's a first implementation of error reporting in the NodeGraph for #1115. I've implemented the "clear error status automatically on dirty" behaviour we discussed, and also made sure that errors will be displayed on Boxes if they occur inside.

What I haven't done is limit the error display to only the source node - currently all nodes along the chain from the original source of the problem are displayed with an error status. I'm not sure if this is useful or not, but I've done it that way for now because I decided in the end that `Node::errorSignal()` should be emitted for intermediate nodes - it's not for the signaller to decide what may or may not be interesting, that should be down to the listeners.

If we do decide we don't want to show intermediate errors in the NodeGraph, I think that is achievable if we update the error signal to also provide information about the original source of the error, and then the NodeGraph UI can filter the signals and only display the ones it thinks are relevant. Let me know how things feel in practice and if you'd like me to look into that before we merge.