### PR TITLE
Gadget render request improvements

### DIFF
--- a/include/GafferUI/CompoundNodule.h
+++ b/include/GafferUI/CompoundNodule.h
@@ -87,7 +87,6 @@ class CompoundNodule : public Nodule
 
 		void childAdded( Gaffer::GraphComponent *parent, Gaffer::GraphComponent *child );
 		void childRemoved( Gaffer::GraphComponent *parent, Gaffer::GraphComponent *child );
-		void childRenderRequest( Gadget *child );
 
 		typedef std::map<const Gaffer::Plug *, Nodule *> NoduleMap;
 		NoduleMap m_nodules;

--- a/include/GafferUI/Gadget.h
+++ b/include/GafferUI/Gadget.h
@@ -259,6 +259,10 @@ class Gadget : public Gaffer::GraphComponent
 
 	protected :
 
+		/// Emits renderRequestSignal() as necessary for this and all ancestors.
+		/// Use this rather than emit the signal manually.
+		void requestRender();
+
 		/// The subclass specific part of render(). The public render() method
 		/// sets the GL state up with the name attribute and transform for
 		/// this Gadget, makes sure the style is bound and then calls doRender().
@@ -270,7 +274,6 @@ class Gadget : public Gaffer::GraphComponent
 		void styleChanged();
 		void childAdded( GraphComponent *parent, GraphComponent *child );
 		void childRemoved( GraphComponent *parent, GraphComponent *child );
-		void childRenderRequest( Gadget *child );
 
 		ConstStylePtr m_style;
 

--- a/include/GafferUI/Gadget.h
+++ b/include/GafferUI/Gadget.h
@@ -272,8 +272,7 @@ class Gadget : public Gaffer::GraphComponent
 	private :
 
 		void styleChanged();
-		void childAdded( GraphComponent *parent, GraphComponent *child );
-		void childRemoved( GraphComponent *parent, GraphComponent *child );
+		void parentChanged( GraphComponent *child, GraphComponent *oldParent );
 
 		ConstStylePtr m_style;
 

--- a/src/GafferImageUI/ImageView.cpp
+++ b/src/GafferImageUI/ImageView.cpp
@@ -346,7 +346,7 @@ class ImageViewGadget : public GafferUI::Gadget
 				m_channelToView = channel;
 			}
 
-			renderRequestSignal()( this );
+			requestRender();
 
 			return true;
 		}
@@ -440,7 +440,7 @@ class ImageViewGadget : public GafferUI::Gadget
 					if( boxIntersects( swatchBox, mouseRasterPos ) )
 					{
 						m_sampleColor = *m_colorUiElements[i].color;
-						renderRequestSignal()( this );
+						requestRender();
 						return true;
 					}
 				}
@@ -448,7 +448,7 @@ class ImageViewGadget : public GafferUI::Gadget
 
 			m_drawSelection = m_colorUiElements[1].draw = m_colorUiElements[2].draw = m_colorUiElements[3].draw = false;
 			*m_colorUiElements[0].color = m_sampleColor = sampleColor( m_mousePos );
-			renderRequestSignal()( this );
+			requestRender();
 
 			return true;
 		}
@@ -457,7 +457,7 @@ class ImageViewGadget : public GafferUI::Gadget
 		{
 			m_mousePos = gadgetToDisplaySpace( V3f( event.line.p0.x, event.line.p0.y, 0 ) );
 			*m_colorUiElements[0].color = sampleColor( m_mousePos );
-			renderRequestSignal()( this );
+			requestRender();
 			return true;
 		}
 
@@ -513,7 +513,7 @@ class ImageViewGadget : public GafferUI::Gadget
 
 			m_mousePos = gadgetToDisplaySpace( V3f( event.line.p0.x, event.line.p0.y, 0 ) );
 			*m_colorUiElements[0].color = sampleColor( m_mousePos );
-			renderRequestSignal()( this );
+			requestRender();
 			return true;
 		}
 
