### PR TITLE
Clipping planes

### DIFF
--- a/include/GafferScene/ClippingPlane.h
+++ b/include/GafferScene/ClippingPlane.h
@@ -1,0 +1,69 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENE_CLIPPINGPLANE_H
+#define GAFFERSCENE_CLIPPINGPLANE_H
+
+#include "GafferScene/ObjectSource.h"
+
+namespace GafferScene
+{
+
+class ClippingPlane : public ObjectSource
+{
+
+	public :
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::ClippingPlane, ClippingPlaneTypeId, ObjectSource );
+
+		ClippingPlane( const std::string &name=defaultName<ClippingPlane>() );
+		virtual ~ClippingPlane();
+
+	protected :
+
+		virtual void hashGlobals( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
+		virtual IECore::ConstCompoundObjectPtr computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const;
+
+		virtual void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		virtual IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const;
+
+};
+
+IE_CORE_DECLAREPTR( ClippingPlane )
+
+} // namespace GafferScene
+
+#endif // GAFFERSCENE_CLIPPINGPLANE_H

--- a/include/GafferScene/RendererAlgo.h
+++ b/include/GafferScene/RendererAlgo.h
@@ -65,6 +65,13 @@ void outputCamera( const ScenePlug *scene, const IECore::CompoundObject *globals
 /// Outputs the camera from the specified location.
 void outputCamera( const ScenePlug *scene, const ScenePlug::ScenePath &cameraPath, const IECore::CompoundObject *globals, IECore::Renderer *renderer );
 
+/// Outputs all the visible clipping planes from the scene.
+void outputClippingPlanes( const ScenePlug *scene, const IECore::CompoundObject *globals, IECore::Renderer *renderer );
+
+/// Outputs a single clipping plane from the scene. Returns true for success, and false if no clipping plane
+/// was found or if it was invisible.
+bool outputClippingPlane( const ScenePlug *scene, const ScenePlug::ScenePath &path, IECore::Renderer *renderer );
+
 /// Outputs the attributes stored in the globals.
 void outputGlobalAttributes( const IECore::CompoundObject *globals, IECore::Renderer *renderer );
 

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -72,7 +72,7 @@ enum TypeId
 	PathFilterTypeId = 110527,
 	AttributesTypeId = 110528,
 	AlembicSourceTypeId = 110529,
-	SourceTypeId = 110530, // obsolete, available for reuse
+	ClippingPlaneTypeId = 110530,
 	SceneContextVariablesTypeId = 110531,
 	StandardOptionsTypeId = 110532,
 	SubTreeTypeId = 110533,

--- a/include/GafferSceneBindings/ClippingPlaneBinding.h
+++ b/include/GafferSceneBindings/ClippingPlaneBinding.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENEBINDINGS_CLIPPINGPLANEBINDING_H
+#define GAFFERSCENEBINDINGS_CLIPPINGPLANEBINDING_H
+
+namespace GafferSceneBindings
+{
+
+void bindClippingPlane();
+
+} // namespace GafferSceneBindings
+
+#endif // GAFFERSCENEBINDINGS_CLIPPINGPLANEBINDING_H

--- a/python/GafferRenderManTest/RenderManRenderTest.py
+++ b/python/GafferRenderManTest/RenderManRenderTest.py
@@ -637,6 +637,22 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 		rib = "\n".join( file( "/tmp/test.rib" ).readlines() )
 		self.assertTrue( "LightSource \"pointlight\"" not in rib )
 
+	def testClippingPlane( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["c"] = GafferScene.ClippingPlane()
+
+		s["r"] = GafferRenderMan.RenderManRender()
+		s["r"]["mode"].setValue( "generate" )
+		s["r"]["ribFileName"].setValue( "/tmp/test.rib" )
+		s["r"]["in"].setInput( s["c"]["out"] )
+
+		s["r"].execute()
+
+		rib = "\n".join( file( "/tmp/test.rib" ).readlines() )
+		self.assertTrue( "ClippingPlane" in rib )
+
 	def setUp( self ) :
 
 		for f in (

--- a/python/GafferSceneTest/ClippingPlaneTest.py
+++ b/python/GafferSceneTest/ClippingPlaneTest.py
@@ -1,0 +1,58 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+
+import GafferScene
+import GafferSceneTest
+
+class ClippingPlaneTest( GafferSceneTest.SceneTestCase ) :
+
+	def test( self ) :
+
+		c = GafferScene.ClippingPlane()
+		self.assertSceneValid( c["out"] )
+
+		self.assertEqual( c["out"].bound( "/clippingPlane" ), IECore.Box3f( IECore.V3f( -0.5, -0.5, 0 ), IECore.V3f( 0.5 ) ) )
+
+		g = c["out"]["globals"].getValue()
+		s = g["gaffer:sets"]["__clippingPlanes"]
+		self.assertEqual( s.value.paths(), [ "/clippingPlane" ] )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -102,6 +102,7 @@ from SceneAlgoTest import SceneAlgoTest
 from CoordinateSystemTest import CoordinateSystemTest
 from DeleteOutputsTest import DeleteOutputsTest
 from ExternalProceduralTest import ExternalProceduralTest
+from ClippingPlaneTest import ClippingPlaneTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferSceneUI/ClippingPlaneUI.py
+++ b/python/GafferSceneUI/ClippingPlaneUI.py
@@ -1,7 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2012, John Haddon. All rights reserved.
-#  Copyright (c) 2012-2014, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -35,61 +34,34 @@
 #
 ##########################################################################
 
-from _GafferSceneUI import *
+import Gaffer
+import GafferUI
 
-from SceneHierarchy import SceneHierarchy
-from SceneInspector import SceneInspector
-from FilterPlugValueWidget import FilterPlugValueWidget
-import SceneNodeUI
-import SceneReaderUI
-import SceneProcessorUI
-import FilteredSceneProcessorUI
-import PruneUI
-import SubTreeUI
-import OutputsUI
-import OptionsUI
-import OpenGLAttributesUI
-import SceneContextVariablesUI
-import SceneWriterUI
-import StandardOptionsUI
-import StandardAttributesUI
-import ShaderUI
-import OpenGLShaderUI
-import ObjectSourceUI
-import TransformUI
-import AttributesUI
-import LightUI
-import InteractiveRenderUI
-import SphereUI
-import MapProjectionUI
-import MapOffsetUI
-import CustomAttributesUI
-import CustomOptionsUI
-import SceneViewToolbar
-import SceneSwitchUI
-import ShaderSwitchUI
-import ShaderAssignmentUI
-import ParentConstraintUI
-import ParentUI
-import PrimitiveVariablesUI
-import DuplicateUI
-import GridUI
-import SetFilterUI
-import DeleteGlobalsUI
-import DeleteOptionsUI
-import ExternalProceduralUI
-import ExecutableRenderUI
-import IsolateUI
-import SelectionToolUI
-import CropWindowToolUI
-import CameraUI
-import SetUI
-import ClippingPlaneUI
+import GafferScene
 
-# then all the PathPreviewWidgets. note that the order
-# of import controls the order of display.
+Gaffer.Metadata.registerNode(
 
-from AlembicPathPreview import AlembicPathPreview
-from SceneReaderPathPreview import SceneReaderPathPreview
+	GafferScene.ClippingPlane,
 
-__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", {}, subdirectory = "GafferSceneUI" )
+	"description",
+	"""
+	Creates an arbitrary clipping plane. This is like the near
+	and far clipping planes provided by the Camera node, but
+	can be positioned arbitrarily in space. All geometry on
+	the positive Z side of the plane is clipped away.
+	""",
+
+	plugs = {
+
+		"name" : [
+
+			"description",
+			"""
+			The name of the clipping plane to be created.
+			""",
+
+		],
+
+	}
+
+)

--- a/src/GafferScene/ClippingPlane.cpp
+++ b/src/GafferScene/ClippingPlane.cpp
@@ -1,0 +1,88 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "IECore/ClippingPlane.h"
+
+#include "GafferScene/ClippingPlane.h"
+#include "GafferScene/PathMatcherData.h"
+
+using namespace Gaffer;
+using namespace GafferScene;
+using namespace Imath;
+
+IE_CORE_DEFINERUNTIMETYPED( ClippingPlane );
+
+ClippingPlane::ClippingPlane( const std::string &name )
+	:	ObjectSource( name, "clippingPlane" )
+{
+}
+
+ClippingPlane::~ClippingPlane()
+{
+}
+
+void ClippingPlane::hashGlobals( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
+{
+	ObjectSource::hashGlobals( context, parent, h );
+	namePlug()->hash( h );
+}
+
+IECore::ConstCompoundObjectPtr ClippingPlane::computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const
+{
+	IECore::CompoundObjectPtr result = new IECore::CompoundObject;
+
+	IECore::CompoundDataPtr sets = result->member<IECore::CompoundData>(
+		"gaffer:sets",
+		/* throwExceptions = */ false,
+		/* createIfMissing = */ true
+	);
+
+	PathMatcherDataPtr clippingPlaneSet = new PathMatcherData;
+	clippingPlaneSet->writable().addPath( "/" + namePlug()->getValue() );
+
+	sets->writable()["__clippingPlanes"] = clippingPlaneSet;
+
+	return result;
+}
+
+void ClippingPlane::hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+}
+
+IECore::ConstObjectPtr ClippingPlane::computeSource( const Context *context ) const
+{
+	return new IECore::ClippingPlane();
+}

--- a/src/GafferScene/ExecutableRender.cpp
+++ b/src/GafferScene/ExecutableRender.cpp
@@ -124,6 +124,7 @@ void ExecutableRender::execute() const
 		outputOptions( globals.get(), renderer.get() );
 		outputOutputs( globals.get(), renderer.get() );
 		outputCameras( scene, globals.get(), renderer.get() );
+		outputClippingPlanes( scene, globals.get(), renderer.get() );
 		{
 			WorldBlock world( renderer );
 

--- a/src/GafferScene/InteractiveRender.cpp
+++ b/src/GafferScene/InteractiveRender.cpp
@@ -249,6 +249,7 @@ void InteractiveRender::update()
 		outputOptions( globals.get(), m_renderer.get() );
 		outputOutputs( globals.get(), m_renderer.get() );
 		outputCameras( inPlug(), globals.get(), m_renderer.get() );
+		outputClippingPlanes( inPlug(), globals.get(), m_renderer.get() );
 		{
 			WorldBlock world( m_renderer );
 

--- a/src/GafferScene/ObjectSource.cpp
+++ b/src/GafferScene/ObjectSource.cpp
@@ -39,6 +39,7 @@
 #include "IECore/NullObject.h"
 #include "IECore/Camera.h"
 #include "IECore/CoordinateSystem.h"
+#include "IECore/ClippingPlane.h"
 
 #include "Gaffer/Context.h"
 
@@ -170,6 +171,10 @@ Imath::Box3f ObjectSource::computeBound( const SceneNode::ScenePath &path, const
 	else if( object->isInstanceOf( IECore::CoordinateSystem::staticTypeId() ) )
 	{
 		result = Imath::Box3f( Imath::V3f( 0 ), Imath::V3f( 1 ) );
+	}
+	else if( object->isInstanceOf( IECore::ClippingPlane::staticTypeId() ) )
+	{
+		result = Imath::Box3f( Imath::V3f( -0.5, -0.5, 0 ), Imath::V3f( 0.5 ) );
 	}
 	else
 	{

--- a/src/GafferSceneBindings/ClippingPlaneBinding.cpp
+++ b/src/GafferSceneBindings/ClippingPlaneBinding.cpp
@@ -1,0 +1,50 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "GafferBindings/DependencyNodeBinding.h"
+
+#include "GafferScene/ClippingPlane.h"
+
+#include "GafferSceneBindings/ClippingPlaneBinding.h"
+
+using namespace GafferScene;
+
+void GafferSceneBindings::bindClippingPlane()
+{
+	GafferBindings::DependencyNodeClass<ClippingPlane>();
+}

--- a/src/GafferSceneBindings/SceneAlgoBinding.cpp
+++ b/src/GafferSceneBindings/SceneAlgoBinding.cpp
@@ -36,6 +36,8 @@
 
 #include "boost/python.hpp"
 
+#include "IECore/Camera.h"
+
 #include "IECorePython/ScopedGILRelease.h"
 
 #include "GafferScene/SceneAlgo.h"
@@ -71,6 +73,17 @@ void bindSceneAlgo()
 	def( "visible", visible );
 	def( "matchingPaths", &matchingPathsHelper1 );
 	def( "matchingPaths", &matchingPathsHelper2 );
+	def( "shutter", &shutter );
+	def(
+		"camera",
+		(IECore::CameraPtr (*)( const ScenePlug *, const IECore::CompoundObject * ) )&camera,
+		( arg( "scene" ), arg( "globals" ) = object() )
+	);
+	def(
+		"camera",
+		(IECore::CameraPtr (*)( const ScenePlug *, const ScenePlug::ScenePath &, const IECore::CompoundObject * ) )&camera,
+		( arg( "scene" ), args( "cameraPath" ), arg( "globals" ) = object() )
+	);
 }
 
 } // namespace GafferSceneBindings

--- a/src/GafferSceneModule/GafferSceneModule.cpp
+++ b/src/GafferSceneModule/GafferSceneModule.cpp
@@ -93,6 +93,7 @@
 #include "GafferSceneBindings/ExternalProceduralBinding.h"
 #include "GafferSceneBindings/GroupBinding.h"
 #include "GafferSceneBindings/ScenePathBinding.h"
+#include "GafferSceneBindings/ClippingPlaneBinding.h"
 
 using namespace boost::python;
 using namespace GafferScene;
@@ -167,5 +168,6 @@ BOOST_PYTHON_MODULE( _GafferScene )
 	bindCoordinateSystem();
 	bindExternalProcedural();
 	bindScenePath();
+	bindClippingPlane();
 
 }

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -215,6 +215,7 @@ nodeMenu.append( "/Scene/File/Alembic", GafferScene.AlembicSource, searchText = 
 nodeMenu.append( "/Scene/Source/Object To Scene", GafferScene.ObjectToScene, searchText = "ObjectToScene" )
 nodeMenu.append( "/Scene/Source/Camera", GafferScene.Camera )
 nodeMenu.append( "/Scene/Source/Coordinate System", GafferScene.CoordinateSystem, searchText = "CoordinateSystem" )
+nodeMenu.append( "/Scene/Source/Clipping Plane", GafferScene.ClippingPlane, searchText = "ClippingPlane" )
 nodeMenu.append( "/Scene/Source/External Procedural", GafferScene.ExternalProcedural, searchText = "ExternalProcedural" )
 nodeMenu.append( "/Scene/Source/Grid", GafferScene.Grid )
 nodeMenu.append( "/Scene/Source/Primitive/Cube", GafferScene.Cube )


### PR DESCRIPTION
This adds support for arbitrary clipping planes via a new ClippingPlane node. The only renderer backend to support this right now is the RenderMan one. This requires https://github.com/ImageEngine/cortex/pull/401 to be merged before it will build.
