### PR TITLE
Setting DispatcherUI frameRange widget text in PlaybackRange mode.

### DIFF
--- a/python/GafferUI/DispatcherUI.py
+++ b/python/GafferUI/DispatcherUI.py
@@ -358,6 +358,9 @@ class __FramesModePlugValueWidget( GafferUI.PlugValueWidget ) :
 		frameRange = playback.getFrameRange()
 		frameRange = str(IECore.frameListFromList( range(frameRange[0], frameRange[1]+1) ))
 		self.getPlug().node()["frameRange"].setValue( frameRange )
+		frameRangeWidget = self.__frameRangeWidget()
+		if frameRangeWidget :
+			frameRangeWidget.textWidget().setText( str(frameRange) )
 	
 	def __scriptPlugDirtied( self, plug ) :
 		


### PR DESCRIPTION
This is necessary because CurrentFrame and FullRange mode override the widget text. When we switch back to PlaybackRange from one of those, the actual plug value remains the same, so the setValue call doesn't trigger a widget update on its own.