@@ -526,7 +526,7 @@ class ImageViewGadget : public GafferUI::Gadget
 			}
 			m_dragSelecting = false;
 
-			renderRequestSignal()( this );
+			requestRender();
 			return true;
 		}
 

--- a/src/GafferSceneUI/CropWindowTool.cpp
+++ b/src/GafferSceneUI/CropWindowTool.cpp
@@ -126,7 +126,7 @@ class CropWindowTool::Rectangle : public GafferUI::Gadget
 				return;
 			}
 			m_masked = masked;
-			renderRequestSignal()( this );
+			requestRender();
 		}
 
 		bool getMasked() const
@@ -147,7 +147,7 @@ class CropWindowTool::Rectangle : public GafferUI::Gadget
 				return;
 			}
 			m_caption = caption;
-			renderRequestSignal()( this );
+			requestRender();
 		}
 
 		const std::string &getCaption() const
@@ -239,7 +239,7 @@ class CropWindowTool::Rectangle : public GafferUI::Gadget
 			}
 			m_rectangle = rectangle;
 			rectangleChangedSignal()( this, reason );
-			renderRequestSignal()( this );
+			requestRender();
 		}
 
 		bool mouseMove( const ButtonEvent &event )

--- a/src/GafferSceneUI/SceneGadget.cpp
+++ b/src/GafferSceneUI/SceneGadget.cpp
@@ -867,7 +867,7 @@ void SceneGadget::setScene( GafferScene::ConstScenePlugPtr scene )
 	}
 
 	m_dirtyFlags = UpdateTask::AllDirty;
-	renderRequestSignal()( this );
+	requestRender();
 }
 
 const GafferScene::ScenePlug *SceneGadget::getScene() const
@@ -884,7 +884,7 @@ void SceneGadget::setContext( Gaffer::ContextPtr context )
 
 	m_context = context;
 	m_contextChangedConnection = m_context->changedSignal().connect( boost::bind( &SceneGadget::contextChanged, this, ::_2 ) );
-	renderRequestSignal()( this );
+	requestRender();
 }
 
 Gaffer::Context *SceneGadget::getContext()
@@ -901,7 +901,7 @@ void SceneGadget::setExpandedPaths( GafferScene::ConstPathMatcherDataPtr expande
 {
 	m_expandedPaths = expandedPaths;
 	m_dirtyFlags |= UpdateTask::ExpansionDirty;
-	renderRequestSignal()( this );
+	requestRender();
 }
 
 const GafferScene::PathMatcherData *SceneGadget::getExpandedPaths() const
@@ -917,7 +917,7 @@ void SceneGadget::setMinimumExpansionDepth( size_t depth )
 	}
 	m_minimumExpansionDepth = depth;
 	m_dirtyFlags |= UpdateTask::ExpansionDirty;
-	renderRequestSignal()( this );
+	requestRender();
 }
 
 size_t SceneGadget::getMinimumExpansionDepth() const
@@ -984,7 +984,7 @@ void SceneGadget::setSelection( ConstPathMatcherDataPtr selection )
 {
 	m_selection = selection;
 	m_sceneGraph->applySelection( m_selection->readable() );
-	renderRequestSignal()( this );
+	requestRender();
 }
 
 Imath::Box3f SceneGadget::selectionBound() const
@@ -1056,7 +1056,7 @@ void SceneGadget::plugDirtied( const Gaffer::Plug *plug )
 		return;
 	}
 
-	renderRequestSignal()( this );
+	requestRender();
 }
 
 void SceneGadget::contextChanged( const IECore::InternedString &name )
@@ -1064,7 +1064,7 @@ void SceneGadget::contextChanged( const IECore::InternedString &name )
 	if( !boost::starts_with( name.string(), "ui:" ) )
 	{
 		m_dirtyFlags = UpdateTask::AllDirty;
-		renderRequestSignal()( this );
+		requestRender();
 	}
 }
 

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -191,13 +191,13 @@ class GnomonPlane : public GafferUI::Gadget
 		void enter()
 		{
 			m_hovering = true;
-			renderRequestSignal()( this );
+			requestRender();
 		}
 
 		void leave()
 		{
 			m_hovering = false;
-			renderRequestSignal()( this );
+			requestRender();
 		}
 
 		bool m_hovering;
