### PR TITLE
Added a test for CompoundEditor.__repr__() lifetime bug.

### DIFF
--- a/python/GafferUITest/CompoundEditorTest.py
+++ b/python/GafferUITest/CompoundEditorTest.py
@@ -97,6 +97,18 @@ class CompoundEditorTest( GafferUITest.TestCase ) :
 		self.assertEqual( wc(), None )
 		self.assertEqual( wn(), None )
 
+	def testReprLifetime( self ) :
+
+		s = Gaffer.ScriptNode()
+		c = GafferUI.CompoundEditor( s )
+
+		wc = weakref.ref( c )
+		repr( c )
+
+		del c
+
+		self.assertEqual( wc(), None )
+
 if __name__ == "__main__":
 	unittest.main()
 


### PR DESCRIPTION
Here's a test to accompany #1184. This is the sort of thing we really should be unit testing in GafferUITest - critical bugs which are trivial to right test cases for...