### PR TITLE
Expression serialisation fixes

### DIFF
--- a/include/Gaffer/Expression.h
+++ b/include/Gaffer/Expression.h
@@ -113,7 +113,6 @@ class Expression : public ComputeNode
 		const ValuePlug *outPlug() const;
 
 		void plugSet( Plug *plug );
-		void parentChanged( GraphComponent *child, GraphComponent *oldParent );
 
 		void updatePlugs( const std::string &outPlugPath, std::vector<std::string> &inPlugPaths );
 

--- a/src/Gaffer/Expression.cpp
+++ b/src/Gaffer/Expression.cpp
@@ -296,11 +296,13 @@ void Expression::updatePlugs( const std::string &dstPlugPath, std::vector<std::s
 			throw IECore::Exception( boost::str( boost::format( "Source plug \"%s\" does not exist" ) % *it ) );
 		}
 		PlugPtr inPlug = srcPlug->createCounterpart( "plug", Plug::In );
+		inPlug->setFlags( Plug::Dynamic, true );
 		inPlugs->addChild( inPlug );
 		inPlug->setInput( srcPlug );
 	}
 
 	PlugPtr outPlug = dstPlug->createCounterpart( g_outPlugName, Plug::Out );
+	outPlug->setFlags( Plug::Dynamic, true );
 	setChild( g_outPlugName, outPlug );
 	dstPlug->setInput( outPlug );
 }

--- a/src/Gaffer/Expression.cpp
+++ b/src/Gaffer/Expression.cpp
@@ -78,7 +78,6 @@ Expression::Expression( const std::string &name )
 	);
 
 	plugSetSignal().connect( boost::bind( &Expression::plugSet, this, ::_1 ) );
-	parentChangedSignal().connect( boost::bind( &Expression::parentChanged, this, ::_1, ::_2 ) );
 }
 
 Expression::~Expression()
@@ -240,21 +239,6 @@ void Expression::plugSet( Plug *plug )
 			m_engine = 0;
 		}
 
-	}
-}
-
-void Expression::parentChanged( GraphComponent *child, GraphComponent *oldParent )
-{
-	assert( this == child );
-	if( oldParent == 0 && parent<GraphComponent>() )
-	{
-		// assume we've just been created and parented during the loading of a script.
-		// our plugs are already set up, so we just need to make sure we have an engine.
-		std::string expression = expressionPlug()->getValue();
-		if( expression.size() )
-		{
-			m_engine = Engine::create( enginePlug()->getValue(), expression );
-		}
 	}
 }
 

--- a/src/Gaffer/Expression.cpp
+++ b/src/Gaffer/Expression.cpp
@@ -263,6 +263,7 @@ void Expression::updatePlugs( const std::string &dstPlugPath, std::vector<std::s
 	}
 
 	// otherwise try to create connections to the plugs the expression wants
+	/// \todo Early out if the plugs we have are already suitable.
 
 	ValuePlug *dstPlug = p->descendant<ValuePlug>( dstPlugPath );
 	if( !dstPlug )

--- a/src/GafferBindings/ExpressionBinding.cpp
+++ b/src/GafferBindings/ExpressionBinding.cpp
@@ -39,7 +39,6 @@
 #include "IECore/MessageHandler.h"
 #include "IECorePython/RefCountedBinding.h"
 #include "IECorePython/ScopedGILLock.h"
-#include "IECorePython/Wrapper.h"
 
 #include "Gaffer/Expression.h"
 #include "GafferBindings/DependencyNodeBinding.h"