@@ -424,7 +424,7 @@ class CameraOverlay : public GafferUI::Gadget
 				return;
 			}
 			m_resolutionGate = resolutionGate;
-			renderRequestSignal()( this );
+			requestRender();
 		}
 
 		const Box2f &getResolutionGate() const
@@ -440,7 +440,7 @@ class CameraOverlay : public GafferUI::Gadget
 				return;
 			}
 			m_cropWindow = cropWindow;
-			renderRequestSignal()( this );
+			requestRender();
 		}
 
 		const Box2f &getCropWindow() const
@@ -455,7 +455,7 @@ class CameraOverlay : public GafferUI::Gadget
 				return;
 			}
 			m_caption = caption;
-			renderRequestSignal()( this );
+			requestRender();
 		}
 
 		const std::string &getCaption() const
@@ -1143,7 +1143,7 @@ void SceneView::baseStateChanged()
 {
 	/// \todo This isn't transferring the override state properly. Probably an IECoreGL problem.
 	m_sceneGadget->baseState()->add( const_cast<IECoreGL::State *>( baseState() ) );
-	m_sceneGadget->renderRequestSignal()( m_sceneGadget.get() );
+	viewportGadget()->renderRequestSignal()( viewportGadget() );
 }
 
 void SceneView::plugSet( Gaffer::Plug *plug )

--- a/src/GafferSceneUI/SelectionTool.cpp
+++ b/src/GafferSceneUI/SelectionTool.cpp
@@ -78,7 +78,7 @@ class SelectionTool::DragOverlay : public GafferUI::Gadget
 				return;
 			}
 			m_startPosition = p;
-			renderRequestSignal()( this );
+			requestRender();
 		}
 
 		const V3f &getStartPosition() const
@@ -93,7 +93,7 @@ class SelectionTool::DragOverlay : public GafferUI::Gadget
 				return;
 			}
 			m_endPosition = p;
-			renderRequestSignal()( this );
+			requestRender();
 		}
 
 		const V3f &getEndPosition() const

--- a/src/GafferUI/BackdropNodeGadget.cpp
+++ b/src/GafferUI/BackdropNodeGadget.cpp
@@ -296,7 +296,7 @@ void BackdropNodeGadget::plugDirtied( const Gaffer::Plug *plug )
 		plug == boundPlug()
 	)
 	{
-		renderRequestSignal()( this );
+		requestRender();
 	}
 }
 
@@ -325,7 +325,7 @@ bool BackdropNodeGadget::mouseMove( Gadget *gadget, const ButtonEvent &event )
 	if( newHovered != m_hovered )
 	{
 		m_hovered = newHovered;
-		renderRequestSignal()( this );
+		requestRender();
 	}
 
 	return true;
@@ -395,7 +395,7 @@ void BackdropNodeGadget::leave( Gadget *gadget, const ButtonEvent &event )
 {
 	Pointer::setCurrent( "" );
 	m_hovered = false;
-	renderRequestSignal()( this );
+	requestRender();
 }
 
 float BackdropNodeGadget::hoverWidth() const
@@ -455,7 +455,7 @@ void BackdropNodeGadget::nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore:
 	{
 		if( updateUserColor() )
 		{
-			renderRequestSignal()( this );
+			requestRender();
 		}
 	}
 }

--- a/src/GafferUI/CompoundNodule.cpp
+++ b/src/GafferUI/CompoundNodule.cpp
@@ -73,8 +73,6 @@ CompoundNodule::CompoundNodule( Gaffer::CompoundPlugPtr plug, LinearContainer::O
 			m_row->addChild( nodule );
 		}
 	}
-
-	m_row->renderRequestSignal().connect( boost::bind( &CompoundNodule::childRenderRequest, this, ::_1 ) );
 }
 
 CompoundNodule::~CompoundNodule()
