### PR TITLE
Multithreaded, selective attribute updates

### DIFF
--- a/include/GafferScene/InteractiveRender.h
+++ b/include/GafferScene/InteractiveRender.h
@@ -37,6 +37,8 @@
 #ifndef GAFFERSCENE_INTERACTIVERENDER_H
 #define GAFFERSCENE_INTERACTIVERENDER_H
 
+#include "tbb/pipeline.h"
+
 #include "IECore/Renderer.h"
 
 #include "Gaffer/Node.h"
@@ -111,9 +113,12 @@ class InteractiveRender : public Gaffer::Node
 		void parentChanged( Gaffer::GraphComponent *child, Gaffer::GraphComponent *oldParent );
 
 		void update();
+		
+		static void runPipeline(tbb::pipeline* p);
+		void outputScene( bool update );
+		
 		void updateLights();
 		void updateAttributes();
-		void updateAttributesWalk( const ScenePlug::ScenePath &path );
 		void updateCameras();
 		void updateCoordinateSystems();
 
@@ -123,6 +128,17 @@ class InteractiveRender : public Gaffer::Node
 
 		typedef std::set<std::string> LightHandles;
 
+		// hierarchical structure for tracking scene information:
+		class SceneGraph;
+		boost::shared_ptr<SceneGraph> m_sceneGraph;
+
+		// tbb classes for performing multithreaded traversals of the scene graph, etc.
+		class SceneGraphBuildTask;
+
+		class SceneGraphIteratorFilter;
+		class SceneGraphEvaluatorFilter;
+		class SceneGraphOutputFilter;
+		
 		IECore::RendererPtr m_renderer;
 		ConstScenePlugPtr m_scene;
 		State m_state;

--- a/include/GafferScene/InteractiveRender.h
+++ b/include/GafferScene/InteractiveRender.h
@@ -134,6 +134,7 @@ class InteractiveRender : public Gaffer::Node
 
 		// tbb classes for performing multithreaded traversals of the scene graph, etc.
 		class SceneGraphBuildTask;
+		class ChildNamesUpdateTask;
 
 		class SceneGraphIteratorFilter;
 		class SceneGraphEvaluatorFilter;

--- a/include/GafferScene/InteractiveRender.h
+++ b/include/GafferScene/InteractiveRender.h
@@ -114,7 +114,7 @@ class InteractiveRender : public Gaffer::Node
 
 		void update();
 		
-		static void runPipeline(tbb::pipeline* p);
+		static void runPipeline(tbb::pipeline *p);
 		void outputScene( bool update );
 		
 		void updateLights();

--- a/src/GafferScene/InteractiveRender.cpp
+++ b/src/GafferScene/InteractiveRender.cpp
@@ -373,7 +373,14 @@ void InteractiveRender::plugDirtied( const Gaffer::Plug *plug )
 			// checking for locations that are no longer present, and flag them as absent if this
 			// is the case:
 			ChildNamesUpdateTask *task = new( tbb::task::allocate_root() ) ChildNamesUpdateTask( inPlug(), m_context.get(), m_sceneGraph.get(), ScenePlug::ScenePath() );
-			tbb::task::spawn_root_and_wait( *task );
+			try
+			{
+				tbb::task::spawn_root_and_wait( *task );
+			}
+			catch( const std::exception& e )
+			{
+				IECore::msg( IECore::Msg::Error, "InteractiveRender::update", e.what() );
+			}
 		}
 	}
 	else if(

--- a/src/GafferScene/InteractiveRender.cpp
+++ b/src/GafferScene/InteractiveRender.cpp
@@ -680,6 +680,9 @@ class InteractiveRender::SceneGraphOutputFilter : public tbb::thread_bound_filte
 
 void InteractiveRender::runPipeline(tbb::pipeline *p)
 {
+	// \todo: tune this number to find a balance between memory and speed once
+	// we have a load of production data:
+	
 	p->run( 2 * tbb::task_scheduler_init::default_num_threads() );
 }
 

--- a/src/GafferScene/InteractiveRender.cpp
+++ b/src/GafferScene/InteractiveRender.cpp
@@ -1103,4 +1103,5 @@ void InteractiveRender::stop()
 	m_state = Stopped;
 	m_lightHandles.clear();
 	m_attributesDirty = m_lightsDirty = m_camerasDirty = true;
+	m_sceneGraph.reset( (SceneGraph*)NULL );
 }

