### PR TITLE
Edit menu fixes

### DIFF
--- a/include/GafferUI/GraphGadget.h
+++ b/include/GafferUI/GraphGadget.h
@@ -113,8 +113,8 @@ class GraphGadget : public ContainerGadget
 		/// \note Here "upstream" nodes are defined as nodes at the end of input
 		/// connections as shown in the graph - invisible connections and
 		/// invisible nodes are not considered at all.
-		size_t upstreamNodeGadgets( const Gaffer::Node *node, std::vector<NodeGadget *> &upstreamNodeGadgets );
-		size_t upstreamNodeGadgets( const Gaffer::Node *node, std::vector<const NodeGadget *> &upstreamNodeGadgets ) const;
+		size_t upstreamNodeGadgets( const Gaffer::Node *node, std::vector<NodeGadget *> &upstreamNodeGadgets, size_t degreesOfSeparation = Imath::limits<size_t>::max() );
+		size_t upstreamNodeGadgets( const Gaffer::Node *node, std::vector<const NodeGadget *> &upstreamNodeGadgets, size_t degreesOfSeparation = Imath::limits<size_t>::max() ) const;
 
 		/// Sets the position of the specified node within the graph. This
 		/// method may be used even when the node currently has no NodeGadget
@@ -193,7 +193,7 @@ class GraphGadget : public ContainerGadget
 		ConnectionGadget *reconnectionGadgetAt( NodeGadget *gadget, const IECore::LineSegment3f &lineInGadgetSpace ) const;
 		void updateDragReconnectCandidate( const DragDropEvent &event );
 
-		void upstreamNodeGadgetsWalk( NodeGadget *gadget, std::set<NodeGadget *> &upstreamNodeGadgets );
+		void upstreamNodeGadgetsWalk( NodeGadget *gadget, std::set<NodeGadget *> &upstreamNodeGadgets, size_t degreesOfSeparation );
 
 		Gaffer::NodePtr m_root;
 		Gaffer::ScriptNodePtr m_scriptNode;

--- a/include/GafferUI/GraphGadget.h
+++ b/include/GafferUI/GraphGadget.h
@@ -116,6 +116,22 @@ class GraphGadget : public ContainerGadget
 		size_t upstreamNodeGadgets( const Gaffer::Node *node, std::vector<NodeGadget *> &upstreamNodeGadgets, size_t degreesOfSeparation = Imath::limits<size_t>::max() );
 		size_t upstreamNodeGadgets( const Gaffer::Node *node, std::vector<const NodeGadget *> &upstreamNodeGadgets, size_t degreesOfSeparation = Imath::limits<size_t>::max() ) const;
 
+		/// Finds all the downstream NodeGadgets connected to the specified node
+		/// and appends them to the specified vector. Returns the new size of the vector.
+		/// \note Here "downstream" nodes are defined as nodes at the end of output
+		/// connections as shown in the graph - invisible connections and
+		/// invisible nodes are not considered at all.
+		size_t downstreamNodeGadgets( const Gaffer::Node *node, std::vector<NodeGadget *> &downstreamNodeGadgets, size_t degreesOfSeparation = Imath::limits<size_t>::max() );
+		size_t downstreamNodeGadgets( const Gaffer::Node *node, std::vector<const NodeGadget *> &downstreamNodeGadgets, size_t degreesOfSeparation = Imath::limits<size_t>::max() ) const;
+
+		/// Finds all the NodeGadgets connected to the specified node
+		/// and appends them to the specified vector. Returns the new size of the vector.
+		/// \note Here "connected" nodes are defined as nodes at the end of
+		/// connections as shown in the graph - invisible connections and
+		/// invisible nodes are not considered at all.
+		size_t connectedNodeGadgets( const Gaffer::Node *node, std::vector<NodeGadget *> &connectedNodeGadgets, Gaffer::Plug::Direction direction = Gaffer::Plug::Invalid, size_t degreesOfSeparation = Imath::limits<size_t>::max() );
+		size_t connectedNodeGadgets( const Gaffer::Node *node, std::vector<const NodeGadget *> &connectedNodeGadgets, Gaffer::Plug::Direction direction = Gaffer::Plug::Invalid, size_t degreesOfSeparation = Imath::limits<size_t>::max() ) const;
+
 		/// Sets the position of the specified node within the graph. This
 		/// method may be used even when the node currently has no NodeGadget
 		/// associated with it, and the position will be used if and when a NodeGadget
@@ -193,7 +209,7 @@ class GraphGadget : public ContainerGadget
 		ConnectionGadget *reconnectionGadgetAt( NodeGadget *gadget, const IECore::LineSegment3f &lineInGadgetSpace ) const;
 		void updateDragReconnectCandidate( const DragDropEvent &event );
 
