### PR TITLE
Fixed creation of expressions for BoolPlugs.

### DIFF
--- a/python/GafferUI/ExpressionUI.py
+++ b/python/GafferUI/ExpressionUI.py
@@ -63,12 +63,7 @@ def __createExpression( plug ) :
 		expression += plug.relativeName( parentNode ).replace( ".", "']['" )
 		expression += "'] = "
 
-		if isinstance( plug, Gaffer.StringPlug ) :
-			expression += "''"
-		elif isinstance( plug, Gaffer.IntPlug ) :
-			expression += "1"
-		elif isinstance( plug, Gaffer.FloatPlug ) :
-			expression += "1.0"
+		expression += repr( plug.getValue() )
 
 		expressionNode["expression"].setValue( expression )
 


### PR DESCRIPTION
Because there was no value being assigned in the default expression, parsing failed, and the expression editor was not shown. Now we always use the current plug value for the default value of the expression, which also means that the initial value for the expression will always be valid (otherwise it could be out of range for instance).