### PR TITLE
OpDialogue messages

### DIFF
--- a/python/GafferCortexUI/OpDialogue.py
+++ b/python/GafferCortexUI/OpDialogue.py
@@ -382,7 +382,7 @@ class OpDialogue( GafferUI.Dialogue ) :
 
 		self.__messageWidget.messageHandler().handle(
 			IECore.Msg.Level.Error,
-			"",
+			"Problem Executing {opName}".format( opName=self.__node.getParameterised()[0].typeName() ),
 			str( exceptionInfo[1] ),
 		)
 

--- a/python/GafferCortexUI/OpDialogue.py
+++ b/python/GafferCortexUI/OpDialogue.py
@@ -382,8 +382,8 @@ class OpDialogue( GafferUI.Dialogue ) :
 
 		self.__messageWidget.messageHandler().handle(
 			IECore.Msg.Level.Error,
+			"",
 			str( exceptionInfo[1] ),
-			""
 		)
 
 		self.__frame.setChild( self.__progressUI )


### PR DESCRIPTION
Hi @johnhaddon,

We noticed that some errors presented by the Op Dialogue were being added to the message handler with an empty string for the message, since we have our custom message handler it was causing some confusion for the artists where the interface that uses this custom message handler does not show any information about the context at all (that is too advanced). so it would end showing just an "error" string without any extra information associated with that.

The reason for the empty messages is the fact that the exception info was being added as context in the messageHandler and nothing was being added to the message. It seems to happen when a parameter validation raises an exception, for instance ("publishDescription : The publish must have a description"). This pull request just switches the context to the message (since we don't want to end up having empty ie core messages)

Do you see any problems with this change ?

#### change log
- GafferUI: Fixed message handler empty messages in the OpDialogue