### PR TITLE
PathFilter optimization + disabling caching for filters

### DIFF
--- a/include/GafferScene/PathFilter.h
+++ b/include/GafferScene/PathFilter.h
@@ -40,7 +40,7 @@
 #include "Gaffer/TypedObjectPlug.h"
 
 #include "GafferScene/Filter.h"
-#include "GafferScene/PathMatcher.h"
+#include "GafferScene/PathMatcherData.h"
 
 namespace GafferScene
 {
@@ -71,8 +71,20 @@ class PathFilter : public Filter
 
 	private :
 
+		// Filter matches are computed using a PathMatcher data structure in one of two ways:
+		// if pathsPlug() is receiving data from an output plug, we compute the PathMatcher
+		// using an intermediate plug called __pathMatcher, as it's possible the paths we're
+		// testing against could vary depending on the context:
+		
 		Gaffer::ObjectPlug *pathMatcherPlug();
 		const Gaffer::ObjectPlug *pathMatcherPlug() const;
+
+		// If that's not the case, we can improve performance by precomputing the PathMatcher
+		// whenever the plug is dirtied, which saves on graph evaluations:
+		
+		void plugDirtied( const Gaffer::Plug *plug );
+
+		PathMatcherDataPtr m_pathMatcher;
 
 		static size_t g_firstPlugIndex;
 

--- a/src/GafferScene/Filter.cpp
+++ b/src/GafferScene/Filter.cpp
@@ -51,7 +51,7 @@ Filter::Filter( const std::string &name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new BoolPlug( "enabled", Gaffer::Plug::In, true ) );
-	addChild( new IntPlug( "out", Gaffer::Plug::Out, NoMatch, NoMatch, EveryMatch ) );
+	addChild( new IntPlug( "out", Gaffer::Plug::Out, NoMatch, NoMatch, EveryMatch, Plug::Default & ( ~Plug::Cacheable ) ) );
 }
 
 Filter::~Filter()

--- a/src/GafferScene/PathFilter.cpp
+++ b/src/GafferScene/PathFilter.cpp
@@ -35,6 +35,8 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
+#include <boost/bind.hpp>
+
 #include "Gaffer/Context.h"
 
 #include "GafferScene/ScenePlug.h"
@@ -56,6 +58,8 @@ PathFilter::PathFilter( const std::string &name )
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new StringVectorDataPlug( "paths", Plug::In, new StringVectorData ) );
 	addChild( new ObjectPlug( "__pathMatcher", Plug::Out, new PathMatcherData ) );
+	
+	plugDirtiedSignal().connect( boost::bind( &PathFilter::plugDirtied, this, ::_1 ) );
 }
 
 PathFilter::~PathFilter()
@@ -80,6 +84,31 @@ Gaffer::ObjectPlug *PathFilter::pathMatcherPlug()
 const Gaffer::ObjectPlug *PathFilter::pathMatcherPlug() const
 {
 	return getChild<Gaffer::ObjectPlug>( g_firstPlugIndex + 1 );
+}
+
+void PathFilter::plugDirtied( const Gaffer::Plug *plug )
+{
+	if( plug == pathsPlug() )
+	{
+		//\todo: share this logic with Switch::variesWithContext()
+		Plug* sourcePlug = pathsPlug()->source<Plug>();
+		if( sourcePlug->direction() == Plug::Out && IECore::runTimeCast<const ComputeNode>( sourcePlug->node() ) )
+		{
+			// pathsPlug() is receiving data from a plug whose value is context varying, meaning 
+			// we need to use the intermediate pathMatcherPlug() in computeMatch() instead:
+			
+			m_pathMatcher = 0;
+		}
+		else
+		{
+			// pathsPlug() value is not context varying, meaning we can save on graph evaluations
+			// by just precomputing it here and directly using it in computeMatch():
+			
+			ConstStringVectorDataPtr paths = pathsPlug()->getValue();
+			m_pathMatcher = new PathMatcherData;
+			m_pathMatcher->writable().init( paths->readable().begin(), paths->readable().end() );
+		}
+	}
 }
 
 void PathFilter::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
@@ -138,7 +167,11 @@ unsigned PathFilter::computeMatch( const ScenePlug *scene, const Gaffer::Context
 	const ScenePathData *pathData = context->get<ScenePathData>( ScenePlug::scenePathContextName, 0 );
 	if( pathData )
 	{
-		ConstPathMatcherDataPtr pathMatcher = boost::static_pointer_cast<const PathMatcherData>( pathMatcherPlug()->getValue() );
+		// If we have a precomputed PathMatcher, we use that to compute matches, otherwise
+		// we grab the PathMatcher from the intermediate plug (which is a bit more expensive
+		// as it involves graph evaluations):
+		
+		ConstPathMatcherDataPtr pathMatcher = m_pathMatcher ? m_pathMatcher : boost::static_pointer_cast<const PathMatcherData>( pathMatcherPlug()->getValue() );
 		return pathMatcher->readable().match( pathData->readable() );
 	}
 	return NoMatch;

--- a/src/GafferScene/PathFilter.cpp
+++ b/src/GafferScene/PathFilter.cpp
@@ -97,7 +97,7 @@ void PathFilter::plugDirtied( const Gaffer::Plug *plug )
 			// pathsPlug() is receiving data from a plug whose value is context varying, meaning 
 			// we need to use the intermediate pathMatcherPlug() in computeMatch() instead:
 			
-			m_pathMatcher = 0;
+			m_pathMatcher = NULL;
 		}
 		else
 		{
@@ -152,7 +152,7 @@ void PathFilter::compute( Gaffer::ValuePlug *output, const Gaffer::Context *cont
 void PathFilter::hashMatch( const ScenePlug *scene, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	typedef IECore::TypedData<ScenePlug::ScenePath> ScenePathData;
-	const ScenePathData *pathData = context->get<ScenePathData>( ScenePlug::scenePathContextName, 0 );
+	const ScenePathData *pathData = context->get<ScenePathData>( ScenePlug::scenePathContextName, NULL );
 	if( pathData )
 	{
 		const ScenePlug::ScenePath &path = pathData->readable();
@@ -164,7 +164,7 @@ void PathFilter::hashMatch( const ScenePlug *scene, const Gaffer::Context *conte
 unsigned PathFilter::computeMatch( const ScenePlug *scene, const Gaffer::Context *context ) const
 {
 	typedef IECore::TypedData<ScenePlug::ScenePath> ScenePathData;
-	const ScenePathData *pathData = context->get<ScenePathData>( ScenePlug::scenePathContextName, 0 );
+	const ScenePathData *pathData = context->get<ScenePathData>( ScenePlug::scenePathContextName, NULL );
 	if( pathData )
 	{
 		// If we have a precomputed PathMatcher, we use that to compute matches, otherwise


### PR DESCRIPTION
Improved performance on a big instancing scene by about 20%. I should probably test this on some other scenes before merging, and maybe I should get rid of the hashMatch() methods too?