@@ -145,9 +143,4 @@ void CompoundNodule::childRemoved( Gaffer::GraphComponent *parent, Gaffer::Graph
 			break;
 		}
 	}
-}
-
-void CompoundNodule::childRenderRequest( Gadget *child )
-{
-	renderRequestSignal()( this );
 }

--- a/src/GafferUI/ConnectionGadget.cpp
+++ b/src/GafferUI/ConnectionGadget.cpp
@@ -122,7 +122,7 @@ void ConnectionGadget::setMinimised( bool minimised )
 		return;
 	}
 	m_minimised = minimised;
-	renderRequestSignal()( this );
+	requestRender();
 }
 
 bool ConnectionGadget::getMinimised() const

--- a/src/GafferUI/ContainerGadget.cpp
+++ b/src/GafferUI/ContainerGadget.cpp
@@ -66,7 +66,7 @@ void ContainerGadget::setPadding( const Imath::Box3f &padding )
 		return;
 	}
 	m_padding = padding;
-	renderRequestSignal()( this );
+	requestRender();
 }
 
 const Imath::Box3f &ContainerGadget::getPadding() const

--- a/src/GafferUI/Gadget.cpp
+++ b/src/GafferUI/Gadget.cpp
@@ -61,8 +61,7 @@ Gadget::Gadget( const std::string &name )
 	std::string n = "__Gaffer::Gadget::" + boost::lexical_cast<std::string>( (size_t)this );
 	m_glName = IECoreGL::NameStateComponent::glNameFromName( n, true );
 
-	childAddedSignal().connect( boost::bind( &Gadget::childAdded, this, ::_1, ::_2 ) );
-	childRemovedSignal().connect( boost::bind( &Gadget::childRemoved, this, ::_1, ::_2 )  );
+	parentChangedSignal().connect( boost::bind( &Gadget::parentChanged, this, ::_1, ::_2 ) );
 }
 
 GadgetPtr Gadget::select( GLuint id )
@@ -402,14 +401,15 @@ void Gadget::styleChanged()
 	requestRender();
 }
 
-void Gadget::childAdded( GraphComponent *parent, GraphComponent *child )
+void Gadget::parentChanged( GraphComponent *child, GraphComponent *oldParent )
 {
-	assert( parent==this );
-	requestRender();
-}
-
-void Gadget::childRemoved( GraphComponent *parent, GraphComponent *child )
-{
-	assert( parent==this );
-	requestRender();
+	assert( child==this );
+	if( Gadget *oldParentGadget = IECore::runTimeCast<Gadget>( oldParent ) )
+	{
+		oldParentGadget->requestRender();
+	}
+	if( Gadget *parentGadget = child->parent<Gadget>() )
+	{
+		parentGadget->requestRender();
+	}
 }

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -871,13 +871,13 @@ bool GraphGadget::dragEnter( GadgetPtr gadget, const DragDropEvent &event )
 		V2f pos = V2f( i.x, i.y );
 		offsetNodes( m_scriptNode->selection(), pos - m_lastDragPosition );
 		m_lastDragPosition = pos;
-		renderRequestSignal()( this );
+ 		requestRender();
 		return true;
 	}
 	else if( m_dragMode == Selecting )
 	{
 		m_lastDragPosition = V2f( i.x, i.y );
-		renderRequestSignal()( this );
+ 		requestRender();
 		return true;
 	}
 
@@ -934,7 +934,7 @@ bool GraphGadget::dragMove( GadgetPtr gadget, const DragDropEvent &event )
 		offsetNodes( m_scriptNode->selection(), pos - m_lastDragPosition );
 		m_lastDragPosition = pos;
 		updateDragReconnectCandidate( event );
-		renderRequestSignal()( this );
+ 		requestRender();
 		return true;
 	}
 	else
@@ -942,7 +942,7 @@ bool GraphGadget::dragMove( GadgetPtr gadget, const DragDropEvent &event )
 		// we're drag selecting
 		m_lastDragPosition = V2f( i.x, i.y );
 		updateDragSelection( false );
