### PR TITLE
Multithreaded child procedural instantiation in SceneProcedural

### DIFF
--- a/include/GafferScene/SceneProcedural.h
+++ b/include/GafferScene/SceneProcedural.h
@@ -130,6 +130,15 @@ class SceneProcedural : public IECore::Renderer::Procedural
 		
 		void decrementPendingProcedurals() const;
 		
+		// We use this variable for caching the bound computation, so we can compute bounds for
+		// a SceneProcedural's children in parallel, and avoid computing them again when we send
+		// them all to the renderer in serial
+		mutable Imath::Box3f m_bound;
+		
+		// struct for creating child procedurals in parallel and computing their bounds, using
+		// tbb::parallel_for:
+		class SceneProceduralCreate;
+		
 		static tbb::mutex g_allRenderedMutex;
 		static AllRenderedSignal g_allRenderedSignal;
 		

--- a/include/GafferScene/SceneProcedural.h
+++ b/include/GafferScene/SceneProcedural.h
@@ -115,6 +115,7 @@ class SceneProcedural : public IECore::Renderer::Procedural
 	private :
 
 		void updateAttributes( bool full );
+		void computeBound();
 		void motionTimes( unsigned segments, std::set<float> &times ) const;
 		
 		// A global counter of all the scene procedurals that are hanging around but haven't been rendered yet, which 

--- a/include/GafferScene/SceneProcedural.h
+++ b/include/GafferScene/SceneProcedural.h
@@ -133,7 +133,7 @@ class SceneProcedural : public IECore::Renderer::Procedural
 		// We use this variable for caching the bound computation, so we can compute bounds for
 		// a SceneProcedural's children in parallel, and avoid computing them again when we send
 		// them all to the renderer in serial
-		mutable Imath::Box3f m_bound;
+		Imath::Box3f m_bound;
 		
 		// struct for creating child procedurals in parallel and computing their bounds, using
 		// tbb::parallel_for:

--- a/src/GafferScene/SceneProcedural.cpp
+++ b/src/GafferScene/SceneProcedural.cpp
@@ -419,6 +419,9 @@ IECore::MurmurHash SceneProcedural::hash() const
 void SceneProcedural::updateAttributes( bool full )
 {
 	Context::Scope scopedContext( m_context.get() );
+	
+	// \todo: Investigate if it's worth keeping these around and reusing them in SceneProcedural::render().
+	
 	ConstCompoundObjectPtr attributes;
 	if( full )
 	{


### PR DESCRIPTION
Both the constructor and the bound() method in SceneProcedural involve potentially expensive graph evaluations, which I've parallelized in this pull request.

This involved adding an m_bound member variable, which stores the result of bound() so the computation doesn't happen twice. SceneProcedural::render() now creates child SceneProcedurals and calls their bound() methods in parallel, so the attribute evaluation in SceneProcedural::SceneProcedural and the bound evaluation when we send the procedural to the renderer no longer happen in series.