### PR TITLE
Light and coordinate system visibility fixes

### DIFF
--- a/include/GafferScene/SceneAlgo.h
+++ b/include/GafferScene/SceneAlgo.h
@@ -62,6 +62,11 @@ class PathMatcher;
 /// the next path element within its child names.
 bool exists( const ScenePlug *scene, const ScenePlug::ScenePath &path );
 
+/// Returns true if the specified location is visible, and false otherwise.
+/// This operates by traversing the path from the root, terminating if
+/// the "scene:visible" attribute is false.
+bool visible( const ScenePlug *scene, const ScenePlug::ScenePath &path );
+
 /// Finds all the paths in the scene that are matched by the filter, and adds them into the PathMatcher.
 void matchingPaths( const Filter *filter, const ScenePlug *scene, PathMatcher &paths );
 /// As above, but specifying the filter as a plug - typically Filter::matchPlug() or

--- a/python/GafferSceneTest/SceneAlgoTest.py
+++ b/python/GafferSceneTest/SceneAlgoTest.py
@@ -88,6 +88,56 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 		self.assertFalse( GafferScene.exists( group["out"], "/group/sphere2" ) )
 		self.assertFalse( GafferScene.exists( group["out"], "/group/plane/child" ) )
 
+	def testVisible( self ) :
+
+		sphere = GafferScene.Sphere()
+		group = GafferScene.Group()
+		group["in"].setInput( sphere["out"] )
+		group2 = GafferScene.Group()
+		group2["in"].setInput( group["out"] )
+
+		visibleFilter = GafferScene.PathFilter()
+
+		attributes1 = GafferScene.StandardAttributes()
+		attributes1["attributes"]["visibility"]["enabled"].setValue( True )
+		attributes1["attributes"]["visibility"]["value"].setValue( True )
+		attributes1["in"].setInput( group2["out"] )
+		attributes1["filter"].setInput( visibleFilter["match"] )
+
+		invisibleFilter = GafferScene.PathFilter()
+
+		attributes2 = GafferScene.StandardAttributes()
+		attributes2["attributes"]["visibility"]["enabled"].setValue( True )
+		attributes2["attributes"]["visibility"]["value"].setValue( False )
+		attributes2["in"].setInput( attributes1["out"] )
+		attributes2["filter"].setInput( invisibleFilter["match"] )
+
+		self.assertTrue( GafferScene.visible( attributes2["out"], "/group/group/sphere" ) )
+		self.assertTrue( GafferScene.visible( attributes2["out"], "/group/group" ) )
+		self.assertTrue( GafferScene.visible( attributes2["out"], "/group" ) )
+		self.assertTrue( GafferScene.visible( attributes2["out"], "/" ) )
+
+		visibleFilter["paths"].setValue( IECore.StringVectorData( [ "/group" ] ) )
+
+		self.assertTrue( GafferScene.visible( attributes2["out"], "/group/group/sphere" ) )
+		self.assertTrue( GafferScene.visible( attributes2["out"], "/group/group" ) )
+		self.assertTrue( GafferScene.visible( attributes2["out"], "/group" ) )
+		self.assertTrue( GafferScene.visible( attributes2["out"], "/" ) )
+
+		invisibleFilter["paths"].setValue( IECore.StringVectorData( [ "/group/group" ] ) )
+
+		self.assertFalse( GafferScene.visible( attributes2["out"], "/group/group/sphere" ) )
+		self.assertFalse( GafferScene.visible( attributes2["out"], "/group/group" ) )
+		self.assertTrue( GafferScene.visible( attributes2["out"], "/group" ) )
+		self.assertTrue( GafferScene.visible( attributes2["out"], "/" ) )
+
+		visibleFilter["paths"].setValue( IECore.StringVectorData( [ "/group/group/sphere" ] ) )
+
+		self.assertFalse( GafferScene.visible( attributes2["out"], "/group/group/sphere" ) )
+		self.assertFalse( GafferScene.visible( attributes2["out"], "/group/group" ) )
+		self.assertTrue( GafferScene.visible( attributes2["out"], "/group" ) )
+		self.assertTrue( GafferScene.visible( attributes2["out"], "/" ) )
+
 if __name__ == "__main__":
 	unittest.main()
 

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -222,14 +222,19 @@ bool outputLight( const ScenePlug *scene, const ScenePlug::ScenePath &path, IECo
 		return false;
 	}
 
-	ConstCompoundObjectPtr attributes = scene->fullAttributes( path );
-	const BoolData *visibilityData = attributes->member<BoolData>( "scene:visible" );
-	if( visibilityData && !visibilityData->readable() )
+	if( !visible( scene, path ) )
 	{
+		/// \todo Since both visible() and fullAttributes() perform similar work,
+		/// we may want to combine them into one query if we see this function
+		/// being a significant fraction of render time. Maybe something like
+		/// `fullAttributes( returnNullIfInvisible = true )`? It probably also
+		/// makes sense to migrate all the convenience functions from ScenePlug
+		/// into SceneAlgo.
 		return false;
 	}
 
-	M44f transform = scene->fullTransform( path );
+	ConstCompoundObjectPtr attributes = scene->fullAttributes( path );
+	const M44f transform = scene->fullTransform( path );
 
 	std::string lightHandle;
 	ScenePlug::pathToString( path, lightHandle );

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -294,9 +294,7 @@ bool outputCoordinateSystem( const ScenePlug *scene, const ScenePlug::ScenePath 
 		return false;
 	}
 
-	ConstCompoundObjectPtr attributes = scene->fullAttributes( path );
-	const BoolData *visibilityData = attributes->member<BoolData>( "scene:visible" );
-	if( visibilityData && !visibilityData->readable() )
+	if( !visible( scene, path ) )
 	{
 		return false;
 	}

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -74,6 +74,28 @@ bool GafferScene::exists( const ScenePlug *scene, const ScenePlug::ScenePath &pa
 	return true;
 }
 
+bool GafferScene::visible( const ScenePlug *scene, const ScenePlug::ScenePath &path )
+{
+	ContextPtr context = new Context( *Context::current(), Context::Borrowed );
+	Context::Scope scopedContext( context.get() );
+
+	ScenePlug::ScenePath p; p.reserve( path.size() );
+	for( ScenePlug::ScenePath::const_iterator it = path.begin(), eIt = path.end(); it != eIt; ++it )
+	{
+		p.push_back( *it );
+		context->set( ScenePlug::scenePathContextName, p );
+
+		ConstCompoundObjectPtr attributes = scene->attributesPlug()->getValue();
+		const BoolData *visibilityData = attributes->member<BoolData>( "scene:visible" );
+		if( visibilityData && !visibilityData->readable() )
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
 namespace
 {
 

--- a/src/GafferSceneBindings/SceneAlgoBinding.cpp
+++ b/src/GafferSceneBindings/SceneAlgoBinding.cpp
@@ -68,6 +68,7 @@ static void matchingPathsHelper2( const Gaffer::IntPlug *filterPlug, const Scene
 void bindSceneAlgo()
 {
 	def( "exists", exists );
+	def( "visible", visible );
 	def( "matchingPaths", &matchingPathsHelper1 );
 	def( "matchingPaths", &matchingPathsHelper2 );
 }


### PR DESCRIPTION
This fixes a bug whereby lights and coordinate systems were still being output if their parents were hidden, but they themselves had visibility turned on. The key here is that you cannot use `fullAttributes()` to determine visibility, so I've introduced a new `visible()` function in SceneAlgo to do it right.