### PR TITLE
Highlighting of non-default plugs in NodeEditor.

### DIFF
--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -116,10 +116,17 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def _updateFromPlug( self ) :
 
+		plug = self.getPlug()
+
 		self.__label.setEnabled(
-			self.getPlug() is not None and
-			not self.getPlug().getFlags( Gaffer.Plug.Flags.ReadOnly )
+			plug is not None and
+			not plug.getFlags( Gaffer.Plug.Flags.ReadOnly )
 		)
+
+		highlighted = plug.getInput() is not None
+		if not highlighted and isinstance( plug, Gaffer.ValuePlug ) :
+			highlighted = highlighted or not plug.isSetToDefault()
+		self.__label.setHighlighted( highlighted )
 
 	def __dragBegin( self, widget, event ) :
 

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -70,7 +70,7 @@ _styleSheet = string.Template(
 
 	QLabel[gafferHighlighted=\"true\"] {
 
-		color: $brightColor;
+		color: #b0d8fb;
 
 	}
 
@@ -994,7 +994,7 @@ _styleSheet = string.Template(
 	"backgroundLighter" : "#6c6c6c",
 	"backgroundLight" : "#7d7d7d",
 	"brightColor" : "#779cbd",
-	"foreground" : "#f0f0f0",
+	"foreground" : "#e0e0e0",
 	"foregroundFaded" : "#999999",
 	"alternateColor" : "#454545",
 	"errorColor" : "#ff5555",


### PR DESCRIPTION
This hopefully takes care of #1216. I tried using bold or italic text instead, and although bold looked quite nice, it seemed a bit jarring as the text layout jumped when turning it on and off (due to the different sizes of the bold and regular characters). Hopefully this seems acceptable.