--- a/src/GafferScene/InteractiveRender.cpp
+++ b/src/GafferScene/InteractiveRender.cpp
@@ -562,7 +562,7 @@ class InteractiveRender::SceneGraphOutputFilter : public tbb::thread_bound_filte
 		{
 		}
 		
-		~SceneGraphOutputFilter()
+		virtual ~SceneGraphOutputFilter()
 		{
 			// close pending attribute blocks:
 			while( m_attrBlockCounter )

--- a/src/GafferScene/InteractiveRender.cpp
+++ b/src/GafferScene/InteractiveRender.cpp
@@ -83,7 +83,7 @@ class InteractiveRender::SceneGraph
 
 	public :
 
-		SceneGraph() : m_parent(0)
+		SceneGraph() : m_parent( NULL )
 		{
 		}
 
@@ -409,6 +409,20 @@ class InteractiveRender::SceneGraphIteratorFilter : public tbb::filter
 			m_childIndices.push_back( 0 );
 		}
 		
+		virtual void *operator()( void *item )
+		{
+			if( m_childIndices.empty() )
+			{
+				// we've finished the iteration
+				return NULL;
+			}
+			InteractiveRender::SceneGraph *s = m_current;
+			next();
+			return s;
+		}
+	
+	private:
+		
 		void next()
 		{
 			// go down one level in the hierarchy if we can:
@@ -444,20 +458,6 @@ class InteractiveRender::SceneGraphIteratorFilter : public tbb::filter
 			}
 		}
 		
-		void *operator()( void *item )
-		{
-			if( m_childIndices.empty() )
-			{
-				// we've finished the iteration
-				return NULL;
-			}
-			InteractiveRender::SceneGraph *s = m_current;
-			next();
-			return s;
-		}
-	
-	private:
-		
 		SceneGraph *m_current;
 		std::vector<size_t> m_childIndices;
 };
@@ -481,7 +481,7 @@ class InteractiveRender::SceneGraphEvaluatorFilter : public tbb::filter
 		{
 		}
 
-		void *operator()( void *item )
+		virtual void *operator()( void *item )
 		{
 			SceneGraph *s = (SceneGraph*)item;
 			ScenePlug::ScenePath path;
@@ -525,7 +525,7 @@ class InteractiveRender::SceneGraphEvaluatorFilter : public tbb::filter
 					}
 				}
 			}
-			catch( const std::exception& e )
+			catch( const std::exception &e )
 			{
 				std::string name;
 				ScenePlug::pathToString( path, name );
@@ -575,7 +575,7 @@ class InteractiveRender::SceneGraphOutputFilter : public tbb::thread_bound_filte
 			}
 		}
 		
-		void *operator()( void *item )
+		virtual void *operator()( void *item )
 		{
 			SceneGraph *s = (SceneGraph*)item;
 			ScenePlug::ScenePath path;
@@ -666,7 +666,7 @@ class InteractiveRender::SceneGraphOutputFilter : public tbb::thread_bound_filte
 					s->m_object = 0;
 				}
 			}
-			catch( const std::exception& e )
+			catch( const std::exception &e )
 			{
 				IECore::msg( IECore::Msg::Error, "InteractiveRender::update", name + ": " + e.what() );
 			}

--- a/src/GafferScene/InteractiveRender.cpp
+++ b/src/GafferScene/InteractiveRender.cpp
@@ -123,7 +123,7 @@ class InteractiveRender::SceneGraph
 		// actual scene data:
 		IECore::ConstCompoundObjectPtr m_attributes;
 		IECore::ConstObjectPtr m_object;
-		IECore::M44fDataPtr m_transform;
+		Imath::M44f m_transform;
 };
 
 size_t InteractiveRender::g_firstPlugIndex = 0;
