### PR TITLE
Added dirty propagation test for ContextVariables

### DIFF
--- a/python/GafferTest/ContextVariablesTest.py
+++ b/python/GafferTest/ContextVariablesTest.py
@@ -61,6 +61,30 @@ class ContextVariablesTest( GafferTest.TestCase ) :
 		c["variables"].addMember( "a", IECore.StringData( "A" ) )
 		self.assertEqual( c["out"].getValue(), "A" )
 
+	def testDirtyPropagation( self ) :
+
+		n = GafferTest.StringInOutNode()
+
+		c = Gaffer.ContextVariablesComputeNode()
+		c["in"] = Gaffer.StringPlug()
+		c["out"] = Gaffer.StringPlug( direction = Gaffer.Plug.Direction.Out )
+		c["in"].setInput( n["out"] )
+
+		# adding a variable should dirty the output:
+		dirtied = GafferTest.CapturingSlot( c.plugDirtiedSignal() )
+		c["variables"].addMember( "a", IECore.StringData( "A" ) )
+		self.failUnless( c["out"] in [ p[0] for p in dirtied ] )
+
+		# modifying the variable should dirty the output:
+		dirtied = GafferTest.CapturingSlot( c.plugDirtiedSignal() )
+		c["variables"]["member1"]["value"].setValue("b")
+		self.failUnless( c["out"] in [ p[0] for p in dirtied ] )
+
+		# removing the variable should also dirty the output:
+		dirtied = GafferTest.CapturingSlot( c.plugDirtiedSignal() )
+		c["variables"].removeChild(c["variables"]["member1"])
+		self.failUnless( c["out"] in [ p[0] for p in dirtied ] )
+
 if __name__ == "__main__":
 	unittest.main()
 


### PR DESCRIPTION
Two things seem to be failing here. To start with, it looks like tweaking a value on a ContextVariables node doesn't signal dirtiness properly, because ContextVariables<BaseType>::affects() isn't implemented correctly.

The other problem seems wider ranging: adding a member to/removing it from the "variables" plug on a ContextVariables node (and similar nodes) should trigger a propagateDirtiness and dirty its output, seeing as it affects its value. This seems problematic though - I tried calling propagateDirtiness( this ) in CompoundPlug::childAddedOrRemoved(), but compound plugs don't trigger calls to affects(), so that was the end of that. This is probably affecting other nodes with compound plugs like GafferScene::CustomAttributes too.