### PR TITLE
appleseed: fixed render threads and texture memory options

### DIFF
--- a/python/GafferAppleseedUI/AppleseedOptionsUI.py
+++ b/python/GafferAppleseedUI/AppleseedOptionsUI.py
@@ -147,7 +147,7 @@ def __systemSummary( plug ) :
 	if plug["numThreads"]["enabled"].getValue() :
 		info.append( "Threads %d" % plug["numThreads"]["value"].getValue() )
 	if plug["textureMem"]["enabled"].getValue() :
-		info.append( "Texture Mem %d MB" % plug["textureMem"]["value"].getValue() )
+		info.append( "Texture Mem %d Kb" % plug["textureMem"]["value"].getValue() )
 	if plug["tileOrdering"]["enabled"].getValue() :
 		info.append( "Tile Ordering %s" % plug["tileOrdering"]["value"].getValue().capitalize() )
 
@@ -229,8 +229,8 @@ GafferUI.PlugValueWidget.registerCreator(
 			"summary" : __systemSummary,
 			"namesAndLabels" : (
 				( "as:searchpath", "Searchpath" ),
-				( "as:num_threads", "Threads" ),
-				( "as:texture_mem", "Texture Cache Size" ),
+				( "as:cfg:rendering_threads", "Threads" ),
+				( "as:cfg:texture_store:max_size", "Texture Cache Size" ),
 				( "as:cfg:generic_frame_renderer:tile_ordering", "Tile Ordering" ),
 			),
 		},

--- a/src/GafferAppleseed/AppleseedOptions.cpp
+++ b/src/GafferAppleseed/AppleseedOptions.cpp
@@ -93,7 +93,7 @@ AppleseedOptions::AppleseedOptions( const std::string &name )
 
 	// system parameters
 	options->addOptionalMember( "as:searchpath", new IECore::StringData( "" ), "searchPath", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "as:num_threads", new IECore::IntData( 8 ), "numThreads", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "as:texture_mem", new IECore::IntData( 256 ), "textureMem", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "as:cfg:rendering_threads", new IECore::IntData( 8 ), "numThreads", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "as:cfg:texture_store:max_size", new IECore::IntData( 256 * 1024 ), "textureMem", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "as:cfg:generic_frame_renderer:tile_ordering", new IECore::StringData( "hilbert" ), "tileOrdering", Gaffer::Plug::Default, false );
 }


### PR DESCRIPTION
This PR fixes the rendering threads and max texture cache size that were not working previously.
It is a breaking change (one that's quite easy to fix with a text editor).
I can add a backwards compatible workaround, instead of fixing it in the AppleseedOptions node but
I think that the number of scenes affected by this change will be very low at this point and it might be better just fixing it.

My plan is to review the code for similar issues (I think this is the only one), 
fix them and not doing any breaking changes after the first release.

Would that be ok?
