### PR TITLE
Threading crash fix

### DIFF
--- a/include/GafferTest/ComputeNodeTest.h
+++ b/include/GafferTest/ComputeNodeTest.h
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012, John Haddon. All rights reserved.
-//  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,37 +34,14 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "IECorePython/ScopedGILRelease.h"
+#ifndef GAFFERTEST_COMPUTENODETEST_H
+#define GAFFERTEST_COMPUTENODETEST_H
 
-#include "GafferBindings/DependencyNodeBinding.h"
-
-#include "GafferTest/MultiplyNode.h"
-#include "GafferTest/RecursiveChildIteratorTest.h"
-#include "GafferTest/FilteredRecursiveChildIteratorTest.h"
-#include "GafferTest/MetadataTest.h"
-#include "GafferTest/ContextTest.h"
-#include "GafferTest/ComputeNodeTest.h"
-
-using namespace boost::python;
-using namespace GafferTest;
-
-static void testMetadataThreadingWrapper()
-{
-	IECorePython::ScopedGILRelease gilRelease;
-	testMetadataThreading();
-}
-
-BOOST_PYTHON_MODULE( _GafferTest )
+namespace GafferTest
 {
 
-	GafferBindings::DependencyNodeClass<MultiplyNode>();
+void testComputeNodeThreading();
 
-	def( "testRecursiveChildIterator", &testRecursiveChildIterator );
-	def( "testFilteredRecursiveChildIterator", &testFilteredRecursiveChildIterator );
-	def( "testMetadataThreading", &testMetadataThreadingWrapper );
-	def( "testManyContexts", &testManyContexts );
-	def( "testManySubstitutions", &testManySubstitutions );
-	def( "testManyEnvironmentSubstitutions", &testManyEnvironmentSubstitutions );
-	def( "testComputeNodeThreading", &testComputeNodeThreading );
+} // namespace GafferTest
 
-}
+#endif // GAFFERTEST_COMPUTENODETEST_H

--- a/include/GafferTest/MultiplyNode.h
+++ b/include/GafferTest/MultiplyNode.h
@@ -38,6 +38,7 @@
 #define GAFFERTEST_MULTIPLYNODE_H
 
 #include "Gaffer/ComputeNode.h"
+#include "Gaffer/NumericPlug.h"
 
 #include "GafferTest/TypeIds.h"
 
@@ -54,6 +55,15 @@ class MultiplyNode : public Gaffer::ComputeNode
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferTest::MultiplyNode, MultiplyNodeTypeId, Gaffer::ComputeNode );
 
+		Gaffer::IntPlug *op1Plug();
+		const Gaffer::IntPlug *op1Plug() const;
+
+		Gaffer::IntPlug *op2Plug();
+		const Gaffer::IntPlug *op2Plug() const;
+
+		Gaffer::IntPlug *productPlug();
+		const Gaffer::IntPlug *productPlug() const;
+
 		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
 
 	protected :
@@ -61,7 +71,13 @@ class MultiplyNode : public Gaffer::ComputeNode
 		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
 
+	private :
+
+		static size_t g_firstPlugIndex;
+
 };
+
+IE_CORE_DECLAREPTR( MultiplyNode )
 
 } // namespace GafferTest
 

--- a/python/GafferTest/ComputeNodeTest.py
+++ b/python/GafferTest/ComputeNodeTest.py
@@ -452,5 +452,9 @@ class ComputeNodeTest( GafferTest.TestCase ) :
 
 		self.assertTrue( self.fRan )
 
