### PR TITLE
Optimised CompoundDataPlug::hash() to ignore disabled members.

### DIFF
--- a/include/Gaffer/CompoundDataPlug.h
+++ b/include/Gaffer/CompoundDataPlug.h
@@ -127,6 +127,9 @@ class CompoundDataPlug : public Gaffer::CompoundPlug
 		/// Extracts a Data value from a plug previously created with createPlugFromData().
 		static IECore::DataPtr extractDataFromPlug( const ValuePlug *plug );
 
+		virtual IECore::MurmurHash hash() const;
+		void hash( IECore::MurmurHash &h ) const;
+
 	private :
 
 		template<typename T>

--- a/python/GafferSceneTest/StandardOptionsTest.py
+++ b/python/GafferSceneTest/StandardOptionsTest.py
@@ -75,6 +75,7 @@ class StandardOptionsTest( GafferSceneTest.SceneTestCase ) :
 
 		h = o2["out"]["globals"].hash()
 
+		o1["options"]["renderResolution"]["enabled"].setValue( True )
 		o1["options"]["renderResolution"]["value"].setValue( IECore.V2i( 10 ) )
 
 		self.assertNotEqual( o2["out"]["globals"].hash(), h )

--- a/python/GafferTest/CompoundDataPlugTest.py
+++ b/python/GafferTest/CompoundDataPlugTest.py
@@ -348,6 +348,45 @@ class CompoundDataPlugTest( GafferTest.TestCase ) :
 
 		assertPostconditions( s2 )
 
+	def testHashOmitsDisabledMembers( self ) :
+
+		p = Gaffer.CompoundDataPlug()
+		h1 = p.hash()
+
+		m1 = p.addOptionalMember( "test1", 10, enabled = False )
+		m2 = p.addOptionalMember( "test2", 10, enabled = False )
+
+		# even though we've added members, they're both
+		# disabled, so as far as the hash is concerned, they're
+		# not there.
+		h2 = p.hash()
+		self.assertEqual( h1, h2 )
+
+		# when we enable one, the hash should change.
+		m1["enabled"].setValue( True )
+		h3 = p.hash()
+		self.assertNotEqual( h2, h3 )
+
+		# and it should continue to change as we change the
+		# name and value for the enabled member.
+
+		m1["value"].setValue( 20 )
+		h4 = p.hash()
+		self.assertNotEqual( h3, h4 )
+
+		m1["name"].setValue( "test3" )
+		h5 = p.hash()
+		self.assertNotEqual( h4, h5 )
+
+		# but changing the name and value for the disabled
+		# member should have no effect at all.
+		
+		m2["value"].setValue( 40 )
+		self.assertEqual( h5, p.hash() )
+
+		m2["name"].setValue( "test4" )
+		self.assertEqual( h5, p.hash() )
+
 if __name__ == "__main__":
 	unittest.main()
 

--- a/src/Gaffer/CompoundDataPlug.cpp
+++ b/src/Gaffer/CompoundDataPlug.cpp
@@ -221,6 +221,31 @@ void CompoundDataPlug::fillCompoundData( IECore::CompoundDataMap &compoundDataMa
 	}
 }
 
+IECore::MurmurHash CompoundDataPlug::hash() const
+{
+	IECore::MurmurHash h;
+	for( MemberPlugIterator it( this ); it != it.end(); ++it )
+	{
+		const MemberPlug *plug = it->get();
+		bool active = true;
+		if( plug->children().size() == 3 )
+		{
+			active = plug->getChild<BoolPlug>( 2 )->getValue();
+		}
+		if( active )
+		{
+			plug->getChild<ValuePlug>( 0 )->hash( h );
+			plug->getChild<ValuePlug>( 1 )->hash( h );
+		}
+	}
+	return h;
+}
+
+void CompoundDataPlug::hash( IECore::MurmurHash &h ) const
+{
+	h.append( hash() );
+}
+
 void CompoundDataPlug::fillCompoundObject( IECore::CompoundObject::ObjectMap &compoundObjectMap ) const
 {
 	std::string name;


### PR DESCRIPTION
It's quite common to have a lot of disabled members in nodes like StandardAttributes/StandardOptions etc, because everything starts out disabled and users only turn on what they need.

This knocks 20% off the hashing of globals for a production benchmark.