### PR TITLE
Copy/paste in plug popup menus

### DIFF
--- a/apps/gui/gui-1.py
+++ b/apps/gui/gui-1.py
@@ -128,14 +128,14 @@ class gui( Gaffer.Application ) :
 		assert( applicationRoot.isSame( self.root() ) )
 
 		data = applicationRoot.getClipboardContents()
-		if isinstance( data, IECore.StringData ) :
-			QtGui = GafferUI._qtImport( "QtGui" )
-			clipboard = QtGui.QApplication.clipboard()
-			try :
-				self.__ignoreQtClipboardContentsChanged = True # avoid triggering an unecessary copy back in __qtClipboardContentsChanged
-				clipboard.setText( data.value )
-			finally :
-				self.__ignoreQtClipboardContentsChanged = False
+
+		QtGui = GafferUI._qtImport( "QtGui" )
+		clipboard = QtGui.QApplication.clipboard()
+		try :
+			self.__ignoreQtClipboardContentsChanged = True # avoid triggering an unecessary copy back in __qtClipboardContentsChanged
+			clipboard.setText( str( data ) )
+		finally :
+			self.__ignoreQtClipboardContentsChanged = False
 				
 	def __qtClipboardContentsChanged( self ) :
 	

--- a/python/GafferUI/CompoundNumericPlugValueWidget.py
+++ b/python/GafferUI/CompoundNumericPlugValueWidget.py
@@ -110,14 +110,14 @@ class CompoundNumericPlugValueWidget( GafferUI.PlugValueWidget ) :
 		return self.__row
 
 	# Reimplemented to perform casting between vector and color types.
-	def _dropValue( self, dragDropEvent ) :
+	def _convertValue( self, value ) :
 
-		result = GafferUI.PlugValueWidget._dropValue( self, dragDropEvent )
+		result = GafferUI.PlugValueWidget._convertValue( self, value )
 		if result is not None :
 			return result
 
-		if isinstance( dragDropEvent.data, IECore.Data ) and hasattr( dragDropEvent.data, "value" ) :
-			value = dragDropEvent.data.value
+		if isinstance( value, IECore.Data ) and hasattr( value, "value" ) :
+			value = value.value
 			if hasattr( value, "dimensions" ) and isinstance( value.dimensions(), int ) :
 				with self.getContext() :
 					result = self.getPlug().getValue()

--- a/python/GafferUI/Menu.py
+++ b/python/GafferUI/Menu.py
@@ -137,7 +137,7 @@ class Menu( GafferUI.Widget ) :
 		elif isinstance( function, Gaffer.WeakMethod ) :
 			return inspect.getargspec( function.method() )[0][1:]
 		elif isinstance( function, functools.partial ) :
-			return inspect.getargspec( function.func )[0]
+			return self.__argNames( function.func )[0]
 
 		return []
 

--- a/python/GafferUI/PlugWidget.py
+++ b/python/GafferUI/PlugWidget.py
@@ -100,7 +100,7 @@ class PlugWidget( GafferUI.Widget ) :
 		layout.addWidget( self.__valueWidget._qtWidget() )
 
 		# The plugValueWidget() may have smarter drop behaviour than the labelPlugValueWidget(),
-		# because it has specialised PlugValueWidget._dropValue(). It's also more meaningful to the
+		# because it has specialised PlugValueWidget._convertValue(). It's also more meaningful to the
 		# user if we highlight the plugValueWidget() on dragEnter rather than the label. So we
 		# forward the dragEnter/dragLeave/drop signals from the labelPlugValueWidget() to the plugValueWidget().
 		self.__dragEnterConnection = self.__label.dragEnterSignal().connect( 0, Gaffer.WeakMethod( self.__labelDragEnter ) )

--- a/python/GafferUI/RandomUI.py
+++ b/python/GafferUI/RandomUI.py
@@ -222,6 +222,7 @@ def __popupMenu( menuDefinition, plugValueWidget ) :
 
 	input = plug.getInput()
 	if input is None and plugValueWidget._editable() :
+		menuDefinition.prepend( "/RandomiseDivider", { "divider" : True } )
 		menuDefinition.prepend( "/Randomise...", { "command" : IECore.curry( __createRandom, plug ) } )
 
 __popupMenuConnection = GafferUI.PlugValueWidget.popupMenuSignal().connect( __popupMenu )


### PR DESCRIPTION
This implements a fairly basic form of #601. It doesn't deal with fancy stuff like cut/paste for whole tab groups and so on - that will make more sense to do once we have some of the other UI refactoring in place. I did change the name of a protected method on PlugValueWidget, but searched GitHub and found no uses except those within Gaffer itself. The changes to Qt clipboard sync will need porting to Caribou, because there's a separate copy of them there.