### PR TITLE
Persistent hash cache

### DIFF
--- a/include/Gaffer/DependencyNode.h
+++ b/include/Gaffer/DependencyNode.h
@@ -91,6 +91,7 @@ class DependencyNode : public Node
 
 		friend class Plug;
 		friend class ValuePlug;
+		friend class CompoundPlug;
 		class DirtyPlugs;
 		static tbb::enumerable_thread_specific<DirtyPlugs> g_dirtyPlugs;
 

--- a/include/Gaffer/DependencyNode.h
+++ b/include/Gaffer/DependencyNode.h
@@ -38,6 +38,8 @@
 #ifndef GAFFER_DEPENDENCYNODE_H
 #define GAFFER_DEPENDENCYNODE_H
 
+#include "tbb/enumerable_thread_specific.h"
+
 #include "Gaffer/Node.h"
 
 namespace Gaffer
@@ -89,6 +91,8 @@ class DependencyNode : public Node
 
 		friend class Plug;
 		friend class ValuePlug;
+		class DirtyPlugs;
+		static tbb::enumerable_thread_specific<DirtyPlugs> g_dirtyPlugs;
 
 		static void propagateDirtiness( Plug *plugToDirty );
 

--- a/include/Gaffer/ValuePlug.h
+++ b/include/Gaffer/ValuePlug.h
@@ -45,6 +45,7 @@
 #include <boost/multi_index/random_access_index.hpp>
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/member.hpp>
+#include <boost/utility/value_init.hpp>
 
 #include "Gaffer/Plug.h"
 #include "Gaffer/PlugIterator.h"
@@ -210,12 +211,22 @@ class ValuePlug : public Plug
 				boost::multi_index::random_access<>,
 				boost::multi_index::ordered_unique< boost::multi_index::member<HashCacheElement,IECore::MurmurHash,&HashCacheElement::first> >
 			>
-		> HashCache;
+		> HashCacheMap;
 		
-		typedef HashCache::nth_index<1>::type::iterator HashCacheIterator;
+		typedef HashCacheMap::nth_index<1>::type::iterator HashCacheIterator;
+		
+		struct HashCache
+		{
+			HashCacheMap cache;
+			boost::value_initialized<int> graphUpdateCount;
+		};
 		
 		mutable tbb::enumerable_thread_specific<HashCache> m_hashCaches;
-
+		
+		// global graph update count which changes every time DependencyNode::propagateDirtiness
+		// is called.
+		static boost::value_initialized<int> g_graphUpdateCount;
+		
 };
 
 IE_CORE_DECLAREPTR( ValuePlug )

--- a/python/GafferImageTest/FormatTest.py
+++ b/python/GafferImageTest/FormatTest.py
@@ -114,16 +114,18 @@ class FormatTest( unittest.TestCase ) :
 		s = Gaffer.ScriptNode()
 		s.addChild( n )
 
-		h1 = n["out"]["format"].hash()
+		with s.context():
+		
+			h1 = n["out"]["format"].hash()
 
-		# Change the default format.
-		GafferImage.Format.registerFormat( self.__testFormatValue(), self.__testFormatName() )
-		GafferImage.Format.setDefaultFormat( s, self.__testFormatValue() )
+			# Change the default format.
+			GafferImage.Format.registerFormat( self.__testFormatValue(), self.__testFormatName() )
+			GafferImage.Format.setDefaultFormat( s, self.__testFormatValue() )
 
-		# Check that the hash has changed.
-		h2 = n["out"]["format"].hash()
+			# Check that the hash has changed.
+			h2 = n["out"]["format"].hash()
 
-		self.assertNotEqual( h1, h2 )
+			self.assertNotEqual( h1, h2 )
 
 	def testDefaultFormatChanged( self ) :
 		# Create a grade node and check that the format changes if it is unconnected.

--- a/python/GafferSceneTest/CustomAttributesTest.py
+++ b/python/GafferSceneTest/CustomAttributesTest.py
@@ -79,7 +79,7 @@ class CustomAttributesTest( GafferSceneTest.SceneTestCase ) :
 		# isn't allowed attributes.
 		a["attributes"].addMember( "ri:shadingRate", IECore.FloatData( 0.25 ) )
 		self.assertEqual( a["out"].attributes( "/" ), IECore.CompoundObject() )