-		renderRequestSignal()( this );
+ 		requestRender();
 		return true;
 	}
 
@@ -1105,12 +1105,12 @@ bool GraphGadget::dragEnd( GadgetPtr gadget, const DragDropEvent &event )
 		}
 
 		m_dragReconnectCandidate = 0;
-		renderRequestSignal()( this );
+ 		requestRender();
 	}
 	else if( dragMode == Selecting )
 	{
 		updateDragSelection( true );
-		renderRequestSignal()( this );
+ 		requestRender();
 	}
 
 	return true;

--- a/src/GafferUI/Handle.cpp
+++ b/src/GafferUI/Handle.cpp
@@ -72,7 +72,7 @@ void Handle::setType( Type type )
 	}
 
 	m_type = type;
-	renderRequestSignal()( this );
+ 	requestRender();
 }
 
 Handle::Type Handle::getType() const
@@ -121,13 +121,13 @@ void Handle::doRender( const Style *style ) const
 void Handle::enter()
 {
 	m_hovering = true;
-	renderRequestSignal()( this );
+ 	requestRender();
 }
 
 void Handle::leave()
 {
 	m_hovering = false;
-	renderRequestSignal()( this );
+ 	requestRender();
 }
 
 bool Handle::buttonPress( const ButtonEvent &event )

--- a/src/GafferUI/LinearContainer.cpp
+++ b/src/GafferUI/LinearContainer.cpp
@@ -77,7 +77,7 @@ void LinearContainer::setOrientation( Orientation orientation )
 	if( orientation != m_orientation )
 	{
 		m_orientation = orientation;
-		renderRequestSignal()( this );
+		requestRender();
 		m_clean = false;
 	}
 }
@@ -97,7 +97,7 @@ void LinearContainer::setAlignment( Alignment alignment )
 	{
 		m_alignment = alignment;
 		m_clean = false;
-		renderRequestSignal()( this );
+		requestRender();
 	}
 }
 
@@ -116,7 +116,7 @@ void LinearContainer::setSpacing( float spacing )
 	{
 		m_spacing = spacing;
 		m_clean = false;
-		renderRequestSignal()( this );
+ 		requestRender();
 	}
 }
 
@@ -135,7 +135,7 @@ void LinearContainer::setDirection( Direction direction )
 	{
 		m_direction = direction;
 		m_clean = false;
-		renderRequestSignal()( this );
+ 		requestRender();
 	}
 }
 

--- a/src/GafferUI/ObjectView.cpp
+++ b/src/GafferUI/ObjectView.cpp
@@ -81,5 +81,5 @@ void ObjectView::update()
 void ObjectView::baseStateChanged()
 {
 	m_renderableGadget->baseState()->add( const_cast<IECoreGL::State *>( baseState() ) );
-	m_renderableGadget->renderRequestSignal()( m_renderableGadget.get() );
+	viewportGadget()->renderRequestSignal()( viewportGadget() );
 }

--- a/src/GafferUI/RenderableGadget.cpp
+++ b/src/GafferUI/RenderableGadget.cpp
@@ -155,7 +155,7 @@ void RenderableGadget::setRenderable( IECore::ConstVisibleRenderablePtr renderab
 			m_scene->setCamera( 0 );
 			applySelection();
 		}
-		renderRequestSignal()( this );
+ 		requestRender();
 	}
 }
 
@@ -221,7 +221,7 @@ void RenderableGadget::setSelection( const std::set<std::string> &selection )
 	m_selection = selection;
 	applySelection();
 	m_selectionChangedSignal( this );
-	renderRequestSignal()( this );
+ 	requestRender();
 }
 
 RenderableGadget::SelectionChangedSignal &RenderableGadget::selectionChangedSignal()
