### PR TITLE
NodeUI to display non-default plugs differently

### DIFF
--- a/python/Gaffer/NodeAlgo.py
+++ b/python/Gaffer/NodeAlgo.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2014, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2014-2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -113,6 +113,17 @@ def applyUserDefaults( nodeOrNodes ) :
 def hasUserDefault( plug ) :
 	
 	return Gaffer.Metadata.plugValue( plug, "userDefault" ) is not None
+
+def isSetToUserDefault( plug ) :
+	
+	if not hasattr( plug, "getValue" ) :
+		return False
+	
+	userDefault = Gaffer.Metadata.plugValue( plug, "userDefault" )
+	if userDefault is None :
+		return False 
+	
+	return userDefault == plug.getValue()
 
 def applyUserDefault( plug ) :
 	

--- a/python/GafferCortexUI/OpDialogue.py
+++ b/python/GafferCortexUI/OpDialogue.py
@@ -103,6 +103,11 @@ class OpDialogue( GafferUI.Dialogue ) :
 			opInstance = opInstanceOrOpHolderInstance
 			self.__node = Gaffer.ParameterisedHolderNode()
 			self.__node.setParameterised( opInstance )
+			# set the current plug values as userDefaults to provide
+			# a clean NodeUI based on the initial settings of the Op.
+			# we assume that if an OpHolder was passed directly then
+			# the metadata has already been setup as preferred.
+			self.__setUserDefaults( self.__node )
 		else :
 			self.__node = opInstanceOrOpHolderInstance
 			opInstance = self.__node.getParameterised()[0]
@@ -474,3 +479,12 @@ class OpDialogue( GafferUI.Dialogue ) :
 			# show the messages. after this we assume that if the window is smaller
 			# it is because the user has made it so, and wishes it to remain so.
 			self.__messageCollapsibleStateChangedConnection = None
+
+	def __setUserDefaults( self, graphComponent ) :
+
+		if isinstance( graphComponent, Gaffer.Plug ) and hasattr( graphComponent, "getValue" ) :
+			with IECore.IgnoredExceptions( Exception ) :
+				Gaffer.Metadata.registerPlugValue( graphComponent, "userDefault", graphComponent.getValue() )
+		
+		for child in graphComponent.children() :
+			self.__setUserDefaults( child )

--- a/python/GafferTest/NodeAlgoTest.py
+++ b/python/GafferTest/NodeAlgoTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2014, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2014-2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -49,8 +49,10 @@ class NodeAlgoTest( GafferTest.TestCase ) :
 		self.assertFalse( Gaffer.NodeAlgo.hasUserDefault( node["op1"] ) )
 		Gaffer.Metadata.registerPlugValue( GafferTest.AddNode.staticTypeId(), "op1", "userDefault", IECore.IntData( 7 ) )
 		self.assertTrue( Gaffer.NodeAlgo.hasUserDefault( node["op1"] ) )
+		self.assertFalse( Gaffer.NodeAlgo.isSetToUserDefault( node["op1"] ) )
 		Gaffer.NodeAlgo.applyUserDefaults( node )
 		self.assertEqual( node["op1"].getValue(), 7 )
+		self.assertTrue( Gaffer.NodeAlgo.isSetToUserDefault( node["op1"] ) )
 		
 		# even if it's registered, it doesn't get applied outside of the NodeMenu UI
 		node2 = GafferTest.AddNode()
@@ -69,6 +71,7 @@ class NodeAlgoTest( GafferTest.TestCase ) :
 		self.assertFalse( Gaffer.NodeAlgo.hasUserDefault( node3["op1"] ) )
 		Gaffer.NodeAlgo.applyUserDefaults( node3 )
 		self.assertEqual( node3["op1"].getValue(), 0 )
+		self.assertFalse( Gaffer.NodeAlgo.isSetToUserDefault( node["op1"] ) )
 	
 	def testCompoundPlug( self ) :
 		
@@ -76,18 +79,24 @@ class NodeAlgoTest( GafferTest.TestCase ) :
 		
 		self.assertEqual( node["p"]["s"].getValue(), "" )
 		Gaffer.Metadata.registerPlugValue( GafferTest.CompoundPlugNode.staticTypeId(), "p.s", "userDefault", IECore.StringData( "from the metadata" ) )
+		self.assertFalse( Gaffer.NodeAlgo.isSetToUserDefault( node["p"]["s"] ) )
 		Gaffer.NodeAlgo.applyUserDefaults( node )
 		self.assertEqual( node["p"]["s"].getValue(), "from the metadata" )
+		self.assertTrue( Gaffer.NodeAlgo.isSetToUserDefault( node["p"]["s"] ) )
 		
 		# override the metadata for this particular instance
 		Gaffer.Metadata.registerPlugValue( node["p"]["s"], "userDefault", IECore.StringData( "i am special" ) )
+		self.assertFalse( Gaffer.NodeAlgo.isSetToUserDefault( node["p"]["s"] ) )
 		Gaffer.NodeAlgo.applyUserDefaults( node )
 		self.assertEqual( node["p"]["s"].getValue(), "i am special" )
+		self.assertTrue( Gaffer.NodeAlgo.isSetToUserDefault( node["p"]["s"] ) )
 		
 		# this node still gets the original userDefault
 		node2 = GafferTest.CompoundPlugNode()