-		self.assertEqual( a["out"].attributes( "/ball1" ), IECore.CompoundObject( { "ri:shadingRate" : IECore.FloatData( 0.25 ) } ) )
+		self.assertEqual( a["out"].attributes( "/ball1" ), IECore.CompoundObject( { "ri:shadingRate" : IECore.FloatData( 0.25 ) } ) ) # fails because addMember does not correctly propagate dirtiness
 		self.assertEqual( a["out"].attributes( "/ball2" ), IECore.CompoundObject( { "ri:shadingRate" : IECore.FloatData( 0.25 ) } ) )
 
 		# finally once we've applied a filter, we should get some attributes.
@@ -139,7 +139,7 @@ class CustomAttributesTest( GafferSceneTest.SceneTestCase ) :
 			IECore.CompoundObject( {
 				"ri:shadingRate" : IECore.FloatData( 0.5 ),
 				"user:something" : IECore.IntData( 1 ),
-				"user:somethingElse" : IECore.IntData( 10 ),
+				"user:somethingElse" : IECore.IntData( 10 ),  # fails because addMember does not correctly propagate dirtiness
 			} )
 		)
 
@@ -210,7 +210,7 @@ class CustomAttributesTest( GafferSceneTest.SceneTestCase ) :
 		# be a pass-through.
 		a["attributes"].addMember( "ri:shadingRate", IECore.FloatData( 2.0 ) )
 		self.assertSceneHashesEqual( input["out"], a["out"], childPlugNames = ( "globals", "childNames", "transform", "bound", "object" ) )
-		self.assertSceneHashesNotEqual( input["out"], a["out"], childPlugNames = ( "attributes", ) )
+		self.assertSceneHashesNotEqual( input["out"], a["out"], childPlugNames = ( "attributes", ) ) # fails because addMember does not correctly propagate dirtiness
 
 		# when we add a filter, non-matching objects should become pass-throughs
 		f = GafferScene.PathFilter()

--- a/python/GafferSceneTest/DuplicateTest.py
+++ b/python/GafferSceneTest/DuplicateTest.py
@@ -154,5 +154,32 @@ class DuplicateTest( GafferSceneTest.SceneTestCase ) :
 		d["name"].setValue( "test" )
 		self.assertTrue( d["out"]["childNames"] in [ c[0] for c in cs ] )
 