@@ -322,7 +322,7 @@ bool RenderableGadget::buttonPress( GadgetPtr gadget, const ButtonEvent &event )
 	{
 		applySelection();
 		m_selectionChangedSignal( this );
-		renderRequestSignal()( this );
+ 		requestRender();
 	}
 	return true;
 }
@@ -340,7 +340,7 @@ IECore::RunTimeTypedPtr RenderableGadget::dragBegin( GadgetPtr gadget, const Dra
 		// drag to select
 		m_dragStartPosition = m_lastDragPosition = event.line.p0;
 		m_dragSelecting = true;
-		renderRequestSignal()( this );
+ 		requestRender();
 		return this;
 	}
 	else
@@ -365,7 +365,7 @@ bool RenderableGadget::dragEnter( GadgetPtr gadget, const DragDropEvent &event )
 bool RenderableGadget::dragMove( GadgetPtr gadget, const DragDropEvent &event )
 {
 	m_lastDragPosition = event.line.p1;
-	renderRequestSignal()( this );
+ 	requestRender();
 	return true;
 }
 
@@ -398,7 +398,7 @@ bool RenderableGadget::dragEnd( GadgetPtr gadget, const DragDropEvent &event )
 		m_selectionChangedSignal( this );
 	}
 
-	renderRequestSignal()( this );
+ 	requestRender();
 	return true;
 }
 

--- a/src/GafferUI/SpacerGadget.cpp
+++ b/src/GafferUI/SpacerGadget.cpp
@@ -70,7 +70,7 @@ void SpacerGadget::setSize( const Imath::Box3f &size )
 		return;
 	}
 	m_bound = size;
-	renderRequestSignal()( this );
+ 	requestRender();
 }
 
 bool SpacerGadget::acceptsChild( const GraphComponent *potentialChild ) const

--- a/src/GafferUI/SplinePlugGadget.cpp
+++ b/src/GafferUI/SplinePlugGadget.cpp
@@ -173,13 +173,13 @@ void SplinePlugGadget::splineAdded( SetPtr splineStandardSet, IECore::RunTimeTyp
 
 void SplinePlugGadget::pointAdded( GraphComponentPtr spline, GraphComponentPtr pointPlug )
 {
-	renderRequestSignal()( this );
+ 	requestRender();
 }
 
 void SplinePlugGadget::pointRemoved( GraphComponentPtr spline, GraphComponentPtr pointPlug )
 {
 	m_selection->remove( pointPlug.get() );
-	renderRequestSignal()( this );
+ 	requestRender();
 }
 
 bool SplinePlugGadget::selectionAcceptance( ConstStandardSetPtr selection, IECore::ConstRunTimeTypedPtr point )
@@ -217,7 +217,7 @@ void SplinePlugGadget::plugSet( Plug *plug )
 {
 	if( m_splines->contains( plug ) )
 	{
-		renderRequestSignal()( this );
+ 		requestRender();
 	}
 }
 
@@ -334,7 +334,7 @@ bool SplinePlugGadget::buttonPress( GadgetPtr, const ButtonEvent &event )
 
 		if( handled )
 		{
-			renderRequestSignal()( this );
+ 			requestRender();
 		}
 
 		return handled;

--- a/src/GafferUI/StandardConnectionGadget.cpp
+++ b/src/GafferUI/StandardConnectionGadget.cpp
@@ -167,7 +167,7 @@ void StandardConnectionGadget::updateDragEndPoint( const Imath::V3f position, co
 	{
 		throw IECore::Exception( "Not dragging" );
 	}
-	renderRequestSignal()( this );
+ 	requestRender();
 }
 
 void StandardConnectionGadget::doRender( const Style *style ) const
@@ -261,7 +261,7 @@ bool StandardConnectionGadget::dragEnd( GadgetPtr gadget, const DragDropEvent &e
 	}
 
 	m_dragEnd = Gaffer::Plug::Invalid;
-	renderRequestSignal()( this );
+ 	requestRender();
 	return true;
 }
 