@@ -518,7 +518,7 @@ class InteractiveRender::SceneGraphEvaluatorFilter : public tbb::filter
 					// by the SceneGraphBuildTasks, so we only need to compute the object/transform:
 
 					s->m_object = m_scene->objectPlug()->getValue();
-					s->m_transform = new IECore::M44fData( m_scene->transformPlug()->getValue() );
+					s->m_transform = m_scene->transformPlug()->getValue();
 
 				}
 			}
@@ -606,10 +606,9 @@ class InteractiveRender::SceneGraphOutputFilter : public tbb::thread_bound_filte
 				}
 
 				// transform:
-				if( s->m_transform && !m_editMode )
+				if( !m_editMode )
 				{
-					m_renderer->concatTransform( s->m_transform->readable() );
-					s->m_transform = 0;
+					m_renderer->concatTransform( s->m_transform );
 				}
 
 				// attributes:

--- a/src/GafferScene/InteractiveRender.cpp
+++ b/src/GafferScene/InteractiveRender.cpp
@@ -685,9 +685,13 @@ void InteractiveRender::runPipeline(tbb::pipeline *p)
 	
 	p->run( 2 * tbb::task_scheduler_init::default_num_threads() );
 }
-
+#include "sys/time.h"
 void InteractiveRender::outputScene( bool update )
 {
+	struct timeval tv;
+	gettimeofday(&tv, NULL);
+	double t0 = tv.tv_sec + double( tv.tv_usec )/ 1000000;
+	
 	SceneGraphIteratorFilter iterator( m_sceneGraph.get() );
 
 	SceneGraphEvaluatorFilter evaluator(
@@ -715,6 +719,11 @@ void InteractiveRender::outputScene( bool update )
 		continue;
 	}
 	pipelineThread.join();
+	
+	gettimeofday(&tv, NULL);
+	double t1 = tv.tv_sec + double( tv.tv_usec )/ 1000000;
+	
+	std::cerr << "outputScene " << t1 - t0 << std::endl;
 }
 
 void InteractiveRender::update()

--- a/src/GafferScene/InteractiveRender.cpp
+++ b/src/GafferScene/InteractiveRender.cpp
@@ -95,7 +95,7 @@ class InteractiveRender::SceneGraph
 			}
 		}
 		
-		void path( ScenePlug::ScenePath& p )
+		void path( ScenePlug::ScenePath &p )
 		{
 			if( !m_parent )
 			{
@@ -114,7 +114,7 @@ class InteractiveRender::SceneGraph
 		
 		// scene structure data:
 		IECore::InternedString m_name;
-		SceneGraph* m_parent;
+		SceneGraph *m_parent;
 		std::vector<InteractiveRender::SceneGraph *> m_children;
 		
 		// hash of the attributes as of the most recent evaluation:
@@ -304,7 +304,7 @@ class InteractiveRender::SceneGraphBuildTask : public tbb::task
 
 	public :
 
-		SceneGraphBuildTask( const ScenePlug *scene, const Context* context, SceneGraph *sceneGraph, const ScenePlug::ScenePath &scenePath )
+		SceneGraphBuildTask( const ScenePlug *scene, const Context *context, SceneGraph *sceneGraph, const ScenePlug::ScenePath &scenePath )
 			:	m_scene( scene ),
 				m_context( context ),
 				m_sceneGraph( sceneGraph ),
@@ -386,7 +386,7 @@ class InteractiveRender::SceneGraphBuildTask : public tbb::task
 	private :
 
 		const ScenePlug *m_scene;
-		const Context* m_context;
+		const Context *m_context;
 		SceneGraph *m_sceneGraph;
 		ScenePlug::ScenePath m_scenePath;
 };
@@ -403,7 +403,7 @@ class InteractiveRender::SceneGraphBuildTask : public tbb::task
 class InteractiveRender::SceneGraphIteratorFilter : public tbb::filter
 {
 	public:
-		SceneGraphIteratorFilter( InteractiveRender::SceneGraph* start ) :
+		SceneGraphIteratorFilter( InteractiveRender::SceneGraph *start ) :
 			tbb::filter( tbb::filter::serial_in_order ), m_current( start )
 		{
 			m_childIndices.push_back( 0 );
@@ -444,21 +444,21 @@ class InteractiveRender::SceneGraphIteratorFilter : public tbb::filter
 			}
 		}
 		
-		void* operator()( void* item )
+		void *operator()( void *item )
 		{
 			if( m_childIndices.empty() )
 			{
 				// we've finished the iteration
 				return NULL;
 			}
-			InteractiveRender::SceneGraph* s = m_current;
+			InteractiveRender::SceneGraph *s = m_current;
 			next();
 			return s;
 		}
 	
 	private:
 		
-		SceneGraph* m_current;
+		SceneGraph *m_current;
 		std::vector<size_t> m_childIndices;
 };
 
@@ -476,14 +476,14 @@ class InteractiveRender::SceneGraphIteratorFilter : public tbb::filter
 class InteractiveRender::SceneGraphEvaluatorFilter : public tbb::filter
 {
 	public:
-		SceneGraphEvaluatorFilter( const ScenePlug* scene, const Context* context, bool onlyChanged ) :
+		SceneGraphEvaluatorFilter( const ScenePlug *scene, const Context *context, bool onlyChanged ) :
 			tbb::filter( tbb::filter::parallel ), m_scene( scene ), m_context( context ), m_onlyChanged( onlyChanged )
 		{
 		}
 
-		void* operator()( void* item )
+		void *operator()( void *item )
 		{
-			SceneGraph* s = (SceneGraph*)item;
+			SceneGraph *s = (SceneGraph*)item;
 			ScenePlug::ScenePath p;
 			s->path( p );
 
@@ -529,8 +529,8 @@ class InteractiveRender::SceneGraphEvaluatorFilter : public tbb::filter
 
 	private:
 
-		const ScenePlug* m_scene;
-		const Context* m_context;
+		const ScenePlug *m_scene;
+		const Context *m_context;
 		const bool m_onlyChanged;
 };
 
@@ -548,7 +548,7 @@ class InteractiveRender::SceneGraphOutputFilter : public tbb::thread_bound_filte
 {
 	public:
 	
-		SceneGraphOutputFilter( Renderer* renderer, bool editMode ) :
+		SceneGraphOutputFilter( Renderer *renderer, bool editMode ) :
 			tbb::thread_bound_filter( tbb::filter::serial_in_order ), 
 			m_renderer( renderer ),
 			m_attrBlockCounter( 0 ),
@@ -566,9 +566,9 @@ class InteractiveRender::SceneGraphOutputFilter : public tbb::thread_bound_filte
 			}
 		}
 		
-		void* operator()( void* item )
+		void *operator()( void *item )
 		{
-			SceneGraph* s = (SceneGraph*)item;
+			SceneGraph *s = (SceneGraph*)item;
 			ScenePlug::ScenePath path;
 			s->path( path );
 			
@@ -648,7 +648,7 @@ class InteractiveRender::SceneGraphOutputFilter : public tbb::thread_bound_filte
 			// object:
 			if( s->m_object && !m_editMode )
 			{
-				if( const VisibleRenderable* renderable = runTimeCast< const VisibleRenderable >( s->m_object.get() ) )
+				if( const VisibleRenderable *renderable = runTimeCast< const VisibleRenderable >( s->m_object.get() ) )
 				{
 					renderable->render( m_renderer );
 				}
@@ -660,13 +660,13 @@ class InteractiveRender::SceneGraphOutputFilter : public tbb::thread_bound_filte
 		
 	private:
 		
-		Renderer* m_renderer;
+		Renderer *m_renderer;
 		ScenePlug::ScenePath m_previousPath;
 		int m_attrBlockCounter;
 		bool m_editMode;
 };
 
-void InteractiveRender::runPipeline(tbb::pipeline* p)
+void InteractiveRender::runPipeline(tbb::pipeline *p)
 {
 	p->run( 2 * tbb::task_scheduler_init::default_num_threads() );
 }


### PR DESCRIPTION
Initial scene output also goes directly to the renderer, rather than via procedurals, so we can block the main thread