### PR TITLE
Error handling improvements

### DIFF
--- a/src/GafferScene/BranchCreator.cpp
+++ b/src/GafferScene/BranchCreator.cpp
@@ -99,6 +99,10 @@ void BranchCreator::affects( const Plug *input, AffectedPlugsContainer &outputs 
 	}
 	else if( input == parentPlug() )
 	{
+		outputs.push_back( mappingPlug() );
+	}
+	else if( input == mappingPlug() )
+	{
 		for( ValuePlugIterator it( outPlug() ); it != it.end(); it++ )
 		{
 			outputs.push_back( it->get() );

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -112,9 +112,15 @@ class StandardNodeGadget::ErrorGadget : public Gadget
 			{
 				return result;
 			}
+
+			std::set<std::string> reported;
 			for( PlugErrors::const_iterator it = m_errors.begin(); it != m_errors.end(); ++it )
 			{
-				result += it->second.error;
+				if( reported.find( it->second.error ) == reported.end() )
+				{
+					result += it->second.error;
+					reported.insert( it->second.error );
+				}
 			}
 			return result;
 		}


### PR DESCRIPTION
This prevents duplicate errors being displayed on the StandardNodeGadget, and fixes a dirty propagation error in BranchCreator that prevented the error display being cleared for Duplicate nodes.