### PR TITLE
Added ImageReader test case for OIIO error buffer overflows.

### DIFF
--- a/python/GafferImageTest/ImageReaderTest.py
+++ b/python/GafferImageTest/ImageReaderTest.py
@@ -161,6 +161,15 @@ class ImageReaderTest( unittest.TestCase ) :
 		n["out"]["channelNames"].getValue()
 		n["out"].channelData( "R", IECore.V2i( 0 ) )
 
+	def testNoOIIOErrorBufferOverflows( self ) :
+
+		n = GafferImage.ImageReader()
+		n["fileName"].setValue( "thisReallyReallyReallyReallyReallyReallyReallyReallyReallyLongFilenameDoesNotExist.tif" )
+
+		for i in range( 0, 300000 ) :
+			with IECore.IgnoredExceptions( Exception ) :
+				n["out"]["dataWindow"].getValue()
+
 	def testChannelDataHashes( self ) :
 		# Test that two tiles within the same image have different hashes.
 		n = GafferImage.ImageReader()


### PR DESCRIPTION
This is just a small test case for a critical fix David added a while back. I reckon the ImageReader needs a bit of an overhaul, and I wanted to improve the test coverage beforehand.

My main motivation for wanting an overhaul is to actually make the ImageReader error when files don't exist etc. Currently it just carries on regardless, outputting a default image. This makes it impossible to catch errors in automated processes, and also gives no useful feedback via the UI to assist in fixing the problem. There are also a few [obvious performance improvements](https://github.com/ImageEngine/gaffer/blob/master/src/GafferImage/ImageReader.cpp#L144) we could make at the same time.

Do you think it might be worth addressing those fairly soon? I know image stuff probably isn't the number one priority, but I think this would be a nice small chunk, and I'd like to keep chipping away at GafferImage here and there until it's in a bit of a better place.