### PR TITLE
Build fixes

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1247,7 +1247,6 @@ for libraryName, libraryDef in libraries.items() :
 		pythonModuleEnv.Default( pythonModule )
 
 		moduleInstall = pythonModuleEnv.Install( "$BUILD_DIR/python/" + libraryName, pythonModule )
-		pythonModuleEnv.Default( moduleInstall )
 		pythonModuleEnv.Alias( "build", moduleInstall )
 
 	# python component of python module

--- a/config/ie/options
+++ b/config/ie/options
@@ -124,7 +124,7 @@ if getOption( "RELEASE", "0" )=="1" :
 	installRoot = "/software"
 else :
 	buildRoot = os.path.expanduser( "~" )
-	installRoot = os.path.expanduser( "~/gafferTestInstalls" )
+	installRoot = os.path.expanduser( "/tmp/gafferTestInstalls" )
 	versionString += "dev"
 
 BUILD_DIR = buildRoot + "/apps/gaffer/" + versionString + "/" + IEEnv.platform() + "/cortex/" + cortexMajorVersion + "/" + targetApp


### PR DESCRIPTION
- Stopped installing the python module by default. It still compiles by default. Use "scons build" to force it to install. Fixes #1166.
- Moved `installRoot` to /tmp for local IE builds. I presume it's necessary (or desirable) for this to differ from `buildRoot`. If not, I'm happy to make them the same value. I just didn't like the test install clogging up my home dir.