### PR TITLE
Seeds node bound fix

### DIFF
--- a/src/GafferScene/Seeds.cpp
+++ b/src/GafferScene/Seeds.cpp
@@ -108,12 +108,21 @@ void Seeds::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
 
 void Seeds::hashBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	h = inPlug()->boundHash( parentPath );
+	BranchCreator::hashBranchBound( parentPath, branchPath, context, h );
+	h.append( inPlug()->boundHash( parentPath ) );
 }
 
 Imath::Box3f Seeds::computeBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const
 {
-	return inPlug()->bound( parentPath );
+	Box3f b =  inPlug()->bound( parentPath );
+	if( !b.isEmpty() )
+	{
+		// The PointsPrimitive we make has a default point width of 1,
+		// so we must expand our bounding box to take that into account.
+		b.min -= V3f( 0.5 );
+		b.max += V3f( 0.5 );
+	}
+	return b;
 }
 
 void Seeds::hashBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const


### PR DESCRIPTION
IECore::PointsPrimitive used to ignore the width when calculating its bound - now that it does things correctly, we must too, or we generate an invalid scene. This is necessary once https://github.com/ImageEngine/cortex/pull/405 is merged.