+	def testThreading( self ) :
+
+		GafferTest.testComputeNodeThreading()
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferTest/ComputeNodeTest.cpp
+++ b/src/GafferTest/ComputeNodeTest.cpp
@@ -1,0 +1,129 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "tbb/tbb.h"
+#include "tbb/tbb_thread.h"
+
+#include "IECore/Timer.h"
+
+#include "GafferTest/Assert.h"
+#include "GafferTest/MultiplyNode.h"
+#include "GafferTest/ComputeNodeTest.h"
+
+using namespace tbb;
+using namespace Gaffer;
+
+namespace
+{
+
+struct Edit : public tbb::task
+{
+	
+	Edit( const bool &stop )
+		:	m_stop( stop )
+	{
+	}
+
+	virtual tbb::task *execute()
+	{
+		while( !m_stop )
+		{
+			GafferTest::MultiplyNodePtr m = new GafferTest::MultiplyNode;
+			m->op1Plug()->setValue( 10 );
+			m->op1Plug()->setValue( 20 );
+			tbb::this_tbb_thread::yield();
+		}
+
+		return NULL;
+	}
+
+	private :
+
+		const bool &m_stop;
+
+};
+
+struct Compute
+{
+
+	Compute()
+		:	m_node1( new GafferTest::MultiplyNode ), m_node2( new GafferTest::MultiplyNode )
+	{
+		m_node1->op1Plug()->setValue( 3 );
+		m_node1->op2Plug()->setValue( 3 );
+		m_node2->op1Plug()->setInput( m_node1->productPlug() );
+		m_node2->op2Plug()->setValue( 1 );
+	}
+
+	void operator()( const blocked_range<size_t> &r ) const
+	{
+		for( size_t i=r.begin(); i!=r.end(); ++i )
+		{			
+			GAFFERTEST_ASSERT( m_node2->productPlug()->getValue() == 9 );
+		}
+	}
+
+	private :
+
+		GafferTest::MultiplyNodePtr m_node1;
+		GafferTest::MultiplyNodePtr m_node2;
+
+};
+
+} // namespace
+
+void GafferTest::testComputeNodeThreading()
+{
+	// Set up an asynchronous task to be creating and
+	// deleting node graphs on a background thread.
+	bool stop = false;
+	Edit *e = new (tbb::task::allocate_root()) Edit( stop );
+	tbb::task::enqueue( *e );
+
+	// And then do some threaded computation on some
+	// other threads. This should be OK, because the
+	// graphs being edited is not the same as the one
+	// being computed.
+	Compute c;
+	IECore::Timer t;
+	parallel_for( blocked_range<size_t>( 0, 1000000 ), c );
+	// Uncomment for timing information. Since this test
+	// repeats a very small computation many times, its
+	// a good benchmark for measuring overhead in the
+	// ComputeNode/ValuePlug machinery itself.
+	//std::cerr << t.stop() << std::endl;
+	stop = true;
+}

--- a/src/GafferTest/MultiplyNode.cpp
+++ b/src/GafferTest/MultiplyNode.cpp
@@ -43,9 +43,12 @@ using namespace Gaffer;
 
 IE_CORE_DEFINERUNTIMETYPED( MultiplyNode )
 
+size_t MultiplyNode::g_firstPlugIndex = 0;
+
 MultiplyNode::MultiplyNode( const std::string &name )
 	:	ComputeNode( name )
 {
+	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new IntPlug( "op1" ) );
 	addChild( new IntPlug( "op2" ) );
 	addChild( new IntPlug( "product", Plug::Out ) );
@@ -55,13 +58,43 @@ MultiplyNode::~MultiplyNode()
 {
 }
 
+Gaffer::IntPlug *MultiplyNode::op1Plug()
+{
+	return getChild<IntPlug>( g_firstPlugIndex );
+}
+
+const Gaffer::IntPlug *MultiplyNode::op1Plug() const
+{
+	return getChild<IntPlug>( g_firstPlugIndex );
+}
+
+Gaffer::IntPlug *MultiplyNode::op2Plug()
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 1 );
+}
+
+const Gaffer::IntPlug *MultiplyNode::op2Plug() const
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 1 );
+}
+
+Gaffer::IntPlug *MultiplyNode::productPlug()
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 2 );
+}
+
+const Gaffer::IntPlug *MultiplyNode::productPlug() const
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 2 );
+}
+
 void MultiplyNode::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
 {
 	ComputeNode::affects( input, outputs );
 
-	if( input == getChild<IntPlug>( "op1" ) || input == getChild<IntPlug>( "op2" ) )
+	if( input == op1Plug() || input == op2Plug() )
 	{
-		outputs.push_back( getChild<IntPlug>( "product" ) );
+		outputs.push_back( productPlug() );
 	}
 }
 
@@ -71,18 +104,18 @@ void MultiplyNode::hash( const Gaffer::ValuePlug *output, const Gaffer::Context 
 
 	if( output == getChild<IntPlug>( "product" ) )
 	{
-		getChild<IntPlug>( "op1" )->hash( h );
-		getChild<IntPlug>( "op2" )->hash( h );
+		op1Plug()->hash( h );
+		op2Plug()->hash( h );
 	}
 }
 
 void MultiplyNode::compute( ValuePlug *output, const Context *context ) const
 {
-	if( output == getChild<IntPlug>( "product" ) )
+	if( output == productPlug() )
 	{
 		static_cast<IntPlug *>( output )->setValue(
-			getChild<IntPlug>( "op1" )->getValue() *
-			getChild<IntPlug>( "op2" )->getValue()
+			op1Plug()->getValue() *
+			op2Plug()->getValue()
 		);
 		return;
 	}


### PR DESCRIPTION
This fixes the sporadic test failures introduced by https://github.com/ImageEngine/gaffer/pull/1265. Although there is a mutex in there now, it's per-thread (except for clearHashCaches()), so in normal use (lots of concurrent computation with no concurrent edits) it's under no contention whatsoever, and I've used `testComputeNodeThreading()` to verify that performance hasn't suffered. @davidsminor, if you want to run one of your big scene benchmarks just to be double sure, that would be great.