### PR TITLE
Viewer camera evaluation time

### DIFF
--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -768,7 +768,7 @@ class SceneView::LookThrough
 
 			m_overlay->setResolutionGate( Box2f( V2f( offset ), V2f( resolutionGateSize + offset ) ) );
 			m_overlay->setCropWindow( camera->parametersData()->member<Box2fData>( "cropWindow" )->readable() );
-			m_overlay->setCaption( boost::str( boost::format( "%dx%d %.3f" ) % resolution.x % resolution.y % pixelAspectRatio ) );
+			m_overlay->setCaption( boost::str( boost::format( "%dx%d, %.3f, %s" ) % resolution.x % resolution.y % pixelAspectRatio % camera->getName() ) );
 			m_overlay->setVisible( true );
 
 			// Now modify the camera, so that the view through the resolution gate we've calculated

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -543,10 +543,18 @@ class SceneView::LookThrough
 
 			// Set up our nodes. We use a standard options node to disable camera motion blur
 			// and overscan because we don't want them applied to the cameras we retrieve with SceneAlgo.
+			// We also must disable transform blur and deformation blur, because if either of those is
+			// on, the shutter range becomes non-zero and the SceneAlgo transform() method will evaluate the
+			// camera at the shutter start rather than the current time, even though its only evaluating a
+			// single time sample.
 
 			m_standardOptions->inPlug()->setInput( view->inPlug<ScenePlug>() );
 			m_standardOptions->optionsPlug()->getChild<CompoundDataPlug::MemberPlug>( "cameraBlur" )->enabledPlug()->setValue( true );
 			m_standardOptions->optionsPlug()->getChild<CompoundDataPlug::MemberPlug>( "cameraBlur" )->valuePlug<BoolPlug>()->setValue( false );
+			m_standardOptions->optionsPlug()->getChild<CompoundDataPlug::MemberPlug>( "transformBlur" )->enabledPlug()->setValue( true );
+			m_standardOptions->optionsPlug()->getChild<CompoundDataPlug::MemberPlug>( "transformBlur" )->valuePlug<BoolPlug>()->setValue( false );
+			m_standardOptions->optionsPlug()->getChild<CompoundDataPlug::MemberPlug>( "deformationBlur" )->enabledPlug()->setValue( true );
+			m_standardOptions->optionsPlug()->getChild<CompoundDataPlug::MemberPlug>( "deformationBlur" )->valuePlug<BoolPlug>()->setValue( false );
 			m_standardOptions->optionsPlug()->getChild<CompoundDataPlug::MemberPlug>( "overscan" )->enabledPlug()->setValue( true );
 			m_standardOptions->optionsPlug()->getChild<CompoundDataPlug::MemberPlug>( "overscan" )->valuePlug<BoolPlug>()->setValue( false );
 


### PR DESCRIPTION
This fixes a big which caused the viewer to evaluate the camera at the wrong time (the shutter open time, rather than the exact current time as is used in the rest of the viewer). This could not only cause a slight offset in the camera position, but also broke Caribou, because the Maya live scene can only be evaluated at the current timeline time. Fixes internal IE tickets 7079 and INC937024.