### PR TITLE
Filter improvements

### DIFF
--- a/include/GafferScene/Filter.h
+++ b/include/GafferScene/Filter.h
@@ -72,6 +72,11 @@ class Filter : public Gaffer::ComputeNode
 		virtual Gaffer::BoolPlug *enabledPlug();
 		virtual const Gaffer::BoolPlug *enabledPlug() const;
 
+		Gaffer::IntPlug *outPlug();
+		const Gaffer::IntPlug *outPlug() const;
+
+		/// \deprecated Use outPlug() instead - it returns the
+		/// same thing.
 		Gaffer::IntPlug *matchPlug();
 		const Gaffer::IntPlug *matchPlug() const;
 

--- a/include/GafferScene/Filter.h
+++ b/include/GafferScene/Filter.h
@@ -69,9 +69,13 @@ class Filter : public Gaffer::ComputeNode
 		Filter( const std::string &name=defaultName<Filter>() );
 		virtual ~Filter();
 
+		virtual Gaffer::BoolPlug *enabledPlug();
+		virtual const Gaffer::BoolPlug *enabledPlug() const;
+
 		Gaffer::IntPlug *matchPlug();
 		const Gaffer::IntPlug *matchPlug() const;
 
+		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
 		virtual bool sceneAffectsMatch( const ScenePlug *scene, const Gaffer::ValuePlug *child ) const;
 
 		/// Because a single filter may be used with many different input scenes,

--- a/include/GafferScene/Filter.h
+++ b/include/GafferScene/Filter.h
@@ -94,9 +94,9 @@ class Filter : public Gaffer::ComputeNode
 
 	protected :
 
-		/// Implemented to call hashMatch() below when computing the hash for matchPlug().
+		/// Implemented to call hashMatch() below when computing the hash for outPlug().
 		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		/// Implemented to call computeMatch() below when computing the value of matchPlug().
+		/// Implemented to call computeMatch() below when computing the value of outPlug().
 		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
 
 		/// Must be implemented by derived classes.

--- a/include/GafferScene/FilterMixinBase.h
+++ b/include/GafferScene/FilterMixinBase.h
@@ -1,0 +1,71 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENE_FILTERMIXINBASE_H
+#define GAFFERSCENE_FILTERMIXINBASE_H
+
+#include "GafferScene/Filter.h"
+
+namespace GafferScene
+{
+
+/// See SceneMixinBase for details.
+class FilterMixinBase : public Filter
+{
+
+	public :
+
+		FilterMixinBase( const std::string &name=defaultName<FilterMixinBase>() );
+		virtual ~FilterMixinBase();
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::FilterMixinBase, FilterMixinBaseTypeId, Filter );
+
+		virtual bool sceneAffectsMatch( const ScenePlug *scene, const Gaffer::ValuePlug *child ) const;
+
+	private :
+
+		/// These stubs should never be called, because the mixed-in class should implement hash() and compute()
+		/// totally. If they are called, they throw to highlight the fact that something is amiss.
+		virtual void hashMatch( const ScenePlug *scene, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		virtual unsigned computeMatch( const ScenePlug *scene, const Gaffer::Context *context ) const;
+
+};
+
+IE_CORE_DECLAREPTR( FilterMixinBase )
+
+} // namespace GafferScene
+
+#endif // GAFFERSCENE_FILTERMIXINBASE_H

--- a/include/GafferScene/FilterSwitch.h
+++ b/include/GafferScene/FilterSwitch.h
@@ -1,0 +1,52 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFER_FILTERSWITCH_H
+#define GAFFER_FILTERSWITCH_H
+
+#include "Gaffer/Switch.h"
+
+#include "GafferScene/FilterMixinBase.h"
+
+namespace GafferScene
+{
+
+typedef Gaffer::Switch<FilterMixinBase> FilterSwitch;
+IE_CORE_DECLAREPTR( FilterSwitch )
+
+} // namespace GafferScene
+
+#endif // GAFFER_FILTERSWITCH_H

--- a/include/GafferScene/SceneAlgo.h
+++ b/include/GafferScene/SceneAlgo.h
@@ -69,7 +69,7 @@ bool visible( const ScenePlug *scene, const ScenePlug::ScenePath &path );
 
 /// Finds all the paths in the scene that are matched by the filter, and adds them into the PathMatcher.
 void matchingPaths( const Filter *filter, const ScenePlug *scene, PathMatcher &paths );
-/// As above, but specifying the filter as a plug - typically Filter::matchPlug() or
+/// As above, but specifying the filter as a plug - typically Filter::outPlug() or
 /// FilteredSceneProcessor::filterPlug() would be passed.
 void matchingPaths( const Gaffer::IntPlug *filterPlug, const ScenePlug *scene, PathMatcher &paths );
 

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -119,6 +119,8 @@ enum TypeId
 	DeleteOutputsTypeId = 110574,
 	ExternalProceduralTypeId = 110575,
 	ScenePathTypeId = 110576,
+	FilterMixinBaseTypeId = 110577,
+	FilterSwitchTypeId = 110578,
 
 	LastTypeId = 110650
 };

--- a/include/GafferSceneBindings/FilterSwitchBinding.h
+++ b/include/GafferSceneBindings/FilterSwitchBinding.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENEBINDINGS_FILTERSWITCHBINDING_H
+#define GAFFERSCENEBINDINGS_FILTERSWITCHBINDING_H
+
+namespace GafferSceneBindings
+{
+
+void bindFilterSwitch();
+
+} // namespace GafferSceneBindings
+
+#endif // GAFFERSCENEBINDINGS_FILTERSWITCHBINDING_H