+
+	def testDirtyPropagation( self ) :
+
+		s = GafferScene.Sphere()
+		g = GafferScene.Group()
+		g["in"].setInput( s["out"] )
+
+		d = GafferScene.Duplicate()
+		d["in"].setInput( g["out"] )
+
+		dirtied = GafferTest.CapturingSlot( d.plugDirtiedSignal() )
+		s["name"].setValue( "yeahyeah" )
+		self.failUnless( d["__mapping"] in [ p[0] for p in dirtied ] )
+		
+		dirtied = GafferTest.CapturingSlot( d.plugDirtiedSignal() )
+		d["name"].setValue( "/group/yeahyeah" )
+		self.failUnless( d["__mapping"] in [ p[0] for p in dirtied ] )
+		
+		dirtied = GafferTest.CapturingSlot( d.plugDirtiedSignal() )
+		d["target"].setValue( "sphere" )
+		self.failUnless( d["__mapping"] in [ p[0] for p in dirtied ] )
+		
+		dirtied = GafferTest.CapturingSlot( d.plugDirtiedSignal() )
+		d["copies"].setValue( 3 )
+		self.failUnless( d["__mapping"] in [ p[0] for p in dirtied ] )
+		self.failUnless( d["__mapping"] in [ p[0] for p in dirtied ] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/PrimitiveVariablesTest.py
+++ b/python/GafferSceneTest/PrimitiveVariablesTest.py
@@ -56,7 +56,7 @@ class PrimitiveVariablesTest( GafferSceneTest.SceneTestCase ) :
 		self.assertScenesEqual( s["out"], p["out"], childPlugNamesToIgnore=( "object", ) )
 		self.assertSceneHashesEqual( s["out"], p["out"], childPlugNamesToIgnore=( "object", ) )
 
-		self.assertNotEqual( s["out"].objectHash( "/sphere" ), p["out"].objectHash( "/sphere" ) )
+		self.assertNotEqual( s["out"].objectHash( "/sphere" ), p["out"].objectHash( "/sphere" ) ) # fails because addMember does not correctly propagate dirtiness
 		self.assertNotEqual( s["out"].object( "/sphere" ), p["out"].object( "/sphere" ) )
 
 		o1 = s["out"].object( "/sphere" )

--- a/python/GafferSceneTest/SetFilterTest.py
+++ b/python/GafferSceneTest/SetFilterTest.py
@@ -76,7 +76,11 @@ class SetFilterTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertSceneValid( a["out"] )
 
-		self.assertTrue( "doubleSided" not in a["out"].attributes( "/group/plane" ) )
+		# this fails on the current branch. It's failing because the hash caches on the
+		# set filter node haven't been cleared, as it hasn't been touched by
+		# the propagateDirtiness launched by s["paths"].setValue(). This means it's
+		# still erroneously getting a filter match from /group/plane.
+		self.assertTrue( "doubleSided" not in a["out"].attributes( "/group/plane" ) ) # annoying new failure - see comment above
 		self.assertTrue( "doubleSided" not in a["out"].attributes( "/group/plane1" ) )
 		self.assertTrue( "doubleSided" in a["out"].attributes( "/group" ) )
 

--- a/python/GafferSceneTest/ShaderAssignmentTest.py
+++ b/python/GafferSceneTest/ShaderAssignmentTest.py
@@ -169,7 +169,7 @@ class ShaderAssignmentTest( unittest.TestCase ) :
 		s["s2"]["enabled"].setValue( False )
 
 		self.assertTrue( "test:surface" in s["a"]["out"].attributes( "/plane" ) )
-		self.assertEqual( s["a2"]["out"].attributes( "/plane" )["test:surface"][-1].name, "test" )
+		self.assertEqual( s["a2"]["out"].attributes( "/plane" )["test:surface"][-1].name, "test" ) # fails beause dirty propagation is broken - see todo in ShaderAssignment::affects()
 
 	def testInputAcceptanceInsideBoxes( self ) :
 

--- a/python/GafferTest/ContextVariablesTest.py
+++ b/python/GafferTest/ContextVariablesTest.py
@@ -59,7 +59,7 @@ class ContextVariablesTest( GafferTest.TestCase ) :
 		self.assertEqual( c["out"].getValue(), "" )
 
 		c["variables"].addMember( "a", IECore.StringData( "A" ) )
-		self.assertEqual( c["out"].getValue(), "A" )
+		self.assertEqual( c["out"].getValue(), "A" ) # fails because addMember doesn't correctly propagate dirtiness
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/NumericPlugTest.py
+++ b/python/GafferTest/NumericPlugTest.py
@@ -460,12 +460,14 @@ class NumericPlugTest( GafferTest.TestCase ) :
 		self.assertEqual( n.numHashCalls, 1 )
 		self.assertEqual( n.numComputeCalls, 1 )
 
+		# hash values in this context should be stored on the plug, so numHashCalls
+		# should stay at 1:
 		h = n["sum"].hash()
-		self.assertEqual( n.numHashCalls, 2 )
+		self.assertEqual( n.numHashCalls, 1 )
 		self.assertEqual( n.numComputeCalls, 1 )
 
 		self.assertEqual( n["sum"].getValue( _precomputedHash = h ), 30 )
-		self.assertEqual( n.numHashCalls, 2 )
+		self.assertEqual( n.numHashCalls, 1 )
 		self.assertEqual( n.numComputeCalls, 1 )
 
 	def testIsSetToDefault( self ) :

--- a/python/GafferTest/StringPlugTest.py
+++ b/python/GafferTest/StringPlugTest.py
@@ -140,7 +140,7 @@ class StringPlugTest( GafferTest.TestCase ) :
 		self.assertEqual( n["out"].getValue(), "" )
 
 		os.environ["A"] = "a"
-		self.assertEqual( n["out"].getValue(), "a" )
+		self.assertEqual( n["out"].getValue(), "a" ) # fails because changing the environment variable did not trigger propagateDirtiness()
 		h2 = n["out"].hash()
 		self.assertNotEqual( h1, h2 )
 

--- a/python/GafferTest/TypedPlugTest.py
+++ b/python/GafferTest/TypedPlugTest.py
@@ -227,11 +227,13 @@ class TypedPlugTest( GafferTest.TestCase ) :
 		self.assertEqual( n.numComputeCalls, 1 )
 
 		h = n["out"].hash()
-		self.assertEqual( n.numHashCalls, 2 )
+		# this hash should have been cached on the plug, so numHashCalls should have been
+		# unaffected:
+		self.assertEqual( n.numHashCalls, 1 )
 		self.assertEqual( n.numComputeCalls, 1 )
 
 		self.assertEqual( n["out"].getValue( _precomputedHash = h ), "hi" )
-		self.assertEqual( n.numHashCalls, 2 )
+		self.assertEqual( n.numHashCalls, 1 )
 		self.assertEqual( n.numComputeCalls, 1 )
 
 if __name__ == "__main__":

--- a/src/Gaffer/CompoundPlug.cpp
+++ b/src/Gaffer/CompoundPlug.cpp
@@ -42,6 +42,7 @@
 #include "IECore/MurmurHash.h"
 
 #include "Gaffer/CompoundPlug.h"
+#include "Gaffer/DependencyNode.h"
 #include "Gaffer/Node.h"
 #include "Gaffer/BlockedConnection.h"
 
@@ -79,4 +80,5 @@ void CompoundPlug::childAddedOrRemoved()
 	// plugs and removed by removing them.
 	/// \todo Do we really need this?
 	emitPlugSet();
+	DependencyNode::propagateDirtiness( this );
 }

