### PR TITLE
Visible dimensions

### DIFF
--- a/python/GafferRenderManUI/RenderManShaderUI.py
+++ b/python/GafferRenderManUI/RenderManShaderUI.py
@@ -355,6 +355,7 @@ def __nullCreator( plug, annotations ) :
 
 __creators = {
 	"number" : __numberCreator,
+	"vector2" : __numberCreator,
 	"string" : __stringCreator,
 	"boolean" : __booleanCreator,
 	"checkBox" : __booleanCreator,
@@ -411,7 +412,6 @@ GafferUI.PlugValueWidget.registerCreator( GafferRenderMan.RenderManLight, "param
 # Metadata registrations
 ##########################################################################
 
-
 def __nodeDescription( node ) :
 
 	__defaultNodeDescription = """Loads shaders for use in RenderMan renderers. Use the ShaderAssignment node to assign shaders to objects in the scene."""
@@ -458,6 +458,16 @@ def __plugDivider( plug ) :
 
 	return d.value.lower() in ( "True", "true", "1" )
 
+def __plugVisibleDimensions( plug ) :
+
+	annotations = _shaderAnnotations( plug.node() )
+	d = annotations.get( plug.getName() + ".widget", None )
+
+	if d is not None and d.value == "vector2" :
+		return 2
+	else :
+		return None
+
 Gaffer.Metadata.registerNodeDescription( GafferRenderMan.RenderManShader, __nodeDescription )
 
 Gaffer.Metadata.registerNodeValue( GafferRenderMan.RenderManShader, "nodeGadget:color", __nodeColor )
@@ -470,3 +480,6 @@ Gaffer.Metadata.registerPlugValue( GafferRenderMan.RenderManLight, "parameters.*
 
 Gaffer.Metadata.registerPlugValue( GafferRenderMan.RenderManShader, "parameters.*", "divider", __plugDivider )
 Gaffer.Metadata.registerPlugValue( GafferRenderMan.RenderManLight, "parameters.*", "divider", __plugDivider )
+
+Gaffer.Metadata.registerPlugValue( GafferRenderMan.RenderManShader, "parameters.*", "ui:visibleDimensions", __plugVisibleDimensions )
+Gaffer.Metadata.registerPlugValue( GafferRenderMan.RenderManLight, "parameters.*", "ui:visibleDimensions", __plugVisibleDimensions )

--- a/python/GafferUI/CompoundNumericPlugValueWidget.py
+++ b/python/GafferUI/CompoundNumericPlugValueWidget.py
@@ -40,6 +40,11 @@ import IECore
 import Gaffer
 import GafferUI
 
+# Supported metadata :
+#
+#	- "ui:visibleDimensions" controls how many dimensions are actually shown.
+#     For instance, a value of 2 can be used to make a V3fPlug appear like a
+#     V2fPlug.
 class CompoundNumericPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __init__( self, plug, **kw ) :
@@ -53,6 +58,8 @@ class CompoundNumericPlugValueWidget( GafferUI.PlugValueWidget ) :
 			w = GafferUI.NumericPlugValueWidget( p )
 			self.__row.append( w )
 
+		self.__applyVisibleDimensions()
+
 		self.__keyPressConnection = self.keyPressSignal().connect( Gaffer.WeakMethod( self.__keyPress ) )
 
 	def setPlug( self, plug ) :
@@ -63,6 +70,8 @@ class CompoundNumericPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		for index, plug in enumerate( plug.children() ) :
 			self.__row[index].setPlug( plug )
+
+		self.__applyVisibleDimensions()
 
 	def setHighlighted( self, highlighted ) :
 
@@ -169,6 +178,15 @@ class CompoundNumericPlugValueWidget( GafferUI.PlugValueWidget ) :
 				"shortCut" : "Ctrl+G",
 				"active" : not plugValueWidget.getReadOnly(),
 			} )
+
+	def __applyVisibleDimensions( self ) :
+
+		actualDimensions = len( self.getPlug() )
+		visibleDimensions = Gaffer.Metadata.plugValue( self.getPlug(), "ui:visibleDimensions" )
+		visibleDimensions = visibleDimensions if visibleDimensions is not None else actualDimensions
+
+		for i in range( 0, actualDimensions ) :
+			self.__row[i].setVisible( i < visibleDimensions )
 
 __popupMenuConnection = GafferUI.PlugValueWidget.popupMenuSignal().connect( CompoundNumericPlugValueWidget._popupMenu )
 

--- a/python/GafferUITest/CompoundNumericPlugValueWidgetTest.py
+++ b/python/GafferUITest/CompoundNumericPlugValueWidgetTest.py
@@ -72,5 +72,17 @@ class CompoundNumericPlugValueWidgetTest( unittest.TestCase ) :
 			self.assertTrue( w.childPlugValueWidget( n["v1"][i] ).getPlug().isSame( n["v1"][i] ) )
 			self.assertTrue( w.childPlugValueWidget( n["v2"][i] ) is None )
 
+	def testVisibleDimensionsMetadata( self ) :
+
+		n = Gaffer.Node()
+		n["v"] = Gaffer.V3fPlug()
+		Gaffer.Metadata.registerPlugValue( n["v"], "ui:visibleDimensions", 2 )
+
+		w = GafferUI.CompoundNumericPlugValueWidget( n["v"] )
+
+		self.assertTrue( w.childPlugValueWidget( n["v"][0] ).getVisible() )
+		self.assertTrue( w.childPlugValueWidget( n["v"][1] ).getVisible() )
+		self.assertFalse( w.childPlugValueWidget( n["v"][2] ).getVisible() )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This is one for @danieldresser and @cedriclaunay, and adds support for an RSL shader annotation for hiding the Z component of a point/vector/normal parameter. Just add a "parameterName.widget" annotation with a value of "vector2".