@@ -301,13 +301,13 @@ std::string StandardConnectionGadget::getToolTip( const IECore::LineSegment3f &l
 void StandardConnectionGadget::enter( GadgetPtr gadget, const ButtonEvent &event )
 {
 	m_hovering = true;
-	renderRequestSignal()( this );
+ 	requestRender();
 }
 
 void StandardConnectionGadget::leave( GadgetPtr gadget, const ButtonEvent &event )
 {
 	m_hovering = false;
-	renderRequestSignal()( this );
+ 	requestRender();
 }
 
 bool StandardConnectionGadget::nodeSelected( const Nodule *nodule ) const
@@ -342,7 +342,7 @@ void StandardConnectionGadget::plugMetadataChanged( IECore::TypeId nodeTypeId, c
 
 	if( updateUserColor() )
 	{
-		renderRequestSignal()( this );
+ 		requestRender();
 	}
 }
 

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -578,7 +578,7 @@ void StandardNodeGadget::plugDirtied( const Gaffer::Plug *plug )
 	if( dependencyNode && plug == dependencyNode->enabledPlug() )
 	{
 		m_nodeEnabled = static_cast<const Gaffer::BoolPlug *>( plug )->getValue();
-		renderRequestSignal()( this );
+ 		requestRender();
 	}
 
 	if( ErrorGadget *e = errorGadget( /* createIfMissing = */ false ) )
@@ -750,7 +750,7 @@ void StandardNodeGadget::nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore:
 	{
 		if( updateUserColor() )
 		{
-			renderRequestSignal()( this );
+ 			requestRender();
 		}
 	}
 	else if( key == g_paddingKey )

--- a/src/GafferUI/StandardNodule.cpp
+++ b/src/GafferUI/StandardNodule.cpp
@@ -94,7 +94,7 @@ void StandardNodule::setLabelVisible( bool labelVisible )
 		return;
 	}
 	m_labelVisible = labelVisible;
-	renderRequestSignal()( this );
+ 	requestRender();
 }
 
 bool StandardNodule::getLabelVisible() const
@@ -112,7 +112,7 @@ void StandardNodule::updateDragEndPoint( const Imath::V3f position, const Imath:
 	m_dragPosition = position;
 	m_dragTangent = tangent;
 	m_draggingConnection = true;
-	renderRequestSignal()( this );
+ 	requestRender();
 }
 
 void StandardNodule::doRender( const Style *style ) const
@@ -220,7 +220,7 @@ bool StandardNodule::buttonPress( GadgetPtr gadget, const ButtonEvent &event )
 
 IECore::RunTimeTypedPtr StandardNodule::dragBegin( GadgetPtr gadget, const ButtonEvent &event )
 {
-	renderRequestSignal()( this );
+ 	requestRender();
 	if( event.buttons == ButtonEvent::Middle )
 	{
 		GafferUI::Pointer::setCurrent( "plug" );
@@ -280,7 +280,7 @@ bool StandardNodule::dragEnter( GadgetPtr gadget, const DragDropEvent &event )
 			setCompatibleLabelsVisible( event, true );
 		}
 
-		renderRequestSignal()( this );
+ 		requestRender();
 		return true;
 	}
 
@@ -290,7 +290,7 @@ bool StandardNodule::dragEnter( GadgetPtr gadget, const DragDropEvent &event )
 bool StandardNodule::dragMove( GadgetPtr gadget, const DragDropEvent &event )
 {
 	m_dragPosition = event.line.p0;
-	renderRequestSignal()( this );
+ 	requestRender();
 	return true;
 }
 
@@ -325,7 +325,7 @@ bool StandardNodule::dragLeave( GadgetPtr gadget, const DragDropEvent &event )
 		m_draggingConnection = false;
 	}
 
-	renderRequestSignal()( this );
+ 	requestRender();
 	return true;
 }
 
@@ -434,7 +434,7 @@ void StandardNodule::plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffe
 
 	if( updateUserColor() )
 	{
-		renderRequestSignal()( this );
+ 		requestRender();
 	}
 }
 

