### PR TITLE
Stopped display transforms hardcoding OCIO "linear" colour space.

### DIFF
--- a/startup/gui/ocio.py
+++ b/startup/gui/ocio.py
@@ -98,7 +98,7 @@ application.__ocioPlugSetConnection = preferences.plugSetSignal().connect( __plu
 def __displayTransformCreator( name ) :
 
 	result = GafferImage.OpenColorIO()
-	result["inputSpace"].setValue( "linear" )
+	result["inputSpace"].setValue( config.getColorSpace( OCIO.Constants.ROLE_SCENE_LINEAR ).getName() )
 	result["outputSpace"].setValue( config.getDisplayColorSpaceName( defaultDisplay, name ) )
 
 	return result
@@ -121,7 +121,7 @@ def __updateDefaultDisplayTransforms() :
 def __defaultDisplayTransformCreator() :
 
 	result = GafferImage.OpenColorIO()
-	result["inputSpace"].setValue( "linear" )
+	result["inputSpace"].setValue( config.getColorSpace( OCIO.Constants.ROLE_SCENE_LINEAR ).getName() )
 
 	__defaultDisplayTransforms.append( result )
 	__updateDefaultDisplayTransforms()


### PR DESCRIPTION
OCIO allows the "scene referred linear" colour space to be given its own name, so we must query and use that rather than hardcode "linear".