+		self.assertFalse( Gaffer.NodeAlgo.isSetToUserDefault( node2["p"]["s"] ) )
 		Gaffer.NodeAlgo.applyUserDefaults( node2 )
 		self.assertEqual( node2["p"]["s"].getValue(), "from the metadata" )
+		self.assertTrue( Gaffer.NodeAlgo.isSetToUserDefault( node2["p"]["s"] ) )
 	
 	def testSeveral( self ) :	
 		

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2013-2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -126,7 +126,10 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		valueChanged = plug.getInput() is not None
 		if not valueChanged and isinstance( plug, Gaffer.ValuePlug ) :
-			valueChanged = valueChanged or not plug.isSetToDefault()
+			if Gaffer.NodeAlgo.hasUserDefault( plug ) :
+				valueChanged = valueChanged or not Gaffer.NodeAlgo.isSetToUserDefault( plug )
+			else :
+				valueChanged = valueChanged or not plug.isSetToDefault()
 		self.__setValueChanged( valueChanged )
 
 	# Sets whether or not the label be rendered in a ValueChanged state.

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -57,6 +57,7 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 			horizontalAlignment = horizontalAlignment,
 			verticalAlignment = verticalAlignment,
 		)
+		self.__label._qtWidget().setObjectName( "gafferPlugLabel" )
 		layout.addWidget( self.__label._qtWidget() )
 
 		self.__editableLabel = None # we'll make this lazily as needed
@@ -123,10 +124,26 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 			not plug.getFlags( Gaffer.Plug.Flags.ReadOnly )
 		)
 
-		highlighted = plug.getInput() is not None
-		if not highlighted and isinstance( plug, Gaffer.ValuePlug ) :
-			highlighted = highlighted or not plug.isSetToDefault()
-		self.__label.setHighlighted( highlighted )
+		valueChanged = plug.getInput() is not None
+		if not valueChanged and isinstance( plug, Gaffer.ValuePlug ) :
+			valueChanged = valueChanged or not plug.isSetToDefault()
+		self.__setValueChanged( valueChanged )
+
+	# Sets whether or not the label be rendered in a ValueChanged state.
+	def __setValueChanged( self, valueChanged ) :
+
+		if valueChanged == self.__getValueChanged() :
+			return
+
+		self.__label._qtWidget().setProperty( "gafferValueChanged", GafferUI._Variant.toVariant( valueChanged ) )
+		self.__label._repolish()
+
+	def __getValueChanged( self ) :
+
+		if "gafferValueChanged" not in self.__label._qtWidget().dynamicPropertyNames() :
+			return False
+
+		return GafferUI._Variant.fromVariant( self.__label._qtWidget().property( "gafferValueChanged" ) )
 
 	def __dragBegin( self, widget, event ) :
 

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -74,6 +74,15 @@ _styleSheet = string.Template(
 
 	}
 
+	QLabel#gafferPlugLabel[gafferValueChanged=\"true\"] {
+
+		background-image: url($GAFFER_ROOT/graphics/valueChanged.png);
+		background-repeat: no-repeat;
+		background-position: left;
+		padding-left: 20px;
+
+	}
+
 	QMenuBar {
 
 		background-color: $backgroundDarkest;

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -2460,5 +2460,22 @@
        style="fill:#bb2b2b;fill-opacity:1;stroke:#3c3c3c;stroke-width:3.68261814000000021;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
        sodipodi:type="arc"
        inkscape:label="#path3352" />
+    <path
+       sodipodi:type="star"
+       style="fill:#69ffa5;fill-opacity:0.99215686;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:0.5598439;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="forExport:valueChanged"
+       sodipodi:sides="6"
+       sodipodi:cx="298.875"
+       sodipodi:cy="13.687498"
+       sodipodi:r1="5.8454323"
+       sodipodi:r2="1.2886781"
+       sodipodi:arg1="0.94448073"
+       sodipodi:arg2="1.4443827"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 302.30138,18.423424 -3.26391,-3.457531 -2.55071,4.0569 1.36235,-4.555392 -4.78873,-0.180534 4.62626,-1.097861 -2.23802,-4.2374343 3.26391,3.4575313 2.55071,-4.0569002 -1.36235,4.5553922 4.78873,0.180534 -4.62626,1.097861 2.23802,4.237434 z"
+       transform="matrix(1.1039167,-0.49853331,0.49895085,1.1048412,55.474744,203.81434)"
+       inkscape:label="#path3064" />
   </g>
 </svg>


### PR DESCRIPTION
Plug labels now display an icon when the value differs from the default. I surveyed several key users, and demoed several possibilities for them, including bold, italics, varied levels of white/grey, and finally this icon. All users surveyed preferred the icon.

Along with the change to an icon, I've changed the behaviour so that plugs set to their userDefault no longer show this change, but plugs set to their API default do now show the icon. See 5f0a8abdb03ab154a14c0e688f3e8977ba066724 for a discussion of my thinking on that.

Finally, the OpDialogue sets userDefaults for all plugs during initialization. This was mainly motivated by our use in Jabuka, where almost every Op parameter is set to a non-default value prior to the window appearing. Note that we're only doing this when the OpDialogue is initialized with an Op instance, and not when it is given an OpHolder directly (as in the op app), on the assumption that a client providing a node directly has already configured it as desired.

Fixes #1216.