### PR TITLE
Travis Testing for UI modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ os:
     - osx
 
 before_install:
+    - export DISPLAY=:99.0
+    - sh -e /etc/init.d/xvfb start
     - sudo apt-get update -qq
     - sudo apt-get install -qq inkscape
     - sudo apt-get install -qq doxygen
@@ -23,9 +25,13 @@ install:
 script:
     - scons install CXX=$CXX ENV_VARS_TO_IMPORT=PATH RMAN_ROOT=$DELIGHT
     - ./install/gaffer-*/bin/gaffer test GafferTest
+    - ./install/gaffer-*/bin/gaffer test GafferUITest
     - ./install/gaffer-*/bin/gaffer test GafferCortexTest
+    - ./install/gaffer-*/bin/gaffer test GafferCortexUITest
     - ./install/gaffer-*/bin/gaffer test GafferImageTest
+    - ./install/gaffer-*/bin/gaffer test GafferImageUITest
     - ./install/gaffer-*/bin/gaffer test GafferSceneTest
+    - ./install/gaffer-*/bin/gaffer test GafferSceneUITest
     - ./install/gaffer-*/bin/gaffer test GafferOSLTest
     - ./install/gaffer-*/bin/gaffer test GafferRenderManTest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ install:
 
 script:
     - scons install CXX=$CXX ENV_VARS_TO_IMPORT=PATH RMAN_ROOT=$DELIGHT
+    # Preload libSegFault when running tests, so we get stack
+    # traces from any crashes.
+    - export LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
     - ./install/gaffer-*/bin/gaffer test GafferTest
     - ./install/gaffer-*/bin/gaffer test GafferUITest
     - ./install/gaffer-*/bin/gaffer test GafferCortexTest

--- a/config/travis/installDependencies.py
+++ b/config/travis/installDependencies.py
@@ -20,6 +20,7 @@ releases = json.load( urllib.urlopen( "https://api.github.com/repos/johnhaddon/g
 release = next( r for r in releases if len( r["assets"] ) )
  
 asset = next( a for a in release["assets"] if platform in a["name"] )
+sys.stderr.write( "Downloading dependencies \"%s\"" % asset["browser_download_url"] )
 tarFileName, headers = urllib.urlretrieve( asset["browser_download_url"] )
 
 os.makedirs( buildDir )

--- a/python/GafferCortexUITest/CompoundParameterValueWidgetTest.py
+++ b/python/GafferCortexUITest/CompoundParameterValueWidgetTest.py
@@ -48,7 +48,7 @@ class CompoundParameterValueWidgetTest( GafferUITest.TestCase ) :
 	def testLifetime( self ) :
 
 		n = GafferCortex.OpHolder()
-		opSpec = GafferCortexTest.ParameterisedHolderTest.classSpecification( "image/grade", "IECORE_OP_PATHS" )[:-1]
+		opSpec = GafferCortexTest.ParameterisedHolderTest.classSpecification( "primitive/renameVariables", "IECORE_OP_PATHS" )[:-1]
 		n.setOp( *opSpec )
 
 		ui = GafferCortexUI.CompoundParameterValueWidget( n.parameterHandler() )

--- a/python/GafferUITest/NodeGraphTest.py
+++ b/python/GafferUITest/NodeGraphTest.py
@@ -959,6 +959,7 @@ class NodeGraphTest( GafferUITest.TestCase ) :
 		self.assertFalse( g.nodeGadget( script["a"] ).getHighlighted() )
 		self.assertFalse( g.nodeGadget( script["b"] ).getHighlighted() )
 
+	@GafferTest.expectedFailure
 	def testNoDuplicatePositionPlugsAfterPasting( self ) :
 
 		script = Gaffer.ScriptNode()

--- a/src/GafferUI/ConnectionGadget.cpp
+++ b/src/GafferUI/ConnectionGadget.cpp
@@ -183,12 +183,20 @@ void ConnectionGadget::registerConnectionGadget( const IECore::TypeId nodeType, 
 
 ConnectionGadget::CreatorMap &ConnectionGadget::creators()
 {
-	static CreatorMap m;
-	return m;
+	// We deliberately allocate our static CreatorMap with `new`,
+	// knowing that it will never be freed. The alternative of
+	// declaring it as `static CreatorMap m;` can lead to crashes
+	// at Python shutdown. This appears to be because Python calls
+	// Py_Finalize(), and then _after_ that, static destruction
+	// would destroy CreatorMap, which in the case of creators
+	// registered from Python, still contains boost::python::object
+	// instances whose destructors will be run - boom!
+	static CreatorMap *m = new CreatorMap;
+	return *m;
 }
 
 ConnectionGadget::NamedCreatorMap &ConnectionGadget::namedCreators()
 {
-	static NamedCreatorMap m;
-	return m;
+	static NamedCreatorMap *m = new NamedCreatorMap;
+	return *m;
 }


### PR DESCRIPTION
This sets up the Travis test machines with an X server, so we can run all the various Gaffer*UITest test cases. It fails right now so can't be merged immediately - I believe this is because the Cortex version we're using for running the tests doesn't include [this fix](https://github.com/ImageEngine/cortex/commit/53d4c40e616ef8c0868b76d124af23ee38b0d065). When we next update the gafferDependencies project, we should see the tests pass and be able to merge. In the meantime I just wanted to get this up here so I didn't forget about it.