-		void upstreamNodeGadgetsWalk( NodeGadget *gadget, std::set<NodeGadget *> &upstreamNodeGadgets, size_t degreesOfSeparation );
+		void connectedNodeGadgetsWalk( NodeGadget *gadget, std::set<NodeGadget *> &connectedGadgets, Gaffer::Plug::Direction direction, size_t degreesOfSeparation );
 
 		Gaffer::NodePtr m_root;
 		Gaffer::ScriptNodePtr m_scriptNode;

--- a/python/GafferUI/EditMenu.py
+++ b/python/GafferUI/EditMenu.py
@@ -210,8 +210,13 @@ def arrange( menu ) :
 def selectAll( menu ) :
 
 	s = scope( menu )
-	for c in s.parent.children( Gaffer.Node ) :
-		s.script.selection().add( c )
+	if s.nodeGraph is None :
+		return
+
+	graphGadget = s.nodeGraph.graphGadget()
+	for node in s.parent.children( Gaffer.Node ) :
+		if graphGadget.nodeGadget( node ) is not None :
+			s.script.selection().add( node )
 
 ## A function suitable as the command for an Edit/Select None menu item. It must
 # be invoked from a menu that has a ScriptWindow in its ancestry.

--- a/python/GafferUI/EditMenu.py
+++ b/python/GafferUI/EditMenu.py
@@ -37,6 +37,7 @@
 
 from __future__ import with_statement
 
+import sys
 import collections
 
 import IECore
@@ -68,8 +69,20 @@ def appendDefinitions( menuDefinition, prefix="" ) :
 	menuDefinition.append( prefix + "/Select Connected/Inputs", { "command" : selectInputs, "active" : __selectionAvailable } )
 	menuDefinition.append( prefix + "/Select Connected/Add Inputs", { "command" : selectAddInputs, "active" : __selectionAvailable } )
 	menuDefinition.append( prefix + "/Select Connected/InputsDivider", { "divider" : True } )
+
+	menuDefinition.append( prefix + "/Select Connected/Upstream", { "command" : selectUpstream, "active" : __selectionAvailable } )
+	menuDefinition.append( prefix + "/Select Connected/Add Upstream", { "command" : selectAddUpstream, "active" : __selectionAvailable } )
+	menuDefinition.append( prefix + "/Select Connected/UpstreamDivider", { "divider" : True } )
+
 	menuDefinition.append( prefix + "/Select Connected/Outputs", { "command" : selectOutputs, "active" : __selectionAvailable } )
 	menuDefinition.append( prefix + "/Select Connected/Add Outputs", { "command" : selectAddOutputs, "active" : __selectionAvailable } )
+	menuDefinition.append( prefix + "/Select Connected/OutputsDivider", { "divider" : True } )
+
+	menuDefinition.append( prefix + "/Select Connected/Downstream", { "command" : selectDownstream, "active" : __selectionAvailable } )
+	menuDefinition.append( prefix + "/Select Connected/Add Downstream", { "command" : selectAddDownstream, "active" : __selectionAvailable } )
+	menuDefinition.append( prefix + "/Select Connected/DownstreamDivider", { "divider" : True } )
+
+	menuDefinition.append( prefix + "/Select Connected/Add All", { "command" : selectConnected, "active" : __selectionAvailable } )
 
 __Scope = collections.namedtuple( "Scope", [ "scriptWindow", "script", "parent", "nodeGraph" ] )
 
@@ -236,6 +249,18 @@ def selectAddInputs( menu ) :
 
 	__selectConnected( menu, Gaffer.Plug.Direction.In, degreesOfSeparation = 1, add = True )
 
+## The command function for the default "Edit/Select Connected/Upstream" menu item. It must
+# be invoked from a menu that has a ScriptWindow in its ancestry.
+def selectUpstream( menu ) :
+
+	__selectConnected( menu, Gaffer.Plug.Direction.In, degreesOfSeparation = sys.maxint, add = False )
+
+## The command function for the default "Edit/Select Connected/Add Upstream" menu item. It must
+# be invoked from a menu that has a ScriptWindow in its ancestry.
+def selectAddUpstream( menu ) :
+
+	__selectConnected( menu, Gaffer.Plug.Direction.In, degreesOfSeparation = sys.maxint, add = True )
+
 ## The command function for the default "Edit/Select Connected/Outputs" menu item. It must
 # be invoked from a menu that has a ScriptWindow in its ancestry.
 def selectOutputs( menu ) :
@@ -247,6 +272,25 @@ def selectOutputs( menu ) :
 def selectAddOutputs( menu ) :
 
 	__selectConnected( menu, Gaffer.Plug.Direction.Out, degreesOfSeparation = 1, add = True )