--- a/src/Gaffer/DependencyNode.cpp
+++ b/src/Gaffer/DependencyNode.cpp
@@ -91,9 +91,6 @@ const Plug *DependencyNode::correspondingInput( const Plug *output ) const
 // Dirty propagation
 //////////////////////////////////////////////////////////////////////////
 
-namespace
-{
-
 // We don't emit dirtiness immediately for each plug as we traverse the
 // dependency graph for two reasons :
 //
@@ -107,7 +104,7 @@ namespace
 // The container used is stored per-thread as although it's illegal to be
 // monkeying with a script from multiple threads, it's perfectly legal to
 // be monkeying with a different script in each thread.
-class DirtyPlugs
+class DependencyNode::DirtyPlugs
 {
 
 	public :
@@ -128,6 +125,10 @@ class DirtyPlugs
 				if( node )
 				{
 					node->plugDirtiedSignal()( plug );
+				}
+				if( ValuePlug* vPlug = IECore::runTimeCast<ValuePlug>( plug ) )
+				{
+					vPlug->m_hashCaches.clear();
 				}
 			}
 		}
@@ -232,9 +233,7 @@ class DirtyPlugs
 
 };
 
-} // namespace
-
-static tbb::enumerable_thread_specific<DirtyPlugs> g_dirtyPlugs;
+tbb::enumerable_thread_specific<DependencyNode::DirtyPlugs> DependencyNode::g_dirtyPlugs;
 
 void DependencyNode::propagateDirtiness( Plug *plugToDirty )
 {

--- a/src/Gaffer/DependencyNode.cpp
+++ b/src/Gaffer/DependencyNode.cpp
@@ -126,10 +126,6 @@ class DependencyNode::DirtyPlugs
 				{
 					node->plugDirtiedSignal()( plug );
 				}
-				if( ValuePlug* vPlug = IECore::runTimeCast<ValuePlug>( plug ) )
-				{
-					vPlug->m_hashCaches.clear();
-				}
 			}
 		}
 