--- a/python/GafferOSLTest/OSLObjectTest.py
+++ b/python/GafferOSLTest/OSLObjectTest.py
@@ -86,7 +86,7 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 		filter = GafferScene.PathFilter()
 		filter["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
 
-		o["filter"].setInput( filter["match"] )
+		o["filter"].setInput( filter["out"] )
 
 		self.assertSceneValid( o["out"] )
 
@@ -151,7 +151,7 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 		o = GafferOSL.OSLObject()
 		o["in"].setInput( p["out"] )
 		o["shader"].setInput( primVarShader["out"] )
-		o["filter"].setInput( filter["match"] )
+		o["filter"].setInput( filter["out"] )
 
 		for v in o["out"].object( "/plane" )["velocity"].data :
 			self.assertEqual( v, IECore.V3f( 0 ) )

--- a/python/GafferRenderManTest/InteractiveRenderManRenderTest.py
+++ b/python/GafferRenderManTest/InteractiveRenderManRenderTest.py
@@ -324,7 +324,7 @@ class InteractiveRenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 		s["a"] = GafferScene.ShaderAssignment()
 		s["a"]["in"].setInput( s["g"]["out"] )
 		s["a"]["shader"].setInput( s["s"]["out"] )
-		s["a"]["filter"].setInput( s["f"]["match"] )
+		s["a"]["filter"].setInput( s["f"]["out"] )
 
 		s["d"] = GafferScene.Outputs()
 		s["d"].addOutput(

--- a/python/GafferRenderManTest/RenderManRenderTest.py
+++ b/python/GafferRenderManTest/RenderManRenderTest.py
@@ -560,13 +560,13 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 		s["a1"]["attributes"]["visibility"]["enabled"].setValue( True )
 		s["a1"]["attributes"]["visibility"]["value"].setValue( False )
 		s["a1"]["in"].setInput( s["g"]["out"] )
-		s["a1"]["filter"].setInput( s["f1"]["match"] )
+		s["a1"]["filter"].setInput( s["f1"]["out"] )
 
 		s["a2"] = GafferScene.StandardAttributes()
 		s["a2"]["attributes"]["visibility"]["enabled"].setValue( True )
 		s["a2"]["attributes"]["visibility"]["value"].setValue( True )
 		s["a2"]["in"].setInput( s["a1"]["out"] )
-		s["a2"]["filter"].setInput( s["f2"]["match"] )
+		s["a2"]["filter"].setInput( s["f2"]["out"] )
 
 		s["r"] = GafferRenderMan.RenderManRender()
 		s["r"]["mode"].setValue( "generate" )
@@ -608,13 +608,13 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 		s["a1"]["attributes"]["visibility"]["enabled"].setValue( True )
 		s["a1"]["attributes"]["visibility"]["value"].setValue( False )
 		s["a1"]["in"].setInput( s["g"]["out"] )
-		s["a1"]["filter"].setInput( s["f1"]["match"] )
+		s["a1"]["filter"].setInput( s["f1"]["out"] )
 
 		s["a2"] = GafferScene.StandardAttributes()
 		s["a2"]["attributes"]["visibility"]["enabled"].setValue( True )
 		s["a2"]["attributes"]["visibility"]["value"].setValue( True )
 		s["a2"]["in"].setInput( s["a1"]["out"] )
-		s["a2"]["filter"].setInput( s["f2"]["match"] )
+		s["a2"]["filter"].setInput( s["f2"]["out"] )
 
 		s["r"] = GafferRenderMan.RenderManRender()
 		s["r"]["mode"].setValue( "generate" )

--- a/python/GafferSceneTest/AimConstraintTest.py
+++ b/python/GafferSceneTest/AimConstraintTest.py
@@ -70,7 +70,7 @@ class AimConstraintTest( GafferSceneTest.SceneTestCase ) :
 
 		filter = GafferScene.PathFilter()
 		filter["paths"].setValue( IECore.StringVectorData( [ "/group/constrained" ] ) )
-		aim["filter"].setInput( filter["match"] )
+		aim["filter"].setInput( filter["out"] )
 
 		self.assertSceneValid( aim["out"] )
 
@@ -106,7 +106,7 @@ class AimConstraintTest( GafferSceneTest.SceneTestCase ) :
 
 		filter = GafferScene.PathFilter()
 		filter["paths"].setValue( IECore.StringVectorData( [ "/group/constrained" ] ) )
-		aim["filter"].setInput( filter["match"] )
+		aim["filter"].setInput( filter["out"] )
 
 		self.assertSceneValid( aim["out"] )
 
@@ -141,7 +141,7 @@ class AimConstraintTest( GafferSceneTest.SceneTestCase ) :
 
 		filter = GafferScene.PathFilter()
 		filter["paths"].setValue( IECore.StringVectorData( [ "/group/constrained" ] ) )
-		aim["filter"].setInput( filter["match"] )
+		aim["filter"].setInput( filter["out"] )
 
 		self.assertSceneValid( aim["out"] )
 
@@ -189,7 +189,7 @@ class AimConstraintTest( GafferSceneTest.SceneTestCase ) :
 
 		filter = GafferScene.PathFilter()
 		filter["paths"].setValue( IECore.StringVectorData( [ "/group/constrained" ] ) )
-		aim["filter"].setInput( filter["match"] )
+		aim["filter"].setInput( filter["out"] )
 
 		self.assertSceneValid( aim["out"] )
 

--- a/python/GafferSceneTest/CustomAttributesTest.py
+++ b/python/GafferSceneTest/CustomAttributesTest.py
@@ -85,7 +85,7 @@ class CustomAttributesTest( GafferSceneTest.SceneTestCase ) :
 		# finally once we've applied a filter, we should get some attributes.
 		f = GafferScene.PathFilter()
 		f["paths"].setValue( IECore.StringVectorData( [ "/ball1" ] ) )
-		a["filter"].setInput( f["match"] )
+		a["filter"].setInput( f["out"] )
 
 		self.assertEqual( a["out"].attributes( "/" ), IECore.CompoundObject() )
 		self.assertEqual( a["out"].attributes( "/ball1" ), IECore.CompoundObject( { "ri:shadingRate" : IECore.FloatData( 0.25 ) } ) )
@@ -215,7 +215,7 @@ class CustomAttributesTest( GafferSceneTest.SceneTestCase ) :
 		# when we add a filter, non-matching objects should become pass-throughs
 		f = GafferScene.PathFilter()
 		f["paths"].setValue( IECore.StringVectorData( [ "/ball1" ] ) )
-		a["filter"].setInput( f["match"] )
+		a["filter"].setInput( f["out"] )
 		self.assertSceneHashesEqual( input["out"], a["out"], pathsToIgnore = ( "/ball1", ) )
 
 		c = Gaffer.Context()
@@ -274,7 +274,7 @@ class CustomAttributesTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertTrue( "user:test" in s["a"]["out"].attributes( "/plane" ) )
 
-		s["a"]["filter"].setInput( s["f"]["match"] )
+		s["a"]["filter"].setInput( s["f"]["out"] )
 		self.assertFalse( "user:test" in s["a"]["out"].attributes( "/plane" ) )
 
 		s["a"]["filter"].setInput( None )
@@ -291,7 +291,7 @@ class CustomAttributesTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertTrue( "user:test" in s["a"]["out"].attributes( "/plane" ) )
 
-		s["a"]["filter"].setInput( s["f"]["match"] )
+		s["a"]["filter"].setInput( s["f"]["out"] )
 
 		self.assertFalse( "user:test" in s["a"]["out"].attributes( "/plane" ) )
 

--- a/python/GafferSceneTest/FilterSwitchTest.py
+++ b/python/GafferSceneTest/FilterSwitchTest.py
@@ -1,0 +1,148 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferTest
+import GafferScene
+import GafferSceneTest
+
+class FilterSwitchTest( GafferSceneTest.SceneTestCase ) :
+
+	def testConstruct( self ) :
+
+		f = GafferScene.FilterSwitch()
+		self.assertEqual( f.getName(), "FilterSwitch" )
+
+	def testSwitch( self ) :
+
+		# Build a scene with a sphere, a plane, and
+		# a filter switch controlling an attribute
+		# assignment. Index 0 should assign to the
+		# plane and index 1 should assign to the
+		# sphere.
+
+		script = Gaffer.ScriptNode()
+
+		script["plane"] = GafferScene.Plane()
+		script["sphere"] = GafferScene.Sphere()
+		script["group"] = GafferScene.Group()
+		script["group"]["in"].setInput( script["plane"]["out"] )
+		script["group"]["in1"].setInput( script["sphere"]["out"] )
+
+		script["planeSet"] = GafferScene.Set()
+		script["planeSet"]["paths"].setValue( IECore.StringVectorData( [ "/group/plane" ] ) )
+		script["planeSet"]["in"].setInput( script["group"]["out"] )
+
+		script["attributes"] = GafferScene.StandardAttributes()
+		script["attributes"]["attributes"]["visibility"]["enabled"].setValue( True )
+		script["attributes"]["in"].setInput( script["planeSet"]["out"] )
+
+		script["setFilter"] = GafferScene.SetFilter()
+		script["setFilter"]["set"].setValue( "set" )
+
+		script["pathFilter"] = GafferScene.PathFilter()
+		script["pathFilter"]["paths"].setValue( IECore.StringVectorData( [ "/group/sphere" ] ) )
+
+		script["switchFilter"] = GafferScene.FilterSwitch()
+		script["switchFilter"]["in"].setInput( script["setFilter"]["out"] )
+		script["switchFilter"]["in1"].setInput( script["pathFilter"]["out"] )
+
+		script["attributes"]["filter"].setInput( script["switchFilter"]["out"] )
+
+		# Check that we get the assignments we expect for each index.
+
+		self.assertEqual( len( script["attributes"]["out"].attributes( "/group/plane" ) ), 1 )
+		self.assertEqual( len( script["attributes"]["out"].attributes( "/group/sphere" ) ), 0 )
+
+		script["switchFilter"]["index"].setValue( 1 )
+
+		self.assertEqual( len( script["attributes"]["out"].attributes( "/group/plane" ) ), 0 )
+		self.assertEqual( len( script["attributes"]["out"].attributes( "/group/sphere" ) ), 1 )
+
+		# Check that we get dirtiness signalled when changing the
+		# index.
+
+		cs = GafferTest.CapturingSlot( script["attributes"].plugDirtiedSignal() )
+		self.assertEqual( len( cs ), 0 )
+
+		script["switchFilter"]["index"].setValue( 0 )
+		self.assertTrue( script["attributes"]["out"] in [ c[0] for c in cs ] )
+
+		# Check that we get dirtiness signalled for the attributes
+		# when changing the set used by the set filter.
+
+		del cs[:]
+		script["planeSet"]["paths"].setValue( IECore.StringVectorData( [ "/group", "/group/plane" ] ) )
+		self.assertTrue( script["attributes"]["out"]["attributes"] in [ c[0] for c in cs ] )
+
+		# But also check that we don't get it signalled unnecessarily when
+		# the set filter isn't the current index.
+
+		script["switchFilter"]["index"].setValue( 1 )
+		del cs[:]
+		script["planeSet"]["paths"].setValue( IECore.StringVectorData( [ "/group/plane" ] ) )
+		self.assertFalse( script["attributes"]["out"]["attributes"] in [ c[0] for c in cs ] )
+
+		# Now check that we can use expressions successfully on the index.
+
+		script["expression"] = Gaffer.Expression()
+		script["expression"]["engine"].setValue( "python" )
+		script["expression"]["expression"].setValue( 'parent["switchFilter"]["index"] = int( context.getFrame() )' )
+
+		with script.context() :
+
+			script.context().setFrame( 0 )
+			self.assertEqual( len( script["attributes"]["out"].attributes( "/group/plane" ) ), 1 )
+			self.assertEqual( len( script["attributes"]["out"].attributes( "/group/sphere" ) ), 0 )
+
+			script.context().setFrame( 1 )
+			self.assertEqual( len( script["attributes"]["out"].attributes( "/group/plane" ) ), 0 )
+			self.assertEqual( len( script["attributes"]["out"].attributes( "/group/sphere" ) ), 1 )
+
+		# Now we have an expression based on the context, changing the upstream set should
+		# always signal dirtiness for the attributes, because we don't know which index
+		# the switch will use until we actually compute.
+
+		del cs[:]
+		script["planeSet"]["paths"].setValue( IECore.StringVectorData( [ "/group", "/group/plane" ] ) )
+		self.assertTrue( script["attributes"]["out"]["attributes"] in [ c[0] for c in cs ] )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneTest/FreezeTransformTest.py
+++ b/python/GafferSceneTest/FreezeTransformTest.py
@@ -76,7 +76,7 @@ class FreezeTransformTest( GafferSceneTest.SceneTestCase ) :
 
 		t = GafferScene.FreezeTransform()
 		t["in"].setInput( g["out"] )
-		t["filter"].setInput( f["match"] )
+		t["filter"].setInput( f["out"] )
 
 		self.assertSceneValid( t["out"] )
 

--- a/python/GafferSceneTest/IsolateTest.py
+++ b/python/GafferSceneTest/IsolateTest.py
@@ -98,7 +98,7 @@ class IsolateTest( GafferSceneTest.SceneTestCase ) :
 
 		filter = GafferScene.PathFilter()
 		filter["paths"].setValue( IECore.StringVectorData( [ "/*" ] ) )
-		isolate["filter"].setInput( filter["match"] )
+		isolate["filter"].setInput( filter["out"] )
 
 		isolate["enabled"].setValue( False )
 
@@ -149,7 +149,7 @@ class IsolateTest( GafferSceneTest.SceneTestCase ) :
 
 		filter = GafferScene.PathFilter()
 		filter["paths"].setValue( IECore.StringVectorData( [ "/groupA/sphereAB" ] ) )
-		isolate["filter"].setInput( filter["match"] )
+		isolate["filter"].setInput( filter["out"] )
 
 		self.assertNotEqual( isolate["out"].childNamesHash( "/groupA" ), input["out"].childNamesHash( "/groupA" ) )
 		self.assertEqual( isolate["out"].childNames( "/groupA" ), IECore.InternedStringVectorData( [ "sphereAB" ] ) )
@@ -191,7 +191,7 @@ class IsolateTest( GafferSceneTest.SceneTestCase ) :
 
 		filter = GafferScene.PathFilter()
 		filter["paths"].setValue( IECore.StringVectorData( [ "/group/sphere1" ] ) )
-		isolate["filter"].setInput( filter["match"] )
+		isolate["filter"].setInput( filter["out"] )
 
 		self.assertEqual( isolate["out"].bound( "/" ), sphere2.bound() )
 		self.assertEqual( isolate["out"].bound( "/group" ), sphere2.bound() )
@@ -222,7 +222,7 @@ class IsolateTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( set( lightSet.value.paths() ), set( [ "/group/light", "/group/light1" ] ) )
 
 		filter = GafferScene.PathFilter()
-		isolate["filter"].setInput( filter["match"] )
+		isolate["filter"].setInput( filter["out"] )
 
 		lightSet = isolate["out"]["globals"].getValue()["gaffer:sets"]["__lights"]
 		self.assertEqual( set( lightSet.value.paths() ), set( [] ) )
@@ -244,7 +244,7 @@ class IsolateTest( GafferSceneTest.SceneTestCase ) :
 
 		isolate = GafferScene.Isolate()
 		isolate["in"].setInput( grid["out"] )
-		isolate["filter"].setInput( pathFilter["match"] )
+		isolate["filter"].setInput( pathFilter["out"] )
 
 		c = Gaffer.Context()
 		with c :
@@ -301,7 +301,7 @@ class IsolateTest( GafferSceneTest.SceneTestCase ) :
 		filter = GafferScene.PathFilter()
 		filter["paths"].setValue( IECore.StringVectorData( [ "/group1/group2/light1" ] ) )
 
-		isolate["filter"].setInput( filter["match"] )
+		isolate["filter"].setInput( filter["out"] )
 
 		self.assertSceneValid( isolate["out"] )
 		self.assertEqual( isolate["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "group1" ] ) )

--- a/python/GafferSceneTest/ParentConstraintTest.py
+++ b/python/GafferSceneTest/ParentConstraintTest.py
@@ -68,7 +68,7 @@ class ParentConstraintTest( GafferSceneTest.SceneTestCase ) :
 
 		filter = GafferScene.PathFilter()
 		filter["paths"].setValue( IECore.StringVectorData( [ "/group/constrained" ] ) )
-		constraint["filter"].setInput( filter["match"] )
+		constraint["filter"].setInput( filter["out"] )
 
 		self.assertSceneValid( constraint["out"] )
 
@@ -97,7 +97,7 @@ class ParentConstraintTest( GafferSceneTest.SceneTestCase ) :
 
 		filter = GafferScene.PathFilter()
 		filter["paths"].setValue( IECore.StringVectorData( [ "/group/constrained" ] ) )
-		constraint["filter"].setInput( filter["match"] )
+		constraint["filter"].setInput( filter["out"] )
 
 		self.assertSceneValid( constraint["out"] )
 
@@ -118,7 +118,7 @@ class ParentConstraintTest( GafferSceneTest.SceneTestCase ) :
 
 		filter = GafferScene.PathFilter()
 		filter["paths"].setValue( IECore.StringVectorData( [ "/group/constrained" ] ) )
-		constraint["filter"].setInput( filter["match"] )
+		constraint["filter"].setInput( filter["out"] )
 
 		cs = GafferTest.CapturingSlot( constraint.plugDirtiedSignal() )
 

--- a/python/GafferSceneTest/PathFilterTest.py
+++ b/python/GafferSceneTest/PathFilterTest.py
@@ -55,7 +55,7 @@ class PathFilterTest( unittest.TestCase ) :
 		f = GafferScene.PathFilter()
 		cs = GafferTest.CapturingSlot( f.plugDirtiedSignal() )
 		f["paths"].setValue( IECore.StringVectorData( [ "/a" ] ) )
-		self.assertTrue( "match" in [ x[0].getName() for x in cs ] )
+		self.assertTrue( f["match"] in [ x[0] for x in cs ] )
 
 	def testMatch( self ) :
 

--- a/python/GafferSceneTest/PathFilterTest.py
+++ b/python/GafferSceneTest/PathFilterTest.py
@@ -186,5 +186,27 @@ class PathFilterTest( unittest.TestCase ) :
 			c["passName"] = "foreground"
 			self.assertEqual( s["f"]["match"].getValue(), GafferScene.Filter.Result.ExactMatch )
 
+	def testEnabled( self ) :
+
+		f = GafferScene.PathFilter()
+		self.assertTrue( f.enabledPlug().isSame( f["enabled"] ) )
+		self.assertTrue( isinstance( f.enabledPlug(), Gaffer.BoolPlug ) )
+		self.assertEqual( f.enabledPlug().defaultValue(), True )
+		self.assertEqual( f.enabledPlug().getValue(), True )
+		self.assertEqual( f.correspondingInput( f["match"] ), None )
+
+		f["paths"].setValue( IECore.StringVectorData( [ "/a" ] ) )
+
+		with Gaffer.Context() as c :
+
+			c["scene:path"] = IECore.InternedStringVectorData( [ "a" ] )
+			self.assertEqual( f["match"].getValue(), GafferScene.Filter.Result.ExactMatch )
+
+			f["enabled"].setValue( False )
+			self.assertEqual( f["match"].getValue(), GafferScene.Filter.Result.NoMatch )
+
+		a = f.affects( f["enabled"] )
+		self.assertTrue( f["match"] in a )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/PathFilterTest.py
+++ b/python/GafferSceneTest/PathFilterTest.py
@@ -55,7 +55,7 @@ class PathFilterTest( unittest.TestCase ) :
 		f = GafferScene.PathFilter()
 		cs = GafferTest.CapturingSlot( f.plugDirtiedSignal() )
 		f["paths"].setValue( IECore.StringVectorData( [ "/a" ] ) )
-		self.assertTrue( f["match"] in [ x[0] for x in cs ] )
+		self.assertTrue( f["out"] in [ x[0] for x in cs ] )
 
 	def testMatch( self ) :
 
@@ -76,14 +76,14 @@ class PathFilterTest( unittest.TestCase ) :
 
 			with Gaffer.Context() as c :
 				c["scene:path"] = IECore.InternedStringVectorData( path[1:].split( "/" ) )
-				self.assertEqual( f["match"].getValue(), int( result ) )
+				self.assertEqual( f["out"].getValue(), int( result ) )
 
 	def testNullPaths( self ) :
 
 		f = GafferScene.PathFilter()
 		with Gaffer.Context() as c :
 			c["scene:path"] = IECore.InternedStringVectorData( [ "a" ] )
-			self.assertEqual( f["match"].getValue(), int( f.Result.NoMatch ) )
+			self.assertEqual( f["out"].getValue(), int( f.Result.NoMatch ) )
 
 	def testScaling( self ) :
 
@@ -98,7 +98,7 @@ class PathFilterTest( unittest.TestCase ) :
 		with Gaffer.Context() as c :
 			for path in paths :
 				c["scene:path"] = path
-				self.assertTrue( f["match"].getValue() & f.Result.ExactMatch )
+				self.assertTrue( f["out"].getValue() & f.Result.ExactMatch )
 
 	def testInputsAccepted( self ) :
 
@@ -117,7 +117,7 @@ class PathFilterTest( unittest.TestCase ) :
 		s["a"]["in"].setInput( s["p"]["out"] )
 
 		s["f"] = GafferScene.PathFilter()
-		s["a"]["filter"].setInput( s["f"]["match"] )
+		s["a"]["filter"].setInput( s["f"]["out"] )
 
 		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["a"] ] ) )
 
@@ -127,7 +127,7 @@ class PathFilterTest( unittest.TestCase ) :
 
 		s["f"] = GafferScene.PathFilter()
 		s["a"] = GafferScene.Attributes()
-		s["a"]["filter"].setInput( s["f"]["match"] )
+		s["a"]["filter"].setInput( s["f"]["out"] )
 
 		ss = s.serialise( s, Gaffer.StandardSet( [ s["a"] ] ) )
 
@@ -160,7 +160,7 @@ class PathFilterTest( unittest.TestCase ) :
 
 			with Gaffer.Context() as c :
 				c["scene:path"] = IECore.InternedStringVectorData( path[1:].split( "/" ) )
-				self.assertEqual( b["f"]["match"].getValue(), int( result ) )
+				self.assertEqual( b["f"]["out"].getValue(), int( result ) )
 
 	def testPathPlugExpression( self ) :
 
@@ -182,9 +182,9 @@ class PathFilterTest( unittest.TestCase ) :
 
 		with Gaffer.Context() as c :
 			c["scene:path"] = IECore.InternedStringVectorData( [ "a" ])
-			self.assertEqual( s["f"]["match"].getValue(), GafferScene.Filter.Result.NoMatch )
+			self.assertEqual( s["f"]["out"].getValue(), GafferScene.Filter.Result.NoMatch )
 			c["passName"] = "foreground"
-			self.assertEqual( s["f"]["match"].getValue(), GafferScene.Filter.Result.ExactMatch )
+			self.assertEqual( s["f"]["out"].getValue(), GafferScene.Filter.Result.ExactMatch )
 
 	def testEnabled( self ) :
 
@@ -193,20 +193,20 @@ class PathFilterTest( unittest.TestCase ) :
 		self.assertTrue( isinstance( f.enabledPlug(), Gaffer.BoolPlug ) )
 		self.assertEqual( f.enabledPlug().defaultValue(), True )
 		self.assertEqual( f.enabledPlug().getValue(), True )
-		self.assertEqual( f.correspondingInput( f["match"] ), None )
+		self.assertEqual( f.correspondingInput( f["out"] ), None )
 
 		f["paths"].setValue( IECore.StringVectorData( [ "/a" ] ) )
 
 		with Gaffer.Context() as c :
 
 			c["scene:path"] = IECore.InternedStringVectorData( [ "a" ] )
-			self.assertEqual( f["match"].getValue(), GafferScene.Filter.Result.ExactMatch )
+			self.assertEqual( f["out"].getValue(), GafferScene.Filter.Result.ExactMatch )
 
 			f["enabled"].setValue( False )
-			self.assertEqual( f["match"].getValue(), GafferScene.Filter.Result.NoMatch )
+			self.assertEqual( f["out"].getValue(), GafferScene.Filter.Result.NoMatch )
 
 		a = f.affects( f["enabled"] )
-		self.assertTrue( f["match"] in a )
+		self.assertTrue( f["out"] in a )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/PathMatcherTest.py
+++ b/python/GafferSceneTest/PathMatcherTest.py
@@ -170,7 +170,7 @@ class PathMatcherTest( unittest.TestCase ) :
 			c = Gaffer.Context()
 			c["scene:path"] = IECore.InternedStringVectorData( path[1:].split( "/" ) )
 			with c :
-				self.assertEqual( f["match"].getValue(), int( result ) )
+				self.assertEqual( f["out"].getValue(), int( result ) )
 
 	def testWildcardsWithSiblings( self ) :
 
@@ -190,7 +190,7 @@ class PathMatcherTest( unittest.TestCase ) :
 			c = Gaffer.Context()
 			c["scene:path"] = IECore.InternedStringVectorData( path[1:].split( "/" ) )
 			with c :
-				self.assertEqual( f["match"].getValue(), int( result ) )
+				self.assertEqual( f["out"].getValue(), int( result ) )
 
 	def testRepeatedWildcards( self ) :
 
@@ -204,7 +204,7 @@ class PathMatcherTest( unittest.TestCase ) :
 		c = Gaffer.Context()
 		c["scene:path"] = IECore.InternedStringVectorData( [ "a", "s" ] )
 		with c :
-			self.assertEqual( f["match"].getValue(), int( GafferScene.Filter.Result.ExactMatch ) )
+			self.assertEqual( f["out"].getValue(), int( GafferScene.Filter.Result.ExactMatch ) )
 
 	def testEllipsis( self ) :
 
@@ -233,7 +233,7 @@ class PathMatcherTest( unittest.TestCase ) :
 			c = Gaffer.Context()
 			c["scene:path"] = IECore.InternedStringVectorData( path[1:].split( "/" ) )
 			with c :
-				self.assertEqual( f["match"].getValue(), int( result ) )
+				self.assertEqual( f["out"].getValue(), int( result ) )
 
 	def testEllipsisWithMultipleBranches( self ) :
 
@@ -262,7 +262,7 @@ class PathMatcherTest( unittest.TestCase ) :
 			c = Gaffer.Context()
 			c["scene:path"] = IECore.InternedStringVectorData( path[1:].split( "/" ) )
 			with c :
-				self.assertEqual( f["match"].getValue(), int( result ) )
+				self.assertEqual( f["out"].getValue(), int( result ) )
 
 	def testEllipsisAsTerminator( self ) :
 
@@ -284,7 +284,7 @@ class PathMatcherTest( unittest.TestCase ) :
 			c = Gaffer.Context()
 			c["scene:path"] = IECore.InternedStringVectorData( path[1:].split( "/" ) )
 			with c :
-				self.assertEqual( f["match"].getValue(), int( result ) )
+				self.assertEqual( f["out"].getValue(), int( result ) )
 
 	def testCopyConstructorIsDeep( self ) :
 

--- a/python/GafferSceneTest/PointConstraintTest.py
+++ b/python/GafferSceneTest/PointConstraintTest.py
@@ -76,7 +76,7 @@ class PointConstraintTest( GafferSceneTest.SceneTestCase ) :
 
 		filter = GafferScene.PathFilter()
 		filter["paths"].setValue( IECore.StringVectorData( [ "/group/constrained" ] ) )
-		constraint["filter"].setInput( filter["match"] )
+		constraint["filter"].setInput( filter["out"] )
 
 		self.assertSceneValid( constraint["out"] )
 

--- a/python/GafferSceneTest/PruneTest.py
+++ b/python/GafferSceneTest/PruneTest.py
@@ -98,7 +98,7 @@ class PruneTest( GafferSceneTest.SceneTestCase ) :
 
 		filter = GafferScene.PathFilter()
 		filter["paths"].setValue( IECore.StringVectorData( [ "/*" ] ) )
-		prune["filter"].setInput( filter["match"] )
+		prune["filter"].setInput( filter["out"] )
 
 		prune["enabled"].setValue( False )
 
@@ -149,7 +149,7 @@ class PruneTest( GafferSceneTest.SceneTestCase ) :
 
 		filter = GafferScene.PathFilter()
 		filter["paths"].setValue( IECore.StringVectorData( [ "/groupA/sphereAB" ] ) )
-		prune["filter"].setInput( filter["match"] )
+		prune["filter"].setInput( filter["out"] )
 
 		self.assertNotEqual( prune["out"].childNamesHash( "/groupA" ), input["out"].childNamesHash( "/groupA" ) )
 		self.assertEqual( prune["out"].childNames( "/groupA" ), IECore.InternedStringVectorData( [ "sphereAA" ] ) )
@@ -188,7 +188,7 @@ class PruneTest( GafferSceneTest.SceneTestCase ) :
 
 		filter = GafferScene.PathFilter()
 		filter["paths"].setValue( IECore.StringVectorData( [ "/group/sphere2" ] ) )
-		prune["filter"].setInput( filter["match"] )
+		prune["filter"].setInput( filter["out"] )
 
 		self.assertEqual( prune["out"].bound( "/" ), sphere2.bound() )
 		self.assertEqual( prune["out"].bound( "/group" ), sphere2.bound() )
@@ -219,7 +219,7 @@ class PruneTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( set( lightSet.value.paths() ), set( [ "/group/light", "/group/light1" ] ) )
 
 		filter = GafferScene.PathFilter()
-		prune["filter"].setInput( filter["match"] )
+		prune["filter"].setInput( filter["out"] )
 
 		lightSet = prune["out"]["globals"].getValue()["gaffer:sets"]["__lights"]
 		self.assertEqual( set( lightSet.value.paths() ), set( [ "/group/light", "/group/light1" ] ) )
@@ -255,7 +255,7 @@ class PruneTest( GafferSceneTest.SceneTestCase ) :
 
 		prune = GafferScene.Prune()
 		prune["in"].setInput( topGroup["out"] )
-		prune["filter"].setInput( filter["match"] )
+		prune["filter"].setInput( filter["out"] )
 
 		lightSet = prune["out"]["globals"].getValue()["gaffer:sets"]["__lights"]
 		self.assertEqual( set( lightSet.value.paths() ), set( [ "/group/group1/light" ] ) )
@@ -278,7 +278,7 @@ class PruneTest( GafferSceneTest.SceneTestCase ) :
 
 		prune = GafferScene.Prune()
 		prune["in"].setInput( grid["out"] )
-		prune["filter"].setInput( pathFilter["match"] )
+		prune["filter"].setInput( pathFilter["out"] )
 
 		c = Gaffer.Context()
 		with c :

--- a/python/GafferSceneTest/SceneAlgoTest.py
+++ b/python/GafferSceneTest/SceneAlgoTest.py
@@ -102,7 +102,7 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 		attributes1["attributes"]["visibility"]["enabled"].setValue( True )
 		attributes1["attributes"]["visibility"]["value"].setValue( True )
 		attributes1["in"].setInput( group2["out"] )
-		attributes1["filter"].setInput( visibleFilter["match"] )
+		attributes1["filter"].setInput( visibleFilter["out"] )
 
 		invisibleFilter = GafferScene.PathFilter()
 
@@ -110,7 +110,7 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 		attributes2["attributes"]["visibility"]["enabled"].setValue( True )
 		attributes2["attributes"]["visibility"]["value"].setValue( False )
 		attributes2["in"].setInput( attributes1["out"] )
-		attributes2["filter"].setInput( invisibleFilter["match"] )
+		attributes2["filter"].setInput( invisibleFilter["out"] )
 
 		self.assertTrue( GafferScene.visible( attributes2["out"], "/group/group/sphere" ) )
 		self.assertTrue( GafferScene.visible( attributes2["out"], "/group/group" ) )

--- a/python/GafferSceneTest/SetFilterTest.py
+++ b/python/GafferSceneTest/SetFilterTest.py
@@ -64,7 +64,7 @@ class SetFilterTest( GafferSceneTest.SceneTestCase ) :
 		a = GafferScene.StandardAttributes()
 		a["in"].setInput( s["out"] )
 		a["attributes"]["doubleSided"]["enabled"].setValue( True )
-		a["filter"].setInput( f["match"] )
+		a["filter"].setInput( f["out"] )
 
 		self.assertSceneValid( a["out"] )
 
@@ -108,7 +108,7 @@ class SetFilterTest( GafferSceneTest.SceneTestCase ) :
 		# attributes too.
 
 		f = GafferScene.SetFilter()
-		a["filter"].setInput( f["match"] )
+		a["filter"].setInput( f["out"] )
 
 		cs = GafferTest.CapturingSlot( a.plugDirtiedSignal() )
 
@@ -139,12 +139,12 @@ class SetFilterTest( GafferSceneTest.SceneTestCase ) :
 		a1 = GafferScene.StandardAttributes()
 		a1["in"].setInput( s1["out"] )
 		a1["attributes"]["doubleSided"]["enabled"].setValue( True )
-		a1["filter"].setInput( f["match"] )
+		a1["filter"].setInput( f["out"] )
 
 		a2 = GafferScene.StandardAttributes()
 		a2["in"].setInput( s2["out"] )
 		a2["attributes"]["doubleSided"]["enabled"].setValue( True )
-		a2["filter"].setInput( f["match"] )
+		a2["filter"].setInput( f["out"] )
 
 		self.assertSceneValid( a1["out"] )
 		self.assertSceneValid( a2["out"] )
@@ -178,7 +178,7 @@ class SetFilterTest( GafferSceneTest.SceneTestCase ) :
 
 		i = GafferScene.Isolate()
 		i["in"].setInput( s2["out"] )
-		i["filter"].setInput( f["match"] )
+		i["filter"].setInput( f["out"] )
 
 		self.assertSceneValid( i["out"] )
 		self.assertEqual( i["out"].childNames( "/group" ), IECore.InternedStringVectorData( [ "plane" ] ) )

--- a/python/GafferSceneTest/ShaderAssignmentTest.py
+++ b/python/GafferSceneTest/ShaderAssignmentTest.py
@@ -75,7 +75,7 @@ class ShaderAssignmentTest( unittest.TestCase ) :
 
 		f = GafferScene.PathFilter()
 		f["paths"].setValue( IECore.StringVectorData( [ "/ball1" ] ) )
-		a["filter"].setInput( f["match"] )
+		a["filter"].setInput( f["out"] )
 
 		self.assertEqual( a["out"].attributes( "/" ), IECore.CompoundObject() )
 		self.assertNotEqual( a["out"].attributes( "/ball1" ), IECore.CompoundObject() )
@@ -86,13 +86,13 @@ class ShaderAssignmentTest( unittest.TestCase ) :
 		a = GafferScene.ShaderAssignment()
 
 		f = GafferScene.PathFilter()
-		self.assertTrue( a["filter"].acceptsInput( f["match"] ) )
+		self.assertTrue( a["filter"].acceptsInput( f["out"] ) )
 
 		n = GafferTest.AddNode()
 		self.assertFalse( a["filter"].acceptsInput( n["sum"] ) )
 
 		p = Gaffer.IntPlug()
-		p.setInput( f["match"] )
+		p.setInput( f["out"] )
 
 		self.assertTrue( a["filter"].acceptsInput( p ) )
 

--- a/python/GafferSceneTest/StandardAttributesTest.py
+++ b/python/GafferSceneTest/StandardAttributesTest.py
@@ -90,7 +90,7 @@ class StandardAttributesTest( GafferSceneTest.SceneTestCase ) :
 
 		a = GafferScene.StandardAttributes()
 		a["in"].setInput( p["out"] )
-		a["filter"].setInput( f["match"] )
+		a["filter"].setInput( f["out"] )
 		a["attributes"]["transformBlurSegments"]["enabled"].setValue( True )
 		a["attributes"]["transformBlurSegments"]["value"].setValue( 2 )
 

--- a/python/GafferSceneTest/TransformTest.py
+++ b/python/GafferSceneTest/TransformTest.py
@@ -89,7 +89,7 @@ class TransformTest( GafferSceneTest.SceneTestCase ) :
 
 		filter = GafferScene.PathFilter()
 		filter["paths"].setValue( IECore.StringVectorData( [ "/group/sphere" ] ) )
-		transform["filter"].setInput( filter["match"] )
+		transform["filter"].setInput( filter["out"] )
 
 		self.assertSceneValid( transform["out"] )
 
@@ -118,7 +118,7 @@ class TransformTest( GafferSceneTest.SceneTestCase ) :
 
 		filter = GafferScene.PathFilter()
 		filter["paths"].setValue( IECore.StringVectorData( [ "/sphere" ] ) )
-		transform["filter"].setInput( filter["match"] )
+		transform["filter"].setInput( filter["out"] )
 
 		self.assertEqual( transform["space"].getValue(), GafferScene.Transform.Space.World )
 

--- a/python/GafferSceneTest/UnionFilterTest.py
+++ b/python/GafferSceneTest/UnionFilterTest.py
@@ -111,13 +111,13 @@ class UnionFilterTest( GafferSceneTest.SceneTestCase ) :
 
 		u["in"][0].setInput( f1["match"] )
 
-		self.assertEqual( [ x[0].fullName() for x in cs if x[0].direction() == x[0].Direction.Out ], [ "u.match" ] )
+		self.assertEqual( [ x[0] for x in cs if x[0].direction() == x[0].Direction.Out ], [ u["match"] ] )
 
 		del cs[:]
 
 		f1["paths"].setValue( IECore.StringVectorData( [ "/a" ] ) )
 
-		self.assertEqual( [ x[0].fullName() for x in cs if x[0].direction() == x[0].Direction.Out ], [ "u.match" ] )
+		self.assertEqual( [ x[0] for x in cs if x[0].direction() == x[0].Direction.Out ], [ u["match"] ] )
 
 	def testAcceptsInput( self ) :
 

--- a/python/GafferSceneTest/UnionFilterTest.py
+++ b/python/GafferSceneTest/UnionFilterTest.py
@@ -58,12 +58,12 @@ class UnionFilterTest( GafferSceneTest.SceneTestCase ) :
 		] ) )
 
 		u = GafferScene.UnionFilter()