+
+## The command function for the default "Edit/Select Connected/Downstream" menu item. It must
+# be invoked from a menu that has a ScriptWindow in its ancestry.
+def selectDownstream( menu ) :
+
+	__selectConnected( menu, Gaffer.Plug.Direction.Out, degreesOfSeparation = sys.maxint, add = False )
+
+## The command function for the default "Edit/Select Connected/Add Downstream" menu item. It must
+# be invoked from a menu that has a ScriptWindow in its ancestry.
+def selectAddDownstream( menu ) :
+
+	__selectConnected( menu, Gaffer.Plug.Direction.Out, degreesOfSeparation = sys.maxint, add = True )
+
+## The command function for the default "Edit/Select Connected/Add All" menu item. It must
+# be invoked from a menu that has a ScriptWindow in its ancestry.
+def selectConnected( menu ) :
+
+	__selectConnected( menu, Gaffer.Plug.Direction.Invalid, degreesOfSeparation = sys.maxint, add = True )
+
 
 def __selectConnected( menu, direction, degreesOfSeparation, add ) :
 

--- a/python/GafferUI/EditMenu.py
+++ b/python/GafferUI/EditMenu.py
@@ -37,6 +37,8 @@
 
 from __future__ import with_statement
 
+import collections
+
 import IECore
 
 import Gaffer
@@ -69,146 +71,165 @@ def appendDefinitions( menuDefinition, prefix="" ) :
 	menuDefinition.append( prefix + "/Select Connected/Outputs", { "command" : selectOutputs, "active" : __selectionAvailable } )
 	menuDefinition.append( prefix + "/Select Connected/Add Outputs", { "command" : selectAddOutputs, "active" : __selectionAvailable } )
 
+__Scope = collections.namedtuple( "Scope", [ "scriptWindow", "script", "parent", "nodeGraph" ] )
+
+## Returns the scope in which an edit menu item should operate. The return
+# value has "scriptWindow", "script", "root" and "nodeGraph" attributes.
+# The "nodeGraph" attribute may be None if no NodeGraph can be found. Note
+# that in many cases user expectation is that an operation will only apply
+# to nodes currently visible within the NodeGraph, and that nodes can be
+# filtered within the NodeGraph.
+def scope( menu ) :
+
+	scriptWindow = menu.ancestor( GafferUI.ScriptWindow )
+
+	nodeGraph = None
+	## \todo Add public methods for querying focus.
+	focusWidget = GafferUI.Widget._owner( scriptWindow._qtWidget().focusWidget() )
+	if focusWidget is not None :
+		nodeGraph = focusWidget.ancestor( GafferUI.NodeGraph )
+
+	if nodeGraph is None :
+		nodeGraphs = scriptWindow.getLayout().editors( GafferUI.NodeGraph )
+		if nodeGraphs :
+			nodeGraph = nodeGraphs[0]
+
+	if nodeGraph is not None :
+		parent = nodeGraph.graphGadget().getRoot()
+	else :
+		parent = scriptWindow.scriptNode()
+
+	return __Scope( scriptWindow, scriptWindow.scriptNode(), parent, nodeGraph )
+
 ## A function suitable as the command for an Edit/Undo menu item. It must
 # be invoked from a menu that has a ScriptWindow in its ancestry.
 def undo( menu ) :
 
-	scriptWindow = menu.ancestor( GafferUI.ScriptWindow )
-	script = scriptWindow.scriptNode()
-	script.undo()
+	scope( menu ).script.undo()
 
 ## A function suitable as the command for an Edit/Redo menu item. It must
 # be invoked from a menu that has a ScriptWindow in its ancestry.
 def redo( menu ) :
 
-	scriptWindow = menu.ancestor( GafferUI.ScriptWindow )
-	script = scriptWindow.scriptNode()
-	script.redo()
+	scope( menu ).script.redo()
 
 ## A function suitable as the command for an Edit/Cut menu item. It must
 # be invoked from a menu that has a ScriptWindow in its ancestry.
 def cut( menu ) :
 
-	script, parent = __scriptAndParent( menu )
-	with Gaffer.UndoContext( script ) :
-		script.cut( parent, script.selection() )
+	s = scope( menu )
+	with Gaffer.UndoContext( s.script ) :
+		s.script.cut( s.parent, s.script.selection() )
 
 ## A function suitable as the command for an Edit/Copy menu item. It must
 # be invoked from a menu that has a ScriptWindow in its ancestry.
 def copy( menu ) :
 