@@ -238,6 +234,10 @@ tbb::enumerable_thread_specific<DependencyNode::DirtyPlugs> DependencyNode::g_di
 void DependencyNode::propagateDirtiness( Plug *plugToDirty )
 {
 	DirtyPlugs &dirtyPlugs = g_dirtyPlugs.local();
+
+	// update the global graph update count, so the computation engine knows to
+	// invalidate hash caches from the last round of computations:
+	++ValuePlug::g_graphUpdateCount;
 
 	// If the container is currently empty then we are at the start of a traversal,
 	// and will emit plugDirtiedSignal() and empty the container before returning

--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -36,9 +36,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include <stack>
-
-#include "tbb/enumerable_thread_specific.h"
-
+#include "tbb/mutex.h"
 #include "boost/bind.hpp"
 #include "boost/format.hpp"
 #include "boost/unordered_map.hpp"
@@ -204,7 +202,6 @@ class ValuePlug::Computation
 			m_threadData->computationStack.pop();
 			if( m_threadData->computationStack.empty() )
 			{
-				m_threadData->hashCache.clear();
 				m_threadData->errorSource = NULL;
 			}
 		}
@@ -235,16 +232,24 @@ class ValuePlug::Computation
 				return *m_precomputedHash;
 			}
 
-			HashCache &hashCache = m_threadData->hashCache;
-			HashCacheKey key( m_resultPlug, Context::current()->hash() );
-			HashCache::iterator it = hashCache.find( key );
-			if( it != hashCache.end() )
+			static tbb::mutex m;
+			
+			
+			HashCache &hashCache = m_resultPlug->m_hashCaches.local();
+			IECore::MurmurHash key = Context::current()->hash();
+			HashCacheIterator it = hashCache.get<1>().find( key );
+			if( it != hashCache.get<1>().end() )
 			{
 				return it->second;
 			}
 
 			IECore::MurmurHash h = hashInternal();
-			hashCache[key] = h;
+			if( hashCache.size() == 5 )
+			{
+				tbb::mutex::scoped_lock l(m);
+				hashCache.get<0>().pop_front();
+			}
+			hashCache.get<1>().insert( std::make_pair(key, h) );
 			return h;
 		}
 
@@ -370,23 +375,6 @@ class ValuePlug::Computation
 			}
 		}
 
-		// During a single graph evaluation, we actually call ValuePlug::hash()
-		// many times for the same plugs. First hash() is called for the terminating plug,
-		// which will call hash() for all the upstream plugs, and then compute() is called
-		// for the terminating plug, which will call getValue() on the upstream plugs. But
-		// those upstream plugs will need to call their hash() again in getValue(), so their
-		// value can be cached. This ripples on up the chain, leading to quadratic complexity
-		// in the length of the chain of nodes - not good. Thanks is due to David Minor for
-		// being the first to point this out.
-		//
-		// We address this problem by keeping a small per-thread cache of hashes, indexed
-		// by the plug the hash is for and the context the hash was performed in. The
-		// typedefs below describe that data structure. Note that the entries in this cache
-		// are short lived - we flush the cache upon completion of each evaluation of the
-		// graph, as subsequent changes to plug values and connections invalidate our entries.
-		typedef std::pair<const ValuePlug *, IECore::MurmurHash> HashCacheKey;
-		typedef boost::unordered_map<HashCacheKey, IECore::MurmurHash> HashCache;
-
 		// A computation starts with a call to ValuePlug::getValue(), but the compute()
 		// that triggers will make calls to getValue() on upstream plugs too. We use this
 		// stack to keep track of the current computation - each upstream evaluation pushes
@@ -398,7 +386,6 @@ class ValuePlug::Computation
 		struct ThreadData
 		{
 			ThreadData() :	errorSource( NULL ) {}
-			HashCache hashCache;
 			ComputationStack computationStack;
 			const Plug *errorSource;
 		};
@@ -417,8 +404,7 @@ class ValuePlug::Computation
 		}
 
 		// A cache mapping from ValuePlug::hash() to the result of the previous computation
-		// for that hash. This allows us to cache results for faster repeat evaluation. Unlike
-		// the HashCache, the ValueCache persists from one graph evaluation to the next.
+		// for that hash. This allows us to cache results for faster repeat evaluation.
 		typedef IECore::LRUCache<IECore::MurmurHash, IECore::ConstObjectPtr> ValueCache;
 		static ValueCache g_valueCache;
 

--- a/src/GafferScene/BranchCreator.cpp
+++ b/src/GafferScene/BranchCreator.cpp
@@ -96,6 +96,10 @@ void BranchCreator::affects( const Plug *input, AffectedPlugsContainer &outputs 
 	if( input->parent<ScenePlug>() == inPlug() )
 	{
 		outputs.push_back( outPlug()->getChild<ValuePlug>( input->getName() ) );
+		if( input == inPlug()->childNamesPlug() )
+		{
+			outputs.push_back( mappingPlug() );
+		}
 	}
 	else if( input == parentPlug() )
 	{

--- a/src/GafferScene/Duplicate.cpp
+++ b/src/GafferScene/Duplicate.cpp
@@ -139,6 +139,10 @@ void Duplicate::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outp
 		outputs.push_back( outParentPlug() );
 		outputs.push_back( childNamesPlug() );
 	}
+	else if( input == inPlug()->childNamesPlug() )
+	{
+		outputs.push_back( childNamesPlug() );
+	}
 	else if( input == copiesPlug() )
 	{
 		outputs.push_back( childNamesPlug() );
@@ -149,7 +153,7 @@ void Duplicate::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outp
 	}
 	else if( input == childNamesPlug() )
 	{
-		outputs.push_back( outPlug()->childNamesPlug() );
+		outputs.push_back( getChild<Plug>("__mapping") );
 	}
 	else if( transformPlug()->isAncestorOf( input ) )
 	{

--- a/src/GafferScene/FreezeTransform.cpp
+++ b/src/GafferScene/FreezeTransform.cpp
@@ -85,14 +85,16 @@ void FreezeTransform::affects( const Gaffer::Plug *input, AffectedPlugsContainer
 	{
 		outputs.push_back( transformPlug() );
 	}
-	else if(
-		input == transformPlug() ||
-		input == filterPlug()
-	)
+	else if( input == filterPlug() )
+	{
+		outputs.push_back( transformPlug() );
+	}
+	else if( input == transformPlug() )
 	{
 		outputs.push_back( outPlug()->transformPlug() );
 		outputs.push_back( outPlug()->boundPlug() );
 		outputs.push_back( outPlug()->objectPlug() );
+
 	}
 }
 

--- a/src/GafferScene/Seeds.cpp
+++ b/src/GafferScene/Seeds.cpp
@@ -102,7 +102,7 @@ void Seeds::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
 	}
 	else if( input == namePlug() )
 	{
-		outputs.push_back( outPlug()->childNamesPlug() );
+		outputs.push_back( getChild<Plug>("__mapping") );
 	}
 }
 
@@ -167,7 +167,6 @@ IECore::ConstObjectPtr Seeds::computeBranchObject( const ScenePath &parentPath, 
 
 		PrimitivePtr result = runTimeCast<Primitive>( op->operate() );
 		result->variables["type"] = PrimitiveVariable( PrimitiveVariable::Constant, new StringData( pointTypePlug()->getValue() ) );
-
 		return result;
 	}
 	return outPlug()->objectPlug()->defaultValue();


### PR DESCRIPTION
Here's my experimentation with storing persistent hash caches on ValuePlugs and clearing them in propagateDirtiness. It's shown up a bunch of bugs in the dirty propagation mechanism which I've either fixed or added explanatory comments for in the test cases. The most annoying one seemed to be the GafferScene::SetFilter one, because the filter doesn't get touched by propagateDirtiness when you change the globals, but its value needs to change anyway. We could probably fix it by putting some kind of "plugDirtiedCount" variable in the context when we evaluate the filter, don't know if that's a good way of fixing it though.

This branch reduced the scene traversal time from 133 seconds to 70 seconds on a production scene with massive instancing because it wasn't hashing the globals over and over again, which was nice.