-		self.assertEqual( u["match"].getValue(), GafferScene.Filter.Result.NoMatch )
+		self.assertEqual( u["out"].getValue(), GafferScene.Filter.Result.NoMatch )
 
-		h1 = u["match"].hash()
+		h1 = u["out"].hash()
 
-		u["in"][0].setInput( f1["match"] )
-		h2 = u["match"].hash()
+		u["in"][0].setInput( f1["out"] )
+		h2 = u["out"].hash()
 		self.assertNotEqual( h1, h2 )
 
 		for path in [
@@ -75,10 +75,10 @@ class UnionFilterTest( GafferSceneTest.SceneTestCase ) :
 		] :
 			with Gaffer.Context() as c :
 				c["scene:path"] = IECore.InternedStringVectorData( path[1:].split( "/" ) )
- 				self.assertEqual( u["match"].getValue(), f1["match"].getValue() )
+				self.assertEqual( u["out"].getValue(), f1["out"].getValue() )
 
-		u["in"][1].setInput( f2["match"] )
-		h3 = u["match"].hash()
+		u["in"][1].setInput( f2["out"] )
+		h3 = u["out"].hash()
 		self.assertNotEqual( h2, h3 )
 
 		for path, result in [
@@ -93,13 +93,13 @@ class UnionFilterTest( GafferSceneTest.SceneTestCase ) :
 		] :
 			with Gaffer.Context() as c :
 				c["scene:path"] = IECore.InternedStringVectorData( path[1:].split( "/" ) )
