### PR TITLE
Added support for the user data multiLineShort

### DIFF
--- a/python/GafferUI/MultiLineStringPlugValueWidget.py
+++ b/python/GafferUI/MultiLineStringPlugValueWidget.py
@@ -67,6 +67,9 @@ class MultiLineStringPlugValueWidget( GafferUI.PlugValueWidget ) :
 		if self.getPlug() is not None :
 			with self.getContext() :
 				self.__textWidget.setText( self.getPlug().getValue() )
+				
+			fixedLineHeight = Gaffer.Metadata.plugValue( self.getPlug(), "fixedLineHeight" )
+			self.__textWidget.setFixedLineHeight( fixedLineHeight )
 
 		self.__textWidget.setEditable( self._editable() )
 

--- a/python/GafferUI/MultiLineTextWidget.py
+++ b/python/GafferUI/MultiLineTextWidget.py
@@ -47,7 +47,7 @@ class MultiLineTextWidget( GafferUI.Widget ) :
 
 	WrapMode = IECore.Enum.create( "None", "Word", "Character", "WordOrCharacter" )
 
-	def __init__( self, text="", editable=True, wrapMode=WrapMode.WordOrCharacter, **kw ) :
+	def __init__( self, text="", editable=True, wrapMode=WrapMode.WordOrCharacter, fixedLineHeight=None, **kw ) :
 
 		GafferUI.Widget.__init__( self, _PlainTextEdit(), **kw )
 
@@ -68,6 +68,7 @@ class MultiLineTextWidget( GafferUI.Widget ) :
 		self.setText( text )
 		self.setEditable( editable )
 		self.setWrapMode( wrapMode )
+		self.setFixedLineHeight( fixedLineHeight )
 
  		self.__dragEnterConnection = self.dragEnterSignal().connect( Gaffer.WeakMethod( self.__dragEnter ) )
  		self.__dragMoveConnection = self.dragMoveSignal().connect( Gaffer.WeakMethod( self.__dragMove ) )
@@ -131,6 +132,14 @@ class MultiLineTextWidget( GafferUI.Widget ) :
 			QtGui.QTextOption.WrapAnywhere : self.WrapMode.Character,
 			QtGui.QTextOption.WrapAtWordBoundaryOrAnywhere : self.WrapMode.WordOrCharacter,
 		}[self._qtWidget().wordWrapMode()]
+
+	def setFixedLineHeight( self, fixedLineHeight ) :
+
+		self._qtWidget().setFixedLineHeight( fixedLineHeight )
+		
+	def getFixedLineHeight( self ) :
+
+		return self._qtWidget().getFixedLineHeight()
 
 	def setCursorPosition( self, position ) :
 
@@ -319,8 +328,55 @@ class MultiLineTextWidget( GafferUI.Widget ) :
 class _PlainTextEdit( QtGui.QPlainTextEdit ) :
 
 	def __init__( self, parent = None ) :
-
 		QtGui.QPlainTextEdit.__init__( self, parent )
+		self.__fixedLineHeight = None
+		self.__widgetFullyBuilt = False
+		
+	def setFixedLineHeight( self, fixedLineHeight ) :
+		
+		self.__fixedLineHeight = fixedLineHeight
+
+		self.setSizePolicy(
+			self.sizePolicy().horizontalPolicy(),
+			QtGui.QSizePolicy.Expanding if self.__fixedLineHeight is None else QtGui.QSizePolicy.Fixed
+		)
+		
+		self.updateGeometry()
+
+	def getFixedLineHeight( self ) :
+
+		return self.__fixedLineHeight
+	
+	def __computeHeight( self, size ) :
+		
+		fixedLineHeight = self.getFixedLineHeight()
+		
+		# when the multiline is displaying fixed lines
+		if fixedLineHeight is not None :
+
+			# computing the font metrics based on the number of lines
+			height = self.fontMetrics().boundingRect( "M" ).height() * fixedLineHeight
+			
+			# also, we need to compute the widget margins to frame the fixed lines nicely 
+			margin = self.contentsMargins().top() + self.contentsMargins().bottom() + self.document().documentMargin()
+			
+			height += margin
+			
+			size.setHeight(height)
+			
+		return size
+			
+	def sizeHint( self ) :
+
+		size = QtGui.QPlainTextEdit.sizeHint( self )
+			
+		return self.__computeHeight( size )
+	
+	def minimumSizeHint( self ) :
+		
+		size = QtGui.QPlainTextEdit.minimumSizeHint( self )
+		
+		return self.__computeHeight( size )
 
 	def event( self, event ) :
 

--- a/python/GafferUI/TextWidget.py
+++ b/python/GafferUI/TextWidget.py
@@ -378,6 +378,10 @@ class _LineEdit( QtGui.QLineEdit ) :
 			QtGui.QSizePolicy.Expanding if self.__fixedCharacterWidth is None else QtGui.QSizePolicy.Fixed,
 			QtGui.QSizePolicy.Fixed
 		)
+		
+		# we need to make sure that the geometry is up-to-date with the current character width
+		if self.__fixedCharacterWidth is not None:
+			self.updateGeometry()
 
 	def getFixedCharacterWidth( self ) :
 

--- a/python/GafferUITest/MultiLineTextWidgetTest.py
+++ b/python/GafferUITest/MultiLineTextWidgetTest.py
@@ -107,5 +107,27 @@ class MultiLineTextWidgetTest( GafferUITest.TestCase ) :
 		w.insertText( "abc" )
 		self.assertEqual( w.getText(), "1abc2" )
 
+	def testFixedLineHeight( self ) :
+
+		window = GafferUI.Window()
+		widget = GafferUI.MultiLineTextWidget()
+		window.addChild( widget )
+		window.setVisible( True )
+		
+		# initial value
+		widget.setFixedLineHeight( 5 )
+		
+		oldHeight = widget.size().y
+		
+		# changing initial value		
+		widget.setFixedLineHeight( 2 )
+		
+		self.waitForIdle()
+		
+		newHeight = widget.size().y
+		
+		# checking if the geometry has been updated for the new line height
+		self.assertEqual( newHeight == oldHeight, False )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/TextWidgetTest.py
+++ b/python/GafferUITest/TextWidgetTest.py
@@ -137,5 +137,27 @@ class TextWidgetTest( GafferUITest.TestCase ) :
 		w.setErrored( False )
 		self.assertEqual( w.getErrored(), False )
 
+	def testFixedCharacterWidth( self ) :
+
+		window = GafferUI.Window()
+		textWidget = GafferUI.TextWidget()
+		window.addChild( textWidget )
+		window.setVisible( True )
+		
+		# initial value
+		textWidget.setFixedCharacterWidth( 5 )
+
+		oldWidth = textWidget.size().x
+		
+		# changing the initial value
+		textWidget.setFixedCharacterWidth( 2 )
+		
+		self.waitForIdle()
+		
+		newWidth = textWidget.size().x
+		
+		# checking if the geometry has been updated for the new character width
+		self.assertEqual( newWidth == oldWidth, False )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
Adds support for the user data "multiLineShort" which works in conjunction with the user data "multiLine" that makes the StringParameterValueWidget to have a fixed short size which is used for brief descriptions.

#### Changed Log:
- GafferCortexUI: Added support for the user data multiLineShort in the StringParameterValueWidget