### PR TITLE
Control over thread count

### DIFF
--- a/apps/execute/execute-1.py
+++ b/apps/execute/execute-1.py
@@ -146,8 +146,12 @@ class execute( Gaffer.Application ) :
 		
 		with context :
 			for node in nodes :
-				node.executeSequence( frames )
-		
+				try :
+					node.executeSequence( frames )
+				except Exception as exception :
+					IECore.msg( IECore.Msg.Level.Error, "gaffer execute : executing %s" % node.relativeName( scriptNode ), str( exception ) )
+					return 1
+
 		return 0
 
 IECore.registerRunTimeTyped( execute )

--- a/python/Gaffer/Application.py
+++ b/python/Gaffer/Application.py
@@ -51,6 +51,16 @@ class Application( IECore.Parameterised ) :
 		self.parameters().addParameters(
 
 			[
+				
+				IECore.IntParameter(
+					name = "threads",
+					description = "The maximum number of threads used for computation. "
+						"The default value of zero causes the number of threads to "
+						" be chosen automatically based on the available hardware.",		
+					defaultValue = 0,
+					minValue = 0,
+				),
+				
 				IECore.FileNameParameter(
 					name = "profileFileName",
 					description = "If this is specified, then the application "
@@ -59,6 +69,7 @@ class Application( IECore.Parameterised ) :
 					defaultValue = "",
 					allowEmptyString = True
 				),
+
 			]
 
 		)
@@ -108,7 +119,13 @@ class Application( IECore.Parameterised ) :
 
 	def __run( self, args ) :
 
-		self._executeStartupFiles( self.root().getName() )
-		return self._run( args )
+		import _Gaffer
+
+		with _Gaffer._tbb_task_scheduler_init(
+			_Gaffer._tbb_task_scheduler_init.automatic if args["threads"].value == 0 else args["threads"].value
+		) :
+
+			self._executeStartupFiles( self.root().getName() )
+			return self._run( args )
 
 IECore.registerRunTimeTyped( Application, typeName = "Gaffer::Application" )

--- a/python/GafferTest/ApplicationTest.py
+++ b/python/GafferTest/ApplicationTest.py
@@ -1,0 +1,54 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferTest
+
+class ApplicationTest( GafferTest.TestCase ) :
+
+	def testTaskSchedulerInitDoesntSuppressExceptions( self ) :
+
+		def f() :
+
+			import Gaffer._Gaffer as _Gaffer
+			with _Gaffer._tbb_task_scheduler_init( _Gaffer._tbb_task_scheduler_init.automatic ) :
+				raise Exception( "Woops!")
+
+		self.assertRaises( Exception, f )
+
+if __name__ == "__main__":
+	unittest.main()
+

--- a/python/GafferTest/ExecuteApplicationTest.py
+++ b/python/GafferTest/ExecuteApplicationTest.py
@@ -207,6 +207,26 @@ class ExecuteApplicationTest( GafferTest.TestCase ) :
 		self.assertFalse( "Traceback" in error )
 		self.assertEqual( p.returncode, 0 )
 
+	def testErrorReturnStatusForExceptionDuringExecution( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( self.__scriptFileName )
+		s["t"] = GafferTest.TextWriter()
+		s["t"]["fileName"].setValue( "" ) # will cause an error
+		s.save()
+
+		p = subprocess.Popen(
+			"gaffer execute -script " + self.__scriptFileName,
+			shell=True,
+			stderr = subprocess.PIPE,
+		)
+		p.wait()
+
+		error = "".join( p.stderr.readlines() )
+		self.failUnless( "ERROR" in error )
+		self.failUnless( "executing t" in error )
+		self.failUnless( p.returncode )
+
 	def tearDown( self ) :
 
 		files = [ self.__scriptFileName ]

--- a/python/GafferTest/__init__.py
+++ b/python/GafferTest/__init__.py
@@ -128,6 +128,7 @@ from SystemCommandTest import SystemCommandTest
 from TaskListTest import TaskListTest
 from NodeAlgoTest import NodeAlgoTest
 from DotTest import DotTest
+from ApplicationTest import ApplicationTest
 
 if __name__ == "__main__":
 	import unittest

--- a/src/GafferModule/GafferModule.cpp
+++ b/src/GafferModule/GafferModule.cpp
@@ -179,8 +179,8 @@ BOOST_PYTHON_MODULE( _Gaffer )
 
 	object tsi = class_<TaskSchedulerInitWrapper, boost::noncopyable>( "_tbb_task_scheduler_init", no_init )
 		.def( init<int>( arg( "max_threads" ) = tbb::task_scheduler_init::automatic ) )
-		.def( "__enter__", &TaskSchedulerInitWrapper::enter )
-		.def( "__exit__", &TaskSchedulerInitWrapper::exit, return_self<>() )
+		.def( "__enter__", &TaskSchedulerInitWrapper::enter, return_self<>() )
+		.def( "__exit__", &TaskSchedulerInitWrapper::exit )
 	;
 	tsi.attr( "automatic" ) = tbb::task_scheduler_init::automatic;
 

--- a/src/GafferModule/GafferModule.cpp
+++ b/src/GafferModule/GafferModule.cpp
@@ -178,11 +178,11 @@ BOOST_PYTHON_MODULE( _Gaffer )
 	DependencyNodeClass<SwitchComputeNode>();
 
 	object tsi = class_<TaskSchedulerInitWrapper, boost::noncopyable>( "_tbb_task_scheduler_init", no_init )
-		.def( init<int>( arg( "max_threads" ) = tbb::task_scheduler_init::automatic ) )
+		.def( init<int>( arg( "max_threads" ) = int( tbb::task_scheduler_init::automatic ) ) )
 		.def( "__enter__", &TaskSchedulerInitWrapper::enter, return_self<>() )
 		.def( "__exit__", &TaskSchedulerInitWrapper::exit )
 	;
-	tsi.attr( "automatic" ) = tbb::task_scheduler_init::automatic;
+	tsi.attr( "automatic" ) = int( tbb::task_scheduler_init::automatic );
 
 	object behavioursModule( borrowed( PyImport_AddModule( "Gaffer.Behaviours" ) ) );
 	scope().attr( "Behaviours" ) = behavioursModule;


### PR DESCRIPTION
This provides some control over the number of threads that Gaffer uses.

When Gaffer is running standalone the new `-threads N` command line argument controls the number of TBB threads we use for computation. This is done in the base `Application` class so applies to all applications. Although I can imagine our internal mechism for achieving this getting more complex in the future, the basics of optionally specifying a thread count on the command line seems sound, and is pretty much in line with user expectations.

When Gaffer is running via procedurals in a render, the situation is much more complex. Here I've just introduced a hack with a `GAFFERSCENE_SCENEPROCEDURAL_THREADS` environment variable to provide _some_ control. See the extensive comments in SceneProcedural.cpp to understand the true filth of it all. I really hope this is a short-term solution, so have made no effort to present it in a genuinely user-facing way. In truth, I don't yet know what a good way of controlling this would be, so this is really just a temp fix to give us some breathing space.

Longer term we have several things to discuss :

- Should we do our own threading inside a procedural, rather than rely on the renderer for concurrency?
- How should we present the user with controls for the number of threads used when a Dispatcher calls `gaffer execute`?
   - An IntPlug per ExecutableNode?
   - A global setting on the Dispatcher?
- How should we present the user with controls for the number of threads used via procedurals?
   - An option on the StandardOptions node?
   - By automatically matching the renderers thread count?
   - By reusing the mechanism we use for the dispatchers themselves?