- 				self.assertEqual( u["match"].getValue(), int( result ) )
+				self.assertEqual( u["out"].getValue(), int( result ) )
 
 		f2["paths"].setValue( IECore.StringVectorData( [
 			"/a/b",
 		] ) )
 
-		h4 = u["match"].hash()
+		h4 = u["out"].hash()
 		self.assertNotEqual( h3, h4 )
 
 	def testDirtiedSignal( self ) :
@@ -109,24 +109,24 @@ class UnionFilterTest( GafferSceneTest.SceneTestCase ) :
 
 		cs = GafferTest.CapturingSlot( u.plugDirtiedSignal() )
 
-		u["in"][0].setInput( f1["match"] )
+		u["in"][0].setInput( f1["out"] )
 
-		self.assertEqual( [ x[0] for x in cs if x[0].direction() == x[0].Direction.Out ], [ u["match"] ] )
+		self.assertEqual( [ x[0] for x in cs if x[0].direction() == x[0].Direction.Out ], [ u["out"] ] )
 
 		del cs[:]
 
 		f1["paths"].setValue( IECore.StringVectorData( [ "/a" ] ) )
 
-		self.assertEqual( [ x[0] for x in cs if x[0].direction() == x[0].Direction.Out ], [ u["match"] ] )
+		self.assertEqual( [ x[0] for x in cs if x[0].direction() == x[0].Direction.Out ], [ u["out"] ] )
 
 	def testAcceptsInput( self ) :
 
 		f = GafferScene.PathFilter()
 		n = Gaffer.Node()
