### PR TITLE
Viewer camera chooser context fix

### DIFF
--- a/python/GafferUI/ExpressionUI.py
+++ b/python/GafferUI/ExpressionUI.py
@@ -63,12 +63,7 @@ def __createExpression( plug ) :
 		expression += plug.relativeName( parentNode ).replace( ".", "']['" )
 		expression += "'] = "
 
-		if isinstance( plug, Gaffer.StringPlug ) :
-			expression += "''"
-		elif isinstance( plug, Gaffer.IntPlug ) :
-			expression += "1"
-		elif isinstance( plug, Gaffer.FloatPlug ) :
-			expression += "1.0"
+		expression += repr( plug.getValue() )
 
 		expressionNode["expression"].setValue( expression )
 

--- a/python/GafferUI/Viewer.py
+++ b/python/GafferUI/Viewer.py
@@ -127,6 +127,7 @@ class Viewer( GafferUI.NodeSetEditor ) :
 						if self.__currentView is not None:
 							self.__currentView.__updateRequestConnection = self.__currentView.updateRequestSignal().connect( Gaffer.WeakMethod( self.__updateRequest, fallbackResult=None ) )
 							self.__currentView.__pendingUpdate = True
+							self.__currentView.setContext( self.getContext() )
 							self.__viewToolbars[self.__currentView] = GafferUI.NodeToolbar.create( self.__currentView )
 							self.__viewTools[self.__currentView] = [ GafferUI.Tool.create( n, self.__currentView ) for n in GafferUI.Tool.registeredTools( self.__currentView.typeId() ) ]
 							self.__viewTools[self.__currentView].sort( key = lambda v : Gaffer.Metadata.nodeValue( v, "order" ) if Gaffer.Metadata.nodeValue( v, "order" ) is not None else 999 )


### PR DESCRIPTION
This ensures that the camera chooser dialogue in the viewer evaluates the scene at the correct frame. This can be important if some nodes would error outside of a particular frame range (perhaps because they're trying to read a file that doesn't exist). It also fixes an expression creation bug for BoolPlugs, which I discovered in the course of reproducing the camera chooser issue.