-	script, parent = __scriptAndParent( menu )
-	script.copy( parent, script.selection() )
+	s = scope( menu )
+	s.script.copy( s.parent, s.script.selection() )
 
 ## A function suitable as the command for an Edit/Paste menu item. It must
 # be invoked from a menu that has a ScriptWindow in its ancestry.
 def paste( menu ) :
 
-	script, parent = __scriptAndParent( menu )
-	originalSelection = Gaffer.StandardSet( iter( script.selection() ) )
+	s = scope( menu )
+	originalSelection = Gaffer.StandardSet( iter( s.script.selection() ) )
 
-	with Gaffer.UndoContext( script ) :
+	with Gaffer.UndoContext( s.script ) :
 
-		script.paste( parent )
+		s.script.paste( s.parent )
 
 		# try to get the new nodes connected to the original selection
-		nodeGraph = __nodeGraph( menu, focussedOnly=False )
-		if nodeGraph is None :
+		if s.nodeGraph is None :
 			return
 
-		nodeGraph.graphGadget().getLayout().connectNodes( nodeGraph.graphGadget(), script.selection(), originalSelection )
+		s.nodeGraph.graphGadget().getLayout().connectNodes( s.nodeGraph.graphGadget(), s.script.selection(), originalSelection )
 
 		# position the new nodes sensibly
 
-		bound = nodeGraph.bound()
+		bound = s.nodeGraph.bound()
 		mousePosition = GafferUI.Widget.mousePosition()
 		if bound.intersects( mousePosition ) :
 			fallbackPosition = mousePosition - bound.min
 		else :
 			fallbackPosition = bound.center() - bound.min
 
