### PR TITLE
Fixed CompoundEditor lifetime bug

### DIFF
--- a/python/GafferUI/CompoundEditor.py
+++ b/python/GafferUI/CompoundEditor.py
@@ -108,35 +108,35 @@ class CompoundEditor( GafferUI.EditorWidget ) :
 
 		return self.__editorAddedSignal
 
+	def __serialise( self, w ) :
+
+		assert( isinstance( w, GafferUI.SplitContainer ) )
+
+		if len( w ) > 1 :
+			# it's split
+			sizes = w.getSizes()
+			splitPosition = ( float( sizes[0] ) / sum( sizes ) ) if sum( sizes ) else 0
+			return "( GafferUI.SplitContainer.Orientation.%s, %f, ( %s, %s ) )" % ( str( w.getOrientation() ), splitPosition, self.__serialise( w[0] ), self.__serialise( w[1] ) )
+		else :
+			# not split - a tabbed container full of editors
+			tabbedContainer = w[0]
+			tabDict = { "tabs" : tuple( tabbedContainer[:] ) }
+			if tabbedContainer.getCurrent() is not None :
+				tabDict["currentTab"] = tabbedContainer.index( tabbedContainer.getCurrent() )
+			tabDict["tabsVisible"] = tabbedContainer.getTabsVisible()
+
+			tabDict["pinned"] = []
+			for editor in tabbedContainer :
+				if isinstance( editor, GafferUI.NodeSetEditor ) :
+					tabDict["pinned"].append( not editor.getNodeSet().isSame( self.scriptNode().selection() ) )
+				else :
+					tabDict["pinned"].append( None )
+
+			return repr( tabDict )
+	
 	def __repr__( self ) :
 
-		def __serialise( w ) :
-
-			assert( isinstance( w, GafferUI.SplitContainer ) )
-
-			if len( w ) > 1 :
-				# it's split
-				sizes = w.getSizes()
-				splitPosition = ( float( sizes[0] ) / sum( sizes ) ) if sum( sizes ) else 0
-				return "( GafferUI.SplitContainer.Orientation.%s, %f, ( %s, %s ) )" % ( str( w.getOrientation() ), splitPosition, __serialise( w[0] ), __serialise( w[1] ) )
-			else :
-				# not split - a tabbed container full of editors
-				tabbedContainer = w[0]
-				tabDict = { "tabs" : tuple( tabbedContainer[:] ) }
-				if tabbedContainer.getCurrent() is not None :
-					tabDict["currentTab"] = tabbedContainer.index( tabbedContainer.getCurrent() )
-				tabDict["tabsVisible"] = tabbedContainer.getTabsVisible()
-
-				tabDict["pinned"] = []
-				for editor in tabbedContainer :
-					if isinstance( editor, GafferUI.NodeSetEditor ) :
-						tabDict["pinned"].append( not editor.getNodeSet().isSame( self.scriptNode().selection() ) )
-					else :
-						tabDict["pinned"].append( None )
-
-				return repr( tabDict )
-
-		return "GafferUI.CompoundEditor( scriptNode, children = %s )" % __serialise( self.__splitContainer )
+		return "GafferUI.CompoundEditor( scriptNode, children = %s )" % self.__serialise( self.__splitContainer )
 
 	def _layoutMenuDefinition( self, tabbedContainer ) :
 


### PR DESCRIPTION
It looks like the fact that _ _ serialise function that gets declared inside CompoundEditor._ _ repr_ _ was leading to circular references. The fact that _ _ serialise was recursive and used "self" was sufficient to set up a circular dependency in the guts of python that meant that as soon as someone called CompoundEditor._ _ repr_ _, the CompoundEditor became IMMORTAL. Well, until someone called the garbage collector. This was giving me grief when switching scenes in Caribou.

I've fixed it by just turning __serialise into a method.