-		n["match"] = f["match"].createCounterpart( "match", Gaffer.Plug.Direction.Out )
+		n["out"] = f["out"].createCounterpart( "out", Gaffer.Plug.Direction.Out )
 
 		u = GafferScene.UnionFilter()
-		self.assertFalse( u["in"][0].acceptsInput( n["match"] ) )
+		self.assertFalse( u["in"][0].acceptsInput( n["out"] ) )
 
 	def testSceneAffects( self ) :
 
@@ -138,10 +138,10 @@ class UnionFilterTest( GafferSceneTest.SceneTestCase ) :
 		a["in"].setInput( s["out"] )
 
 		f = GafferScene.UnionFilter()
-		a["filter"].setInput( f["match"] )
+		a["filter"].setInput( f["out"] )
 
 		pf = GafferScene.PathFilter()
-		f["in"][0].setInput( pf["match"] )
+		f["in"][0].setInput( pf["out"] )
 
 		# PathFilter isn't sensitive to scene changes, so we shouldn't get
 		# any dirtiness signalled for the attributes.
@@ -157,7 +157,7 @@ class UnionFilterTest( GafferSceneTest.SceneTestCase ) :
 		# the attributes.
 
 		sf = GafferScene.SetFilter()
-		f["in"][1].setInput( sf["match"] )
+		f["in"][1].setInput( sf["out"] )
 
 		cs = GafferTest.CapturingSlot( a.plugDirtiedSignal() )
 