@@ -53,106 +52,113 @@ using namespace Gaffer;
 namespace
 {
 
-class EngineWrapper : public Expression::Engine, public IECorePython::Wrapper<Expression::Engine>
+class EngineWrapper : public IECorePython::RefCountedWrapper<Expression::Engine>
 {
 	public :
 
 		EngineWrapper( PyObject *self )
-				:	Engine(), IECorePython::Wrapper<Expression::Engine>( self, this )
+				:	IECorePython::RefCountedWrapper<Expression::Engine>( self )
 		{
 		}
 
 		virtual std::string outPlug()
 		{
-			IECorePython::ScopedGILLock gilLock;
-			try
+			if( isSubclassed() )
 			{
-				boost::python::override f = this->get_override( "outPlug" );
-				if( f )
+				IECorePython::ScopedGILLock gilLock;
+				try
 				{
-					return f();
+					object f = this->methodOverride( "outPlug" );
+					if( f )
+					{
+						return extract<std::string>( f() );
+					}
 				}
-				else
+				catch( const error_already_set &e )
 				{
-					msg( IECore::Msg::Error, "EngineWrapper::outPlug", "outPlug method not defined in python." );
+					translatePythonException();
 				}
 			}
-			catch( const error_already_set &e )
-			{
-				translatePythonException();
-			}
+			
+			msg( IECore::Msg::Error, "EngineWrapper::outPlug", "outPlug method not defined in python." );
 			return "";
 		}
 
 		virtual void inPlugs( std::vector<std::string> &plugs )
 		{
-			IECorePython::ScopedGILLock gilLock;
-			try
+			if( isSubclassed() )
 			{
-				override f = this->get_override( "inPlugs" );
-				if( f )
+				IECorePython::ScopedGILLock gilLock;
+				try
 				{
-					list pythonPlugs = f();
-					container_utils::extend_container( plugs, pythonPlugs );
+					object f = this->methodOverride( "inPlugs" );
+					if( f )
+					{
+						list pythonPlugs = extract<list>( f() );
+						container_utils::extend_container( plugs, pythonPlugs );
+						return;
+					}
 				}
-				else
+				catch( const error_already_set &e )
 				{
-					msg( IECore::Msg::Error, "EngineWrapper::inPlugs", "inPlugs method not defined in python." );
+					translatePythonException();
 				}
 			}
-			catch( const error_already_set &e )
-			{
-				translatePythonException();
-			}
+
+			msg( IECore::Msg::Error, "EngineWrapper::inPlugs", "inPlugs method not defined in python." );
 		}
 
 		virtual void contextNames( std::vector<IECore::InternedString> &names )
 		{
-			IECorePython::ScopedGILLock gilLock;
-			try
+			if( isSubclassed() )
 			{
-				override f = this->get_override( "contextNames" );
-				if( f )
+				IECorePython::ScopedGILLock gilLock;
+				try
 				{
-					list pythonNames = f();
-					container_utils::extend_container( names, pythonNames );
+					object f = this->methodOverride( "contextNames" );
+					if( f )
+					{
+						list pythonNames = extract<list>( f() );
+						container_utils::extend_container( names, pythonNames );
+						return;
+					}
 				}
-				else
+				catch( const error_already_set &e )
 				{
-					msg( IECore::Msg::Error, "EngineWrapper::contextNames", "contextNames method not defined in python." );
+					translatePythonException();
 				}
 			}
-			catch( const error_already_set &e )
-			{
-				translatePythonException();
-			}
+
+			msg( IECore::Msg::Error, "EngineWrapper::contextNames", "contextNames method not defined in python." );
 		}
 
 		virtual void execute( const Context *context, const std::vector<const ValuePlug *> &proxyInputs, ValuePlug *proxyOutput )
 		{
-			IECorePython::ScopedGILLock gilLock;
-			try
+			if( isSubclassed() )
 			{
-				override f = this->get_override( "execute" );
-				if( f )
+				IECorePython::ScopedGILLock gilLock;
+				try
 				{
-					list pythonProxyInputs;
-					for( std::vector<const ValuePlug *>::const_iterator it = proxyInputs.begin(); it!=proxyInputs.end(); it++ )
+					object f = this->methodOverride( "execute" );
+					if( f )
 					{
-						pythonProxyInputs.append( PlugPtr( const_cast<ValuePlug *>( *it ) ) );
-					}
+						list pythonProxyInputs;
+						for( std::vector<const ValuePlug *>::const_iterator it = proxyInputs.begin(); it!=proxyInputs.end(); it++ )
+						{
+							pythonProxyInputs.append( PlugPtr( const_cast<ValuePlug *>( *it ) ) );
+						}
 
-					f( ContextPtr( const_cast<Context *>( context ) ), pythonProxyInputs, ValuePlugPtr( proxyOutput ) );
+						f( ContextPtr( const_cast<Context *>( context ) ), pythonProxyInputs, ValuePlugPtr( proxyOutput ) );
+						return;
+					}
 				}
-				else
+				catch( const error_already_set &e )
 				{
-					msg( IECore::Msg::Error, "EngineWrapper::execute", "execute method not defined in python." );
+					translatePythonException();
 				}
 			}
-			catch( const error_already_set &e )
-			{
-				translatePythonException();
-			}
+			
+			msg( IECore::Msg::Error, "EngineWrapper::execute", "execute method not defined in python." );
 		}
 
 };