-		fallbackPosition = nodeGraph.graphGadgetWidget().getViewportGadget().rasterToGadgetSpace(
+		fallbackPosition = s.nodeGraph.graphGadgetWidget().getViewportGadget().rasterToGadgetSpace(
 			IECore.V2f( fallbackPosition.x, fallbackPosition.y ),
-			gadget = nodeGraph.graphGadget()
+			gadget = s.nodeGraph.graphGadget()
 		).p0
 		fallbackPosition = IECore.V2f( fallbackPosition.x, fallbackPosition.y )
 
-		nodeGraph.graphGadget().getLayout().positionNodes( nodeGraph.graphGadget(), script.selection(), fallbackPosition )
+		s.nodeGraph.graphGadget().getLayout().positionNodes( s.nodeGraph.graphGadget(), s.script.selection(), fallbackPosition )
 
-		nodeGraph.frame( script.selection(), extend = True )
+		s.nodeGraph.frame( s.script.selection(), extend = True )
 
 ## A function suitable as the command for an Edit/Delete menu item. It must
 # be invoked from a menu that has a ScriptWindow in its ancestry.
 def delete( menu ) :
 
-	script, parent = __scriptAndParent( menu )
-	with Gaffer.UndoContext( script ) :
-		script.deleteNodes( parent, script.selection() )
+	s = scope( menu )
+	with Gaffer.UndoContext( s.script ) :
+		s.script.deleteNodes( s.parent, s.script.selection() )
 
 ## A function suitable as the command for an Edit/Find menu item.  It must
 # be invoked from a menu that has a ScriptWindow in its ancestry.
 def find( menu ) :
 
-	script, parent = __scriptAndParent( menu )
-	scriptWindow = menu.ancestor( GafferUI.ScriptWindow )
+	s = scope( menu )
 
 	try :
-		findDialogue = scriptWindow.__findDialogue
+		findDialogue = s.scriptWindow.__findDialogue
 	except AttributeError :
-		findDialogue = GafferUI.NodeFinderDialogue( parent )
-		scriptWindow.addChildWindow( findDialogue )
-		scriptWindow.__findDialogue = findDialogue
+		findDialogue = GafferUI.NodeFinderDialogue( s.parent )
+		s.scriptWindow.addChildWindow( findDialogue )
+		s.scriptWindow.__findDialogue = findDialogue
 
-	findDialogue.setScope( parent )
+	findDialogue.setScope( s.parent )
 	findDialogue.setVisible( True )
 
 ## A function suitable as the command for an Edit/Arrange menu item.  It must
 # be invoked from a menu that has a ScriptWindow in its ancestry.
 def arrange( menu ) :
 
-	script, parent = __scriptAndParent( menu )
-	nodeGraph = __nodeGraph( menu, focussedOnly=False )
-	if not nodeGraph :
+	s = scope( menu )
+	if not s.nodeGraph :
 		return
 
-	graph = nodeGraph.graphGadget()
+	graph = s.nodeGraph.graphGadget()
 
-	nodes = script.selection()
+	nodes = s.script.selection()
 	if not nodes :
 		nodes = Gaffer.StandardSet( graph.getRoot().children( Gaffer.Node ) )
 
-	with Gaffer.UndoContext( script ) :
+	with Gaffer.UndoContext( s.script ) :
 		graph.getLayout().layoutNodes( graph, nodes )
 
 ## A function suitable as the command for an Edit/Select All menu item. It must
 # be invoked from a menu that has a ScriptWindow in its ancestry.
 def selectAll( menu ) :
 
-	script, parent = __scriptAndParent( menu )
-	for c in parent.children( Gaffer.Node ) :
-		script.selection().add( c )
+	s = scope( menu )
+	for c in s.parent.children( Gaffer.Node ) :
+		s.script.selection().add( c )
 
 ## A function suitable as the command for an Edit/Select None menu item. It must
 # be invoked from a menu that has a ScriptWindow in its ancestry.
 def selectNone( menu ) :
 
-	scriptWindow = menu.ancestor( GafferUI.ScriptWindow )
-	script = scriptWindow.scriptNode()
-
-	script.selection().clear()
+	scope( menu ).script.selection().clear()
 
 ## The command function for the default "Edit/Select Connected/Inputs" menu item. It must
 # be invoked from a menu that has a ScriptWindow in its ancestry.
 def selectInputs( menu ) :
 
-	scriptWindow = menu.ancestor( GafferUI.ScriptWindow )
-	script = scriptWindow.scriptNode()
+	s = scope( menu )
 
 	inputs = Gaffer.StandardSet()
-	for node in script.selection() :
+	for node in s.script.selection() :
 		__inputNodes( node, inputs )
 
-	selection = script.selection()
+	selection = s.script.selection()
 	selection.clear()
 	for node in inputs :
 		selection.add( node )
@@ -217,14 +238,13 @@ def selectInputs( menu ) :
 # be invoked from a menu that has a ScriptWindow in its ancestry.
 def selectAddInputs( menu ) :
 
-	scriptWindow = menu.ancestor( GafferUI.ScriptWindow )
-	script = scriptWindow.scriptNode()
+	s = scope( menu )
 
 	inputs = Gaffer.StandardSet()
-	for node in script.selection() :
+	for node in s.script.selection() :
 		__inputNodes( node, inputs )
 
-	selection = script.selection()
+	selection = s.script.selection()
 	for node in inputs :
 		selection.add( node )
 
@@ -232,14 +252,13 @@ def selectAddInputs( menu ) :
 # be invoked from a menu that has a ScriptWindow in its ancestry.
 def selectOutputs( menu ) :
 
-	scriptWindow = menu.ancestor( GafferUI.ScriptWindow )
-	script = scriptWindow.scriptNode()
+	s = scope( menu )
 
 	outputs = Gaffer.StandardSet()
-	for node in script.selection() :
+	for node in s.script.selection() :
 		__outputNodes( node, outputs )
 
-	selection = script.selection()
+	selection = s.script.selection()
 	selection.clear()
 	for node in outputs :
 		selection.add( node )
@@ -248,66 +267,32 @@ def selectOutputs( menu ) :
 # be invoked from a menu that has a ScriptWindow in its ancestry.
 def selectAddOutputs( menu ) :
 
-	scriptWindow = menu.ancestor( GafferUI.ScriptWindow )
-	script = scriptWindow.scriptNode()
+	s = scope( menu )
 
 	outputs = Gaffer.StandardSet()
-	for node in script.selection() :
+	for node in s.script.selection() :
 		__outputNodes( node, outputs )
 
-	selection = script.selection()
+	selection = s.script.selection()
 	for node in outputs :
 		selection.add( node )
 
 def __selectionAvailable( menu ) :
 
-	scriptWindow = menu.ancestor( GafferUI.ScriptWindow )
-	return True if scriptWindow.scriptNode().selection().size() else False
+	return True if scope( menu ).script.selection().size() else False
 
 def __pasteAvailable( menu ) :
 
-	scriptNode = menu.ancestor( GafferUI.ScriptWindow ).scriptNode()
-	root = scriptNode.ancestor( Gaffer.ApplicationRoot )
+	root = scope( menu ).script.ancestor( Gaffer.ApplicationRoot )
 	return isinstance( root.getClipboardContents(), IECore.StringData )
-
-def __nodeGraph( menu, focussedOnly=True ) :
-
-	scriptWindow = menu.ancestor( GafferUI.ScriptWindow )
-
-	nodeGraph = None
-	## \todo Does this belong as a Window.focussedChild() method?
-	focusWidget = GafferUI.Widget._owner( scriptWindow._qtWidget().focusWidget() )
-	if focusWidget is not None :
-		nodeGraph = focusWidget.ancestor( GafferUI.NodeGraph )
-
-	if nodeGraph is not None or focussedOnly :
-		return nodeGraph
-
-	nodeGraphs = scriptWindow.getLayout().editors( GafferUI.NodeGraph )
-	return nodeGraphs[0] if nodeGraphs else None
-
-def __scriptAndParent( menu ) :
-
-	scriptWindow = menu.ancestor( GafferUI.ScriptWindow )
-	script = scriptWindow.scriptNode()
-
-	nodeGraph = __nodeGraph( menu )
-	if nodeGraph is not None :
-		parent = nodeGraph.graphGadget().getRoot()
-	else :
-		parent = script
-
-	return script, parent
 
 def __undoAvailable( menu ) :
 
-	scriptNode = menu.ancestor( GafferUI.ScriptWindow ).scriptNode()
-	return scriptNode.undoAvailable()
+	return scope( menu ).script.undoAvailable()
 
 def __redoAvailable( menu ) :
 
-	scriptNode = menu.ancestor( GafferUI.ScriptWindow ).scriptNode()
-	return scriptNode.redoAvailable()
+	return scope( menu ).script.redoAvailable()
 
 def __inputNodes( node, inputNodes ) :
 

--- a/python/GafferUITest/NodeGraphTest.py
+++ b/python/GafferUITest/NodeGraphTest.py
@@ -938,6 +938,106 @@ class NodeGraphTest( GafferUITest.TestCase ) :
 		u = [ x.node().relativeName( script ) for x in g.upstreamNodeGadgets( script["f"] ) ]
 		self.assertEqual( u, [ "e" ] )
 
+	def testDownstreamNodeGadgets( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		# a -> b -> c -> e -> f
+		#           |
+		#           v
+		#			d
+
+		script["a"] = GafferTest.AddNode()
+		script["b"] = GafferTest.AddNode()
+		script["c"] = GafferTest.AddNode()
+		script["d"] = GafferTest.AddNode()
+		script["e"] = GafferTest.AddNode()
+		script["f"] = GafferTest.AddNode()
+
+		script["b"]["op1"].setInput( script["a"]["sum"] )
+		script["c"]["op1"].setInput( script["b"]["sum"] )
+		script["d"]["op1"].setInput( script["c"]["sum"] )
+		script["e"]["op1"].setInput( script["c"]["sum"] )
+		script["f"]["op1"].setInput( script["e"]["sum"] )
+
+		g = GafferUI.GraphGadget( script )
+
+		u = [ x.node().relativeName( script ) for x in g.downstreamNodeGadgets( script["b"] ) ]
+		self.assertEqual( len( u ), 4 )
+		self.assertEqual( set( u ), set( [ "c", "d", "e", "f" ] ) )
+
+		u = [ x.node().relativeName( script ) for x in g.downstreamNodeGadgets( script["e"] ) ]
+		self.assertEqual( len( u ), 1 )
+		self.assertEqual( set( u ), set( [ "f" ] ) )
+
+		u = [ x.node().relativeName( script ) for x in g.downstreamNodeGadgets( script["c"], degreesOfSeparation = 1 ) ]
+		self.assertEqual( len( u ), 2 )
+		self.assertEqual( set( u ), set( [ "d", "e" ] ) )
+
+	def testConnectedNodeGadgets( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		# a -> b -> c -> e -> f
+		#           |
+		#           v
+		#			d
+
+		script["a"] = GafferTest.AddNode()
+		script["b"] = GafferTest.AddNode()
+		script["c"] = GafferTest.AddNode()
+		script["d"] = GafferTest.AddNode()
+		script["e"] = GafferTest.AddNode()
+		script["f"] = GafferTest.AddNode()
+
+		script["b"]["op1"].setInput( script["a"]["sum"] )
+		script["c"]["op1"].setInput( script["b"]["sum"] )
+		script["d"]["op1"].setInput( script["c"]["sum"] )
+		script["e"]["op1"].setInput( script["c"]["sum"] )
+		script["f"]["op1"].setInput( script["e"]["sum"] )
+
+		g = GafferUI.GraphGadget( script )
+
+		# test traversing in both directions
+
+		u = [ x.node().relativeName( script ) for x in g.connectedNodeGadgets( script["b"] ) ]
+		self.assertEqual( set( u ), set( [ "a", "c", "d", "e", "f" ] ) )
+
+		u = [ x.node().relativeName( script ) for x in g.connectedNodeGadgets( script["e"] ) ]
+		self.assertEqual( set( u ), set( [ "a", "b", "c", "d", "f" ] ) )
+
+		u = [ x.node().relativeName( script ) for x in g.connectedNodeGadgets( script["c"], degreesOfSeparation = 1 ) ]
+		self.assertEqual( set( u ), set( [ "b", "d", "e" ] ) )
+
+		# test traversing upstream
+
+		u = [ x.node().relativeName( script ) for x in g.connectedNodeGadgets( script["c"], direction = Gaffer.Plug.Direction.In ) ]
+		self.assertEqual( set( u ), set( [ "a", "b" ] ) )
+
+		u = [ x.node().relativeName( script ) for x in g.connectedNodeGadgets( script["c"], direction = Gaffer.Plug.Direction.In, degreesOfSeparation = 1 ) ]
+		self.assertEqual( set( u ), set( [ "b" ] ) )
+
+		# test traversing downstream
+
+		u = [ x.node().relativeName( script ) for x in g.connectedNodeGadgets( script["c"], direction = Gaffer.Plug.Direction.Out ) ]
+		self.assertEqual( set( u ), set( [ "d", "e", "f" ] ) )
+
+		u = [ x.node().relativeName( script ) for x in g.connectedNodeGadgets( script["c"], direction = Gaffer.Plug.Direction.Out, degreesOfSeparation = 1 ) ]
+		self.assertEqual( set( u ), set( [ "d", "e" ] ) )
+
+		# test that invisible nodes are ignored
+
+		g.setFilter( Gaffer.StandardSet( [ script["f"], script["e"], script["c"] ] ) )
+
+		u = [ x.node().relativeName( script ) for x in g.connectedNodeGadgets( script["e"] ) ]
+		self.assertEqual( set( u ), set( [ "f", "c" ] ) )
+
+		u = [ x.node().relativeName( script ) for x in g.connectedNodeGadgets( script["e"], direction = Gaffer.Plug.Direction.In ) ]
+		self.assertEqual( set( u ), set( [ "c" ] ) )
+
+		u = [ x.node().relativeName( script ) for x in g.connectedNodeGadgets( script["e"], direction = Gaffer.Plug.Direction.Out ) ]
+		self.assertEqual( set( u ), set( [ "f" ] ) )
+
 	def testSelectionHighlighting( self ) :
 
 		script = Gaffer.ScriptNode()

--- a/python/GafferUITest/NodeGraphTest.py
+++ b/python/GafferUITest/NodeGraphTest.py
@@ -924,6 +924,13 @@ class NodeGraphTest( GafferUITest.TestCase ) :
 		self.assertEqual( len( u ), 5 )
 		self.assertEqual( set( u ), set( [ "a", "b", "d", "c", "e" ] ) )
 
+		# the degreesOfSeparation argument should limit the depth
+		# of the search.
+
+		u = [ x.node().relativeName( script ) for x in g.upstreamNodeGadgets( script["c"], degreesOfSeparation = 1 ) ]
+		self.assertEqual( len( u ), 2 )
+		self.assertEqual( set( u ), set( [ "b", "d" ] ) )
+
 		# filtered nodes should be ignored
 
 		g.setFilter( Gaffer.StandardSet( [ script["f"], script["e"], script["a"] ] ) )

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -833,11 +833,11 @@ bool GraphGadget::buttonPress( GadgetPtr gadget, const ButtonEvent &event )
 				backdrop->framed( affectedNodes );
 			}
 
-			if( event.modifiers & ButtonEvent::Alt )
+			if( ( event.modifiers & ButtonEvent::Alt ) || ( event.modifiers & ButtonEvent::Control ) )
 			{
-				std::vector<NodeGadget *> upstream;
-				upstreamNodeGadgets( node, upstream );
-				for( std::vector<NodeGadget *>::const_iterator it = upstream.begin(), eIt = upstream.end(); it != eIt; ++it )
+				std::vector<NodeGadget *> connected;
+				connectedNodeGadgets( node, connected, event.modifiers & ButtonEvent::Alt ? Gaffer::Plug::In : Gaffer::Plug::Out );
+				for( std::vector<NodeGadget *>::const_iterator it = connected.begin(), eIt = connected.end(); it != eIt; ++it )
 				{
 					affectedNodes.push_back( (*it)->node() );
 				}

--- a/src/GafferUIBindings/GraphGadgetBinding.cpp
+++ b/src/GafferUIBindings/GraphGadgetBinding.cpp
@@ -108,10 +108,10 @@ static list connectionGadgets2( GraphGadget &graphGadget, const Gaffer::Node *no
 	return l;
 }
 
-static list upstreamNodeGadgets( GraphGadget &graphGadget, const Gaffer::Node *node )
+static list upstreamNodeGadgets( GraphGadget &graphGadget, const Gaffer::Node *node, size_t degreesOfSeparation )
 {
 	std::vector<NodeGadget *> nodeGadgets;
-	graphGadget.upstreamNodeGadgets( node, nodeGadgets );
+	graphGadget.upstreamNodeGadgets( node, nodeGadgets, degreesOfSeparation );
 
 	boost::python::list l;
 	for( std::vector<NodeGadget *>::const_iterator it=nodeGadgets.begin(), eIt=nodeGadgets.end(); it!=eIt; ++it )
@@ -154,7 +154,7 @@ void GafferUIBindings::bindGraphGadget()
 		.def( "connectionGadget", &connectionGadget )
 		.def( "connectionGadgets", &connectionGadgets1, ( arg_( "plug" ), arg_( "excludedNodes" ) = object() ) )
 		.def( "connectionGadgets", &connectionGadgets2, ( arg_( "node" ), arg_( "excludedNodes" ) = object() ) )
-		.def( "upstreamNodeGadgets", &upstreamNodeGadgets )
+		.def( "upstreamNodeGadgets", &upstreamNodeGadgets, ( arg( "node" ), arg( "degreesOfSeparation" ) = Imath::limits<size_t>::max() ) )
 		.def( "setNodePosition", &GraphGadget::setNodePosition )
 		.def( "getNodePosition", &GraphGadget::getNodePosition )
 		.def( "setNodeInputConnectionsMinimised", &GraphGadget::setNodeInputConnectionsMinimised )

--- a/src/GafferUIBindings/GraphGadgetBinding.cpp
+++ b/src/GafferUIBindings/GraphGadgetBinding.cpp
@@ -121,6 +121,32 @@ static list upstreamNodeGadgets( GraphGadget &graphGadget, const Gaffer::Node *n
 	return l;
 }
 
+static list downstreamNodeGadgets( GraphGadget &graphGadget, const Gaffer::Node *node, size_t degreesOfSeparation )
+{
+	std::vector<NodeGadget *> nodeGadgets;
+	graphGadget.downstreamNodeGadgets( node, nodeGadgets, degreesOfSeparation );
+
+	boost::python::list l;
+	for( std::vector<NodeGadget *>::const_iterator it=nodeGadgets.begin(), eIt=nodeGadgets.end(); it!=eIt; ++it )
+	{
+		l.append( NodeGadgetPtr( *it ) );
+	}
+	return l;
+}
+
+static list connectedNodeGadgets( GraphGadget &graphGadget, const Gaffer::Node *node, Gaffer::Plug::Direction direction, size_t degreesOfSeparation )
+{
+	std::vector<NodeGadget *> nodeGadgets;
+	graphGadget.connectedNodeGadgets( node, nodeGadgets, direction, degreesOfSeparation );
+
+	boost::python::list l;
+	for( std::vector<NodeGadget *>::const_iterator it=nodeGadgets.begin(), eIt=nodeGadgets.end(); it!=eIt; ++it )
+	{
+		l.append( NodeGadgetPtr( *it ) );
+	}
+	return l;
+}
+
 static void setLayout( GraphGadget &g, GraphLayoutPtr l )
 {
 	return g.setLayout( l );
@@ -155,6 +181,8 @@ void GafferUIBindings::bindGraphGadget()
 		.def( "connectionGadgets", &connectionGadgets1, ( arg_( "plug" ), arg_( "excludedNodes" ) = object() ) )
 		.def( "connectionGadgets", &connectionGadgets2, ( arg_( "node" ), arg_( "excludedNodes" ) = object() ) )
 		.def( "upstreamNodeGadgets", &upstreamNodeGadgets, ( arg( "node" ), arg( "degreesOfSeparation" ) = Imath::limits<size_t>::max() ) )
+		.def( "downstreamNodeGadgets", &downstreamNodeGadgets, ( arg( "node" ), arg( "degreesOfSeparation" ) = Imath::limits<size_t>::max() ) )
+		.def( "connectedNodeGadgets", &connectedNodeGadgets, ( arg( "node" ), arg( "direction" ) = Gaffer::Plug::Invalid, arg( "degreesOfSeparation" ) = Imath::limits<size_t>::max() ) )
 		.def( "setNodePosition", &GraphGadget::setNodePosition )
 		.def( "getNodePosition", &GraphGadget::getNodePosition )
 		.def( "setNodeInputConnectionsMinimised", &GraphGadget::setNodeInputConnectionsMinimised )


### PR DESCRIPTION
This primarily addresses #1207, stopping "Edit/Select All" from selecting hidden nodes. But it also adds to the GraphGadget API for improving the querying of visible node connections, fixes the "Edit/SelectConnected" menu items to ignore invisible nodes, and adds a bunch of extra useful connection selection items.