--- a/src/GafferUI/TextGadget.cpp
+++ b/src/GafferUI/TextGadget.cpp
@@ -73,7 +73,7 @@ void TextGadget::setText( const std::string &text )
 		Imath::Box3f cb = style()->characterBound( Style::LabelText );
 		m_bound.min.y = std::min( m_bound.min.y, cb.min.y );
 		m_bound.max.y = std::max( m_bound.max.y, cb.max.y );
-		renderRequestSignal()( this );
+ 		requestRender();
 	}
 }
 

--- a/src/GafferUI/ViewportGadget.cpp
+++ b/src/GafferUI/ViewportGadget.cpp
@@ -220,7 +220,7 @@ void ViewportGadget::frame( const Imath::Box3f &box )
 {
 	m_cameraController.frame( box );
 	m_cameraChangedSignal( this );
- 	renderRequestSignal()( this );
+ 	requestRender();
 }
 
 void ViewportGadget::frame( const Imath::Box3f &box, const Imath::V3f &viewDirection,
@@ -228,7 +228,7 @@ void ViewportGadget::frame( const Imath::Box3f &box, const Imath::V3f &viewDirec
 {
  	m_cameraController.frame( box, viewDirection, upVector );
 	m_cameraChangedSignal( this );
-	renderRequestSignal()( this );
+ 	requestRender();
 }
 
 void ViewportGadget::setDragTracking( bool dragTracking )
@@ -564,7 +564,7 @@ bool ViewportGadget::dragMove( GadgetPtr gadget, const DragDropEvent &event )
 		{
 			m_cameraController.motionUpdate( V2i( (int)event.line.p1.x, (int)event.line.p1.y ) );
 			m_cameraChangedSignal( this );
-			renderRequestSignal()( this );
+ 			requestRender();
 		}
 		return true;
 	}
@@ -696,7 +696,7 @@ void ViewportGadget::trackDragIdle()
 	dragMove( this, m_dragTrackingEvent );
 
 	m_cameraChangedSignal( this );
-	renderRequestSignal()( this );
+ 	requestRender();
 }
 
 GadgetPtr ViewportGadget::updatedDragDestination( std::vector<GadgetPtr> &gadgets, const DragDropEvent &event )
@@ -789,7 +789,7 @@ bool ViewportGadget::dragEnd( GadgetPtr gadget, const DragDropEvent &event )
 		{
 			m_cameraController.motionEnd( V2i( (int)event.line.p1.x, (int)event.line.p1.y ) );
 			m_cameraChangedSignal( this );
-			renderRequestSignal()( this );
+ 			requestRender();
 		}
 		return true;
 	}
@@ -827,7 +827,7 @@ bool ViewportGadget::wheel( GadgetPtr gadget, const ButtonEvent &event )
 	m_cameraController.motionEnd( position );
 
 	m_cameraChangedSignal( this );
-	renderRequestSignal()( this );
+ 	requestRender();
 
 	return true;
 }

--- a/src/GafferUIBindings/GadgetBinding.cpp
+++ b/src/GafferUIBindings/GadgetBinding.cpp
@@ -222,6 +222,7 @@ void GafferUIBindings::bindGadget()
 		.staticmethod( "_idleSignalAccessedSignal" )
 		.def( "_executeOnUIThreadSignal", &Gadget::executeOnUIThreadSignal, return_value_policy<reference_existing_object>() )
 		.staticmethod( "_executeOnUIThreadSignal" )
+		.def( "_requestRender", &Gadget::requestRender )
 		.def( "select", &Gadget::select ).staticmethod( "select" )
 	;
 


### PR DESCRIPTION
This reduces the signal/slot overhead used for signalling a Gadget's desire to be rerendered. The new `Gadget::requestRender()` method also gives us a hook to optimise things further in the future, by not constructing the signal unless it is accessed, and only emitting it lazily (so we don't emit it more than once before render() is called again). I've been meaning to do this for a while, but I was prompted to dive into it today because this new approach also fixes a File->New crash bug in Caribou (IE internal ticket 7096).