--- a/src/GafferBindings/ExpressionBinding.cpp
+++ b/src/GafferBindings/ExpressionBinding.cpp
@@ -200,6 +200,47 @@ tuple registeredEnginesWrapper()
 	return boost::python::tuple( l );
 }
 
+class ExpressionSerialiser : public NodeSerialiser
+{
+
+	virtual bool childNeedsSerialisation( const Gaffer::GraphComponent *child ) const
+	{
+		const Expression *expression = child->parent<Expression>();
+		if( child == expression->expressionPlug() )
+		{
+			// We'll serialise this manually ourselves in
+			// postScript() - see comments there.
+			return false;
+		}
+		return NodeSerialiser::childNeedsSerialisation( child );
+	}
+
+	virtual std::string postScript( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const
+	{
+		std::string result = NodeSerialiser::postScript( graphComponent, identifier, serialisation );
+
+		// When the expression plug is set, the Expression node creates an engine,
+		// parses the expression, and connects itself up in the graph. We must therefore
+		// delay the setting of the expression until the whole graph has been created,
+		// otherwise we'll be hunting for plugs referenced in the expression which have
+		// not yet been created. The sad thing about all this is that the serialisation
+		// has already reproduced the network we need anyway - the Expression node doesn't
+		// even need to do anything.
+		//
+		/// \todo We could consider not using plugSetSignal() to trigger expression
+		/// parsing, instead using an explicit method on the Expression class. In that
+		/// case we wouldn't need any custom serialisation at all, but the UI code and
+		/// scripts creating expressions would need to be updated to use the method
+		/// rather than to just set the plug.
+		const Expression *expression = static_cast<const Expression *>( graphComponent );
+		const Serialiser *s = Serialisation::acquireSerialiser( expression->expressionPlug() );
+		result += s->postConstructor( expression->expressionPlug(), serialisation.identifier( expression->expressionPlug() ), serialisation );
+
+		return result;
+	}
+
+};
+
 } // namespace
 
 void GafferBindings::bindExpression()
@@ -212,5 +253,7 @@ void GafferBindings::bindExpression()
 		.def( "registerEngine", &registerEngine ).staticmethod( "registerEngine" )
 		.def( "registeredEngines", &registeredEnginesWrapper ).staticmethod( "registeredEngines" )
 	;
+
+	Serialisation::registerSerialiser( Expression::staticTypeId(), new ExpressionSerialiser );
 
 }

--- a/src/GafferBindings/ExpressionBinding.cpp
+++ b/src/GafferBindings/ExpressionBinding.cpp
@@ -50,6 +50,9 @@ using namespace boost::python;
 using namespace GafferBindings;
 using namespace Gaffer;
 
+namespace
+{
+
 class EngineWrapper : public Expression::Engine, public IECorePython::Wrapper<Expression::Engine>
 {
 	public :
@@ -174,12 +177,12 @@ struct ExpressionEngineCreator
 
 };
 
-static void registerEngine( const std::string &engineType, object creator )
+void registerEngine( const std::string &engineType, object creator )
 {
 	Expression::Engine::registerEngine( engineType, ExpressionEngineCreator( creator ) );
 }
 
-static tuple registeredEnginesWrapper()
+tuple registeredEnginesWrapper()
 {
 	std::vector<std::string> engineTypes;
 	Expression::Engine::registeredEngines( engineTypes );
@@ -190,6 +193,8 @@ static tuple registeredEnginesWrapper()
 	}
 	return boost::python::tuple( l );
 }
+
+} // namespace
 
 void GafferBindings::bindExpression()
 {


### PR DESCRIPTION
This fixes two expression serialisation bugs, reported in #1081 and #1243 :

- Expressions created before the plugs they reference failed to load.
- Extraneous "inN" and "outN" plugs appeared after serialisation and loading.

I've also taken the opportunity to tidy up a few details of the expression node and bindings.