### PR TITLE
Merge node fix

### DIFF
--- a/include/GafferImage/FilterProcessor.h
+++ b/include/GafferImage/FilterProcessor.h
@@ -52,6 +52,11 @@ namespace GafferImage
 /// Only hash connected inputs (if it is enabled).
 /// Expand the data window to by merging all of the connect input's data windows.
 /// Use the first display window encountered on a connected input.
+/// \todo Rename this to something sensible (what does it have to do with filtering?). Ideally I think
+/// we might make both the SceneProcessor and ImageProcessor base classes capable of having multiple inputs
+/// via an ArrayPlug called "in".
+/// \todo Review the usefulness of this base class. At present it is only subclassed by Merge, and it's not clear
+/// that the behaviour of FilterProcessor is useful for any other subclasses.
 class FilterProcessor : public ImageProcessor
 {
 

--- a/include/GafferImage/Merge.h
+++ b/include/GafferImage/Merge.h
@@ -79,6 +79,9 @@ class Merge : public FilterProcessor
 	protected :
 
 		/// The different types of operation that are available.
+		/// \todo Remove the "k" prefix. Expose the enum publicly
+		/// and bind it so we don't have to use hardcoded integers
+		/// from the test scripts.
 		enum
 		{
 			kAdd = 0,

--- a/src/GafferImage/FilterProcessor.cpp
+++ b/src/GafferImage/FilterProcessor.cpp
@@ -69,9 +69,12 @@ void FilterProcessor::affects( const Gaffer::Plug *input, AffectedPlugsContainer
 	const ImagePlugList& inputs( m_inputs.inputs() );
 	for( ImagePlugList::const_iterator it( inputs.begin() ); it < inputs.end(); it++ )
 	{
-		if( input == (*it)->formatPlug() ||
-				input == (*it)->dataWindowPlug() ||
-				input == (*it)->channelNamesPlug() )
+		if(
+			input == (*it)->formatPlug() ||
+			input == (*it)->dataWindowPlug() ||
+			input == (*it)->channelNamesPlug() ||
+			input == (*it)->channelDataPlug()
+		)
 		{
 			outputs.push_back( outPlug()->getChild<ValuePlug>( input->getName() ) );
 			return;


### PR DESCRIPTION
This fixes a bug whereby the merge node didn't signal dirtiness when the input channel data was dirtied. This meant that the viewer didn't update appropriately when setting on the the inputs were changed.