### PR TITLE
Optimised tokenizing

### DIFF
--- a/include/Gaffer/StringAlgo.h
+++ b/include/Gaffer/StringAlgo.h
@@ -82,6 +82,14 @@ int numericSuffix( const std::string &s, std::string *stem = NULL );
 /// As above, but returns defaultSuffix in the case that no suffix exists.
 int numericSuffix( const std::string &s, int defaultSuffix, std::string *stem = NULL );
 
+/// Splits the input string wherever the separator is found, outputting all non-empty tokens
+/// in sequence. Note that this is significantly quicker than boost::tokenizer
+/// where TokenType is IECore::InternedString.
+template<typename TokenType, typename OutputIterator>
+void tokenize( const std::string &s, const char separator, OutputIterator outputIterator );
+template<typename OutputContainer>
+void tokenize( const std::string &s, const char separator, OutputContainer &outputContainer );
+
 } // namespace Gaffer
 
 #include "Gaffer/StringAlgo.inl"

--- a/include/Gaffer/StringAlgo.inl
+++ b/include/Gaffer/StringAlgo.inl
@@ -153,6 +153,29 @@ inline bool MatchPatternLess::operator() ( const std::string &s1, const std::str
 	return *c1 < *c2;
 }
 
+template<typename Token, typename OutputIterator>
+void tokenize( const std::string &s, const char separator, OutputIterator outputIterator )
+{
+	size_t index = 0, size = s.size();
+	while( index < size )
+	{
+		const size_t prevIndex = index;
+		index = s.find( separator, index );
+		index = index == std::string::npos ? size : index;
+		if( index > prevIndex )
+		{
+			*outputIterator++ = Token( s.c_str() + prevIndex, index - prevIndex );
+		}
+		index++;
+	}
+}
+
+template<typename OutputContainer>
+void tokenize( const std::string &s, const char separator, OutputContainer &outputContainer )
+{
+	tokenize<typename OutputContainer::value_type>( s, separator, std::back_inserter( outputContainer ) );
+}
+
 } // namespace Gaffer
 
 #endif // GAFFER_STRINGALGO_INL

--- a/include/GafferScene/PathMatcher.h
+++ b/include/GafferScene/PathMatcher.h
@@ -103,7 +103,6 @@ class PathMatcher
 
 	private :
 
-		typedef boost::tokenizer<boost::char_separator<char> > Tokenizer;
 		struct Node;
 
 		template<typename NameIterator>

--- a/src/GafferScene/PathMatcher.cpp
+++ b/src/GafferScene/PathMatcher.cpp
@@ -238,10 +238,9 @@ bool PathMatcher::operator != ( const PathMatcher &other ) const
 
 unsigned PathMatcher::match( const std::string &path ) const
 {
-	unsigned result = Filter::NoMatch;
-	Tokenizer tokenizer( path, boost::char_separator<char>( "/" ) );
-	matchWalk( m_root.get(), tokenizer.begin(), tokenizer.end(), result );
-	return result;
+	std::vector<IECore::InternedString> tokenizedPath;
+	Gaffer::tokenize( path, '/', tokenizedPath );
+	return match( tokenizedPath );
 }
 
 unsigned PathMatcher::match( const std::vector<IECore::InternedString> &path ) const
@@ -335,8 +334,9 @@ void PathMatcher::matchWalk( Node *node, const NameIterator &start, const NameIt
 
 bool PathMatcher::addPath( const std::string &path )
 {
-	Tokenizer tokenizer( path, boost::char_separator<char>( "/" ) );
-	return addPath( tokenizer.begin(), tokenizer.end() );
+	std::vector<IECore::InternedString> tokenizedPath;
+	Gaffer::tokenize( path, '/', tokenizedPath );
+	return addPath( tokenizedPath );
 }
 
 bool PathMatcher::addPath( const std::vector<IECore::InternedString> &path )
@@ -380,10 +380,9 @@ bool PathMatcher::addPath( const NameIterator &start, const NameIterator &end )
 
 bool PathMatcher::removePath( const std::string &path )
 {
-	bool result = false;
-	Tokenizer tokenizer( path, boost::char_separator<char>( "/" ) );
-	removeWalk( m_root.get(), tokenizer.begin(), tokenizer.end(), /* prune = */ false, result );
-	return result;
+	std::vector<IECore::InternedString> tokenizedPath;
+	Gaffer::tokenize( path, '/', tokenizedPath );
+	return removePath( tokenizedPath );
 }
 
 bool PathMatcher::removePath( const std::vector<IECore::InternedString> &path )
@@ -395,10 +394,9 @@ bool PathMatcher::removePath( const std::vector<IECore::InternedString> &path )
 
 bool PathMatcher::prune( const std::string &path )
 {
-	bool result = false;
-	Tokenizer tokenizer( path, boost::char_separator<char>( "/" ) );
-	removeWalk( m_root.get(), tokenizer.begin(), tokenizer.end(), /* prune = */ true, result );
-	return result;
+	std::vector<IECore::InternedString> tokenizedPath;
+	Gaffer::tokenize( path, '/', tokenizedPath );
+	return prune( tokenizedPath );;
 }
 
 bool PathMatcher::prune( const std::vector<IECore::InternedString> &path )

--- a/src/GafferScene/ScenePlug.cpp
+++ b/src/GafferScene/ScenePlug.cpp
@@ -41,6 +41,7 @@
 #include "IECore/NullObject.h"
 
 #include "Gaffer/Context.h"
+#include "Gaffer/StringAlgo.h"
 
 #include "GafferScene/ScenePlug.h"
 
@@ -364,18 +365,7 @@ IECore::MurmurHash ScenePlug::childNamesHash( const ScenePath &scenePath ) const
 void ScenePlug::stringToPath( const std::string &s, ScenePlug::ScenePath &path )
 {
 	path.clear();
-	size_t index = 0, size = s.size();
-	while( index < size )
-	{
-		const size_t prevIndex = index;
-		index = s.find( '/', index );
-		index = index == std::string::npos ? size : index;
-		if( index > prevIndex )
-		{
-			path.push_back( IECore::InternedString( s.c_str() + prevIndex, index - prevIndex ) );
-		}
-		index++;
-	}
+	tokenize( s, '/', path );
 }
 
 void ScenePlug::pathToString( const ScenePlug::ScenePath &path, std::string &s )


### PR DESCRIPTION
This is part of #852, but since that's a big chunk of work (and is still in progress) I thought it'd be worth breaking off little nuggets where I can and getting them reviewed separately.

This tokenizer gives much improved performance over boost::tokenizer when the tokens will be IECore::InternedString, because it can entirely omit the construction of temporary strings - in the case of the tokens already having been used elsewhere already (very common), this entirely removes any memory allocation for the tokens themselves.