@@ -170,8 +170,8 @@ class UnionFilterTest( GafferSceneTest.SceneTestCase ) :
 
 		sf = GafferScene.SetFilter()
 		dot = Gaffer.Dot()
-		dot.setup( sf["match"] )
-		dot["in"].setInput( sf["match"] )
+		dot.setup( sf["out"] )
+		dot["in"].setInput( sf["out"] )
 
 		uf = GafferScene.UnionFilter()
 		self.assertTrue( uf["in"][0].acceptsInput( dot["out"] ) )
@@ -180,7 +180,7 @@ class UnionFilterTest( GafferSceneTest.SceneTestCase ) :
 		self.assertTrue( uf["in"][0].acceptsInput( dot["out"] ) )
 
 		uf["in"][0].setInput( dot["out"] )
-		dot["in"].setInput( sf["match"] )
+		dot["in"].setInput( sf["out"] )
 
 		a = GafferTest.AddNode()
 		dot2 = Gaffer.Dot()

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -103,6 +103,7 @@ from CoordinateSystemTest import CoordinateSystemTest
 from DeleteOutputsTest import DeleteOutputsTest
 from ExternalProceduralTest import ExternalProceduralTest
 from ClippingPlaneTest import ClippingPlaneTest
+from FilterSwitchTest import FilterSwitchTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferSceneUI/FilterPlugValueWidget.py
+++ b/python/GafferSceneUI/FilterPlugValueWidget.py
@@ -124,7 +124,7 @@ class FilterPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		with Gaffer.UndoContext( self.getPlug().node().scriptNode() ) :
 			self.getPlug().node().parent().addChild( filterNode )
-			self.getPlug().setInput( filterNode["match"] )
+			self.getPlug().setInput( filterNode["out"] )
 
 		# position the node appropriately.
 		## \todo In an ideal world the GraphGadget would do this

--- a/python/GafferSceneUI/FilterSwitchUI.py
+++ b/python/GafferSceneUI/FilterSwitchUI.py
@@ -1,7 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2012, John Haddon. All rights reserved.
-#  Copyright (c) 2012-2014, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -35,63 +34,23 @@
 #
 ##########################################################################
 
-from _GafferSceneUI import *
+import Gaffer
+import GafferUI
+import GafferScene
 
-from SceneHierarchy import SceneHierarchy
-from SceneInspector import SceneInspector
-from FilterPlugValueWidget import FilterPlugValueWidget
-import SceneNodeUI
-import SceneReaderUI
-import SceneProcessorUI
-import FilteredSceneProcessorUI
-import PruneUI
-import SubTreeUI
-import OutputsUI
-import OptionsUI
-import OpenGLAttributesUI
-import SceneContextVariablesUI
-import SceneWriterUI
-import StandardOptionsUI
-import StandardAttributesUI
-import ShaderUI
-import OpenGLShaderUI
-import ObjectSourceUI
-import TransformUI
-import AttributesUI
-import LightUI
-import InteractiveRenderUI
-import SphereUI
-import MapProjectionUI
-import MapOffsetUI
-import CustomAttributesUI
-import CustomOptionsUI
-import SceneViewToolbar
-import SceneSwitchUI
-import ShaderSwitchUI
-import ShaderAssignmentUI
-import ParentConstraintUI
-import ParentUI
-import PrimitiveVariablesUI
-import DuplicateUI
-import GridUI
-import SetFilterUI
-import DeleteGlobalsUI
-import DeleteOptionsUI
-import ExternalProceduralUI
-import ExecutableRenderUI
-import IsolateUI
-import SelectionToolUI
-import CropWindowToolUI
-import CameraUI
-import SetUI
-import ClippingPlaneUI
-import FilterUI
-import FilterSwitchUI
+Gaffer.Metadata.registerNode(
 
-# then all the PathPreviewWidgets. note that the order
-# of import controls the order of display.
+	GafferScene.FilterSwitch,
 
-from AlembicPathPreview import AlembicPathPreview
-from SceneReaderPathPreview import SceneReaderPathPreview
+	"description",
+	"""
+	Chooses between multiple input filters, passing the chosen
+	filter through to the output.
+	""",
 
-__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", {}, subdirectory = "GafferSceneUI" )
+)
+
+GafferUI.Nodule.registerNodule( GafferScene.Filter, "index", lambda plug : None )
+
+GafferUI.PlugValueWidget.registerCreator( GafferScene.Filter, "in", None )
+GafferUI.PlugValueWidget.registerCreator( GafferScene.Filter, "in[0-9]*", None )

--- a/python/GafferSceneUI/FilterUI.py
+++ b/python/GafferSceneUI/FilterUI.py
@@ -1,7 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2012, John Haddon. All rights reserved.
-#  Copyright (c) 2012-2014, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -35,62 +34,47 @@
 #
 ##########################################################################
 
-from _GafferSceneUI import *
+import Gaffer
+import GafferUI
+import GafferScene
 
-from SceneHierarchy import SceneHierarchy
-from SceneInspector import SceneInspector
-from FilterPlugValueWidget import FilterPlugValueWidget
-import SceneNodeUI
-import SceneReaderUI
-import SceneProcessorUI
-import FilteredSceneProcessorUI
-import PruneUI
-import SubTreeUI
-import OutputsUI
-import OptionsUI
-import OpenGLAttributesUI
-import SceneContextVariablesUI
-import SceneWriterUI
-import StandardOptionsUI
-import StandardAttributesUI
-import ShaderUI
-import OpenGLShaderUI
-import ObjectSourceUI
-import TransformUI
-import AttributesUI
-import LightUI
-import InteractiveRenderUI
-import SphereUI
-import MapProjectionUI
-import MapOffsetUI
-import CustomAttributesUI
-import CustomOptionsUI
-import SceneViewToolbar
-import SceneSwitchUI
-import ShaderSwitchUI
-import ShaderAssignmentUI
-import ParentConstraintUI
-import ParentUI
-import PrimitiveVariablesUI
-import DuplicateUI
-import GridUI
-import SetFilterUI
-import DeleteGlobalsUI
-import DeleteOptionsUI
-import ExternalProceduralUI
-import ExecutableRenderUI
-import IsolateUI
-import SelectionToolUI
-import CropWindowToolUI
-import CameraUI
-import SetUI
-import ClippingPlaneUI
-import FilterUI
+Gaffer.Metadata.registerNode(
 
-# then all the PathPreviewWidgets. note that the order
-# of import controls the order of display.
+	GafferScene.Filter,
 
-from AlembicPathPreview import AlembicPathPreview
-from SceneReaderPathPreview import SceneReaderPathPreview
+	"description",
+	"""
+	The base type for all nodes which are capable of choosing which
+	scene locations a FilteredSceneProcessor applies to.
+	""",
 
-__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", {}, subdirectory = "GafferSceneUI" )
+	plugs = {
+
+		"enabled" : [
+
+			"description",
+			"""
+			The on/off state of the filter. When it is off, the
+			filter does not match any locations.
+			""",
+
+			"nodeUI:section", "Node",
+
+		],
+
+		"match" : [
+
+			"description",
+			"""
+			The result of the filter. This should be connected into
+			the "filter" plug of a FilteredSceneProcessor.
+			""",
+
+		]
+
+	}
+
+)
+
+GafferUI.Nodule.registerNodule( GafferScene.Filter, "enabled", lambda plug : None )
+GafferUI.PlugValueWidget.registerCreator( GafferScene.Filter, "match", None )

--- a/python/GafferSceneUI/SceneNodeUI.py
+++ b/python/GafferSceneUI/SceneNodeUI.py
@@ -119,10 +119,6 @@ GafferUI.PlugValueWidget.registerCreator(
 GafferUI.PlugValueWidget.registerCreator( GafferScene.Group, "in[0-9]*", None )
 GafferUI.PlugValueWidget.registerCreator( GafferScene.Group, "transform", GafferUI.TransformPlugValueWidget, collapsed=None )
 
-# Filter
-
-GafferUI.PlugValueWidget.registerCreator( GafferScene.Filter, "match", None )
-
 # Constraint
 
 GafferUI.PlugValueWidget.registerCreator(

--- a/python/GafferSceneUI/SceneReaderPathPreview.py
+++ b/python/GafferSceneUI/SceneReaderPathPreview.py
@@ -208,13 +208,13 @@ class _Camera( Gaffer.Node ) :
 		self["parentConstraint"]["in"].setInput( self["parent"]["out"] )
 		self["parentConstraint"]["target"].setInput( self["lookAt"] )
 		self["parentConstraint"]["targetMode"].setValue( self["parentConstraint"].TargetMode.BoundCenter )
-		self["parentConstraint"]["filter"].setInput( self["cameraFilter"]["match"] )
+		self["parentConstraint"]["filter"].setInput( self["cameraFilter"]["out"] )
 
 		self["cameraRotate"] = GafferScene.Transform()
 		self["cameraRotate"]["in"].setInput( self["parentConstraint"]["out"] )
 		self["cameraRotate"]["transform"]["rotate"]["y"].setInput( self["angle"] )
 		self["cameraRotate"]["space"].setValue( self["cameraRotate"].Space.Object )
-		self["cameraRotate"]["filter"].setInput( self["cameraFilter"]["match"] )
+		self["cameraRotate"]["filter"].setInput( self["cameraFilter"]["out"] )
 
 		self["elevationExpression"] = Gaffer.Expression()
 		self["elevationExpression"]["engine"].setValue( "python" )
@@ -224,7 +224,7 @@ class _Camera( Gaffer.Node ) :
 		self["cameraTranslate"]["in"].setInput( self["cameraRotate"]["out"] )
 		self["cameraTranslate"]["transform"]["translate"]["z"].setInput( self["depth"] )
 		self["cameraTranslate"]["space"].setValue( self["cameraRotate"].Space.Object )
-		self["cameraTranslate"]["filter"].setInput( self["cameraFilter"]["match"] )
+		self["cameraTranslate"]["filter"].setInput( self["cameraFilter"]["out"] )
 
 		self["options"] = GafferScene.StandardOptions()
 		self["options"]["options"]["renderCamera"]["enabled"].setValue( True )

--- a/python/GafferSceneUI/SetFilterUI.py
+++ b/python/GafferSceneUI/SetFilterUI.py
@@ -85,7 +85,7 @@ def __setsPopupMenu( menuDefinition, plugValueWidget ) :
 
 	setNames = set()
 	with plugValueWidget.getContext() :
-		for output in node["match"].outputs() :
+		for output in node["out"].outputs() :
 			if not isinstance( output.node(), GafferScene.SceneProcessor ) :
 				continue
 			globals = output.node()["in"]["globals"].getValue()

--- a/src/GafferScene/Filter.cpp
+++ b/src/GafferScene/Filter.cpp
@@ -51,7 +51,7 @@ Filter::Filter( const std::string &name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new BoolPlug( "enabled", Gaffer::Plug::In, true ) );
-	addChild( new IntPlug( "match", Gaffer::Plug::Out, NoMatch, NoMatch, EveryMatch ) );
+	addChild( new IntPlug( "out", Gaffer::Plug::Out, NoMatch, NoMatch, EveryMatch ) );
 }
 
 Filter::~Filter()
@@ -68,14 +68,24 @@ const Gaffer::BoolPlug *Filter::enabledPlug() const
 	return getChild<Gaffer::BoolPlug>( g_firstPlugIndex );
 }
 
-Gaffer::IntPlug *Filter::matchPlug()
+Gaffer::IntPlug *Filter::outPlug()
 {
 	return getChild<Gaffer::IntPlug>( g_firstPlugIndex + 1 );
 }
 
-const Gaffer::IntPlug *Filter::matchPlug() const
+const Gaffer::IntPlug *Filter::outPlug() const
 {
 	return getChild<Gaffer::IntPlug>( g_firstPlugIndex + 1 );
+}
+
+Gaffer::IntPlug *Filter::matchPlug()
+{
+	return outPlug();
+}
+
+const Gaffer::IntPlug *Filter::matchPlug() const
+{
+	return outPlug();
 }
 
 void Filter::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const

--- a/src/GafferScene/Filter.cpp
+++ b/src/GafferScene/Filter.cpp
@@ -94,7 +94,7 @@ void Filter::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs
 
 	if( input == enabledPlug() )
 	{
-		outputs.push_back( matchPlug() );
+		outputs.push_back( outPlug() );
 	}
 }
 
@@ -116,7 +116,7 @@ const ScenePlug *Filter::getInputScene( const Gaffer::Context *context )
 void Filter::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	ComputeNode::hash( output, context, h );
-	if( output == matchPlug() )
+	if( output == outPlug() )
 	{
 		if( enabledPlug()->getValue() )
 		{
@@ -135,7 +135,7 @@ void Filter::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *conte
 
 void Filter::compute( ValuePlug *output, const Context *context ) const
 {
-	if( output == matchPlug() )
+	if( output == outPlug() )
 	{
 		unsigned match = NoMatch;
 		if( enabledPlug()->getValue() )

--- a/src/GafferScene/FilterMixinBase.cpp
+++ b/src/GafferScene/FilterMixinBase.cpp
@@ -1,0 +1,83 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "IECore/Exception.h"
+
+#include "GafferScene/FilterMixinBase.h"
+
+using namespace IECore;
+using namespace Gaffer;
+using namespace GafferScene;
+
+IE_CORE_DEFINERUNTIMETYPED( FilterMixinBase );
+
+FilterMixinBase::FilterMixinBase( const std::string &name )
+	:	Filter( name )
+{
+	addChild( outPlug()->createCounterpart( "in", Plug::In ) );
+}
+
+FilterMixinBase::~FilterMixinBase()
+{
+}
+
+bool FilterMixinBase::sceneAffectsMatch( const ScenePlug *scene, const Gaffer::ValuePlug *child ) const
+{
+	for( InputIntPlugIterator it( this ); it != it.end(); ++it )
+	{
+		if( Plug *input = (*it)->getInput<Plug>() )
+		{
+			if( Filter *filter = runTimeCast<Filter>( input->node() ) )
+			{
+				if( input == filter->outPlug() && filter->sceneAffectsMatch( scene, child ) )
+				{
+					return true;
+				}
+			}
+		}
+	}
+	return false;
+}
+
+void FilterMixinBase::hashMatch( const ScenePlug *scene, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	throw Exception( "Unexpected call to FilterMixinBase::hashMatch" );
+}
+
+unsigned FilterMixinBase::computeMatch( const ScenePlug *scene, const Gaffer::Context *context ) const
+{
+	throw Exception( "Unexpected call to FilterMixinBase::computeMatch" );
+}

--- a/src/GafferScene/FilterSwitch.cpp
+++ b/src/GafferScene/FilterSwitch.cpp
@@ -1,0 +1,49 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Gaffer/Switch.inl"
+
+#include "GafferScene/FilterSwitch.h"
+
+namespace Gaffer
+{
+
+IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( GafferScene::FilterSwitch, GafferScene::FilterSwitchTypeId )
+
+}
+
+// explicit instantiation
+template class Gaffer::Switch<GafferScene::FilterMixinBase>;

--- a/src/GafferScene/PathFilter.cpp
+++ b/src/GafferScene/PathFilter.cpp
@@ -92,7 +92,7 @@ void PathFilter::affects( const Gaffer::Plug *input, AffectedPlugsContainer &out
 	}
 	else if( input == pathMatcherPlug() )
 	{
-		outputs.push_back( matchPlug() );
+		outputs.push_back( outPlug() );
 	}
 }
 

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -186,7 +186,7 @@ class MatchingPathsTask : public tbb::task
 
 void GafferScene::matchingPaths( const Filter *filter, const ScenePlug *scene, PathMatcher &paths )
 {
-	matchingPaths( filter->matchPlug(), scene, paths );
+	matchingPaths( filter->outPlug(), scene, paths );
 }
 
 void GafferScene::matchingPaths( const Gaffer::IntPlug *filterPlug, const ScenePlug *scene, PathMatcher &paths )

--- a/src/GafferScene/SetFilter.cpp
+++ b/src/GafferScene/SetFilter.cpp
@@ -77,7 +77,7 @@ void SetFilter::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outp
 
 	if( input == setPlug() )
 	{
-		outputs.push_back( matchPlug() );
+		outputs.push_back( outPlug() );
 	}
 }
 

--- a/src/GafferScene/UnionFilter.cpp
+++ b/src/GafferScene/UnionFilter.cpp
@@ -55,7 +55,7 @@ UnionFilter::UnionFilter( const std::string &name )
 	addChild( new ArrayPlug(
 		"in",
 		Plug::In,
-		matchPlug()->createCounterpart( "in", Plug::In )
+		outPlug()->createCounterpart( "in", Plug::In )
 	) );
 }
 
@@ -79,7 +79,7 @@ void UnionFilter::affects( const Gaffer::Plug *input, AffectedPlugsContainer &ou
 
 	if( input->parent<ArrayPlug>() == inPlug() )
 	{
-		outputs.push_back( matchPlug() );
+		outputs.push_back( outPlug() );
 	}
 }
 

--- a/src/GafferSceneBindings/FilterSwitchBinding.cpp
+++ b/src/GafferSceneBindings/FilterSwitchBinding.cpp
@@ -1,0 +1,53 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "GafferBindings/DependencyNodeBinding.h"
+
+#include "GafferScene/FilterSwitch.h"
+
+#include "GafferSceneBindings/FilterSwitchBinding.h"
+
+using namespace boost::python;
+
+void GafferSceneBindings::bindFilterSwitch()
+{
+
+	GafferBindings::DependencyNodeClass<GafferScene::FilterMixinBase>();
+	GafferBindings::DependencyNodeClass<GafferScene::FilterSwitch>();
+
+}

--- a/src/GafferSceneModule/GafferSceneModule.cpp
+++ b/src/GafferSceneModule/GafferSceneModule.cpp
@@ -94,6 +94,7 @@
 #include "GafferSceneBindings/GroupBinding.h"
 #include "GafferSceneBindings/ScenePathBinding.h"
 #include "GafferSceneBindings/ClippingPlaneBinding.h"
+#include "GafferSceneBindings/FilterSwitchBinding.h"
 
 using namespace boost::python;
 using namespace GafferScene;
@@ -169,5 +170,6 @@ BOOST_PYTHON_MODULE( _GafferScene )
 	bindExternalProcedural();
 	bindScenePath();
 	bindClippingPlane();
+	bindFilterSwitch();
 
 }

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -866,7 +866,7 @@ SceneView::SceneView( const std::string &name )
 
 	PathFilterPtr hideFilter = new PathFilter( "hideFilter" );
 	preprocessor->addChild( hideFilter );
-	hide->filterPlug()->setInput( hideFilter->matchPlug() );
+	hide->filterPlug()->setInput( hideFilter->outPlug() );
 
 	// make the output for the preprocessor
 

--- a/startup/GafferScene/filterCompatibility.py
+++ b/startup/GafferScene/filterCompatibility.py
@@ -35,46 +35,13 @@
 ##########################################################################
 
 import Gaffer
-import GafferUI
 import GafferScene
 
-Gaffer.Metadata.registerNode(
+# Provides backwards compatibility by allowing access to "out" plug
+# using its old name of "match".
+def __getItem( self, key ) :
 
-	GafferScene.Filter,
+	key = "out" if key == "match" else key
+	return Gaffer.GraphComponent.__getitem__( self, key )
 
-	"description",
-	"""
-	The base type for all nodes which are capable of choosing which
-	scene locations a FilteredSceneProcessor applies to.
-	""",
-
-	plugs = {
-
-		"enabled" : [
-
-			"description",
-			"""
-			The on/off state of the filter. When it is off, the
-			filter does not match any locations.
-			""",
-
-			"nodeUI:section", "Node",
-
-		],
-
-		"out" : [
-
-			"description",
-			"""
-			The result of the filter. This should be connected into
-			the "filter" plug of a FilteredSceneProcessor.
-			""",
-
-		]
-
-	}
-
-)
-
-GafferUI.Nodule.registerNodule( GafferScene.Filter, "enabled", lambda plug : None )
-GafferUI.PlugValueWidget.registerCreator( GafferScene.Filter, "out", None )
+GafferScene.Filter.__getitem__ = __getItem

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -237,6 +237,7 @@ nodeMenu.append( "/Scene/Attributes/Delete Attributes", GafferScene.DeleteAttrib
 nodeMenu.append( "/Scene/Filters/Set Filter", GafferScene.SetFilter, searchText = "SetFilter" )
 nodeMenu.append( "/Scene/Filters/Path Filter", GafferScene.PathFilter, searchText = "PathFilter" )
 nodeMenu.append( "/Scene/Filters/Union Filter", GafferScene.UnionFilter, searchText = "UnionFilter" )
+nodeMenu.append( "/Scene/Filters/FilterSwitch", GafferScene.FilterSwitch, searchText = "FilterSwitch" )
 nodeMenu.append( "/Scene/Hierarchy/Group", GafferScene.Group )
 nodeMenu.append( "/Scene/Hierarchy/Parent", GafferScene.Parent )
 nodeMenu.append( "/Scene/Hierarchy/Duplicate", GafferScene.Duplicate )

--- a/startup/gui/nodeGraph.py
+++ b/startup/gui/nodeGraph.py
@@ -64,7 +64,7 @@ Gaffer.Metadata.registerNodeValue( GafferScene.SceneProcessor, "nodeGadget:color
 Gaffer.Metadata.registerNodeValue( GafferScene.SceneElementProcessor, "nodeGadget:color", IECore.Color3f( 0.1886, 0.2772, 0.41 ) )
 
 Gaffer.Metadata.registerPlugValue( GafferScene.FilteredSceneProcessor, "filter", "nodule:color", IECore.Color3f( 0.69, 0.5378, 0.2283 ) )
-Gaffer.Metadata.registerPlugValue( GafferScene.Filter, "match", "nodule:color", IECore.Color3f( 0.69, 0.5378, 0.2283 ) )
+Gaffer.Metadata.registerPlugValue( GafferScene.Filter, "out", "nodule:color", IECore.Color3f( 0.69, 0.5378, 0.2283 ) )
 
 Gaffer.Metadata.registerNodeValue( GafferScene.Transform, "nodeGadget:color", IECore.Color3f( 0.485, 0.3112, 0.2255 ) )
 Gaffer.Metadata.registerNodeValue( GafferScene.Constraint, "nodeGadget:color", IECore.Color3f( 0.485, 0.3112, 0.2255 ) )


### PR DESCRIPTION
This takes care of #1196 (enabled plug for Filters) and #1197 (FilterSwitch node).

Note that because the Switch mixin class expects "in" and "out" plugs, I've had to rename the filter "match" plug to "out". I've provided backwards compatibility as far as possible in `startup/GafferScene/filterCompatibility.py`, by aliasing "match" to "out" in a `__getattr__()` override. This should deal with all `.gfr` files and any scripts which access the plug through the normal channels. Scripts which come by the plug in some other way, and then compare the name to "match" would need to be changed - examples in Gaffer included Metadata registrations and unit tests which compared the names rather than the identities of dirtied plugs. I've grepped through IERendering, Caribou and Jabuka and believe there is only one such instance, in the [IERendering MatchUnrelated tests](https://github.com/ImageEngine/rendering/blob/master/test/IEGafferRendering/MatchUnrelated.py#L127).

If you'd prefer to keep the name as-is for the moment, I could probably rejig the Switch class to accept differently named outputs. I do think I prefer the new name though - it seems less awkward and more in keeping with the other primary plugs seen in the node graph.
