### PR TITLE
Sets improvements

### DIFF
--- a/include/GafferScene/PathMatcher.h
+++ b/include/GafferScene/PathMatcher.h
@@ -59,8 +59,8 @@ class PathMatcher
 		/// Constructs a deep copy of other.
 		PathMatcher( const PathMatcher &other );
 
-		template<typename Iterator>
-		PathMatcher( Iterator pathsBegin, Iterator pathsEnd );
+		template<typename PathIterator>
+		PathMatcher( PathIterator pathsBegin, PathIterator pathsEnd );
 
 		/// \todo Should this keep the existing tree in place,
 		/// but just remove the terminator flags on any items
@@ -68,8 +68,8 @@ class PathMatcher
 		/// better performance for selections and expansions
 		/// which will tend to be adding and removing the same
 		/// paths repeatedly.
-		template<typename Iterator>
-		void init( Iterator pathsBegin, Iterator pathsEnd );
+		template<typename PathIterator>
+		void init( PathIterator pathsBegin, PathIterator pathsEnd );
 
 		/// Returns true if the path was added, false if
 		/// it was already there.

--- a/include/GafferScene/PathMatcher.h
+++ b/include/GafferScene/PathMatcher.h
@@ -122,26 +122,35 @@ class PathMatcher
 	private :
 
 		// Struct used to store the name for each node in the tree of paths.
-		// This is just an InternedString with an extra flag to specify whether
-		// or not the name contains wildcards (and will therefore need to
-		// be used with `match()` or the special ellipsis matching code).
+		// This is just an InternedString with an extra field used to separate
+		// names containing wildcards from plain names - since they need to
+		// be used with `match()` or the special ellipsis matching code.
 		struct Name
 		{
 
+			enum Type
+			{
+				Plain = 0, // No wildcards
+				Boundary = 1, // Marker between plain and wildcarded
+				Wildcarded = 2 // Has wildcards or ...
+			};
+
 			Name( IECore::InternedString name );
-			/// Allows explicit instantiation of the hasWildcards member -
-			/// use with care!
-			Name( IECore::InternedString name, bool hasWildcards );
+			// Allows explicit instantiation of the type member -
+			// use with care!
+			Name( IECore::InternedString name, Type type );
 
 			// Less than implemented to do a lexicographical comparison,
-			// first on hasWildcards and then on the name. The comparison
+			// first on type and then on the name. This has the effect of
+			// segregating plain strings from wildcarded strings with the
+			// Boundary type providing a marker between them. The comparison
 			// of the name uses the InternedString operator which compares
 			// via pointer rather than string content, which gives improved
 			// performance.
 			bool operator < ( const Name &other ) const;
 
 			const IECore::InternedString name;
-			const bool hasWildcards;
+			const unsigned char type;
 
 		};
 

--- a/include/GafferScene/PathMatcher.h
+++ b/include/GafferScene/PathMatcher.h
@@ -122,7 +122,7 @@ class PathMatcher
 		void pathsWalk( Node *node, const std::string &path, std::vector<std::string> &paths ) const;
 
 		template<typename NameIterator>
-		void matchWalk( Node *node, const NameIterator &start, const NameIterator &end, unsigned &result ) const;
+		void matchWalk( const Node *node, const NameIterator &start, const NameIterator &end, unsigned &result ) const;
 
 		boost::shared_ptr<Node> m_root;
 

--- a/include/GafferScene/PathMatcher.inl
+++ b/include/GafferScene/PathMatcher.inl
@@ -40,17 +40,17 @@
 namespace GafferScene
 {
 
-template<typename Iterator>
-PathMatcher::PathMatcher( Iterator pathsBegin, Iterator pathsEnd )
+template<typename PathIterator>
+PathMatcher::PathMatcher( PathIterator pathsBegin, PathIterator pathsEnd )
 {
 	init( pathsBegin, pathsEnd );
 }
 
-template<typename Iterator>
-void PathMatcher::init( Iterator pathsBegin, Iterator pathsEnd )
+template<typename PathIterator>
+void PathMatcher::init( PathIterator pathsBegin, PathIterator pathsEnd )
 {
 	clear();
-	for( Iterator it = pathsBegin; it != pathsEnd; it++ )
+	for( PathIterator it = pathsBegin; it != pathsEnd; it++ )
 	{
 		addPath( *it );
 	}

--- a/include/GafferSceneTest/PathMatcherTest.h
+++ b/include/GafferSceneTest/PathMatcherTest.h
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012, John Haddon. All rights reserved.
-//  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,38 +34,14 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
+#ifndef GAFFERSCENETEST_PATHMATCHERTEST_H
+#define GAFFERSCENETEST_PATHMATCHERTEST_H
 
-#include "IECorePython/ScopedGILRelease.h"
-
-#include "GafferBindings/DependencyNodeBinding.h"
-
-#include "GafferSceneTest/CompoundObjectSource.h"
-#include "GafferSceneTest/TraverseScene.h"
-#include "GafferSceneTest/TestShader.h"
-#include "GafferSceneTest/TestLight.h"
-#include "GafferSceneTest/ScenePlugTest.h"
-#include "GafferSceneTest/PathMatcherTest.h"
-
-using namespace boost::python;
-using namespace GafferSceneTest;
-
-static void traverseSceneWrapper( GafferScene::ScenePlug *scenePlug, Gaffer::Context *context )
-{
-	IECorePython::ScopedGILRelease gilRelease;
-	traverseScene( scenePlug, context );
-}
-
-BOOST_PYTHON_MODULE( _GafferSceneTest )
+namespace GafferSceneTest
 {
 
-	GafferBindings::DependencyNodeClass<CompoundObjectSource>();
-	GafferBindings::NodeClass<TestShader>();
-	GafferBindings::NodeClass<TestLight>();
+void testPathMatcherIteratorPrune();
 
-	def( "traverseScene", &traverseSceneWrapper );
-	def( "testManyStringToPathCalls", &testManyStringToPathCalls );
+} // namespace GafferSceneTest
 
-	def( "testPathMatcherIteratorPrune", &testPathMatcherIteratorPrune );
-
-}
+#endif // GAFFERSCENETEST_PATHMATCHERTEST_H

--- a/include/GafferSceneTest/PathMatcherTest.h
+++ b/include/GafferSceneTest/PathMatcherTest.h
@@ -40,6 +40,7 @@
 namespace GafferSceneTest
 {
 
+void testPathMatcherRawIterator();
 void testPathMatcherIteratorPrune();
 
 } // namespace GafferSceneTest

--- a/python/GafferSceneTest/PathMatcherTest.py
+++ b/python/GafferSceneTest/PathMatcherTest.py
@@ -731,6 +731,10 @@ class PathMatcherTest( unittest.TestCase ) :
 		m = GafferScene.PathMatcher()
 		self.assertEqual( m.paths(), [] )
 
+	def testRawIterator( self ) :
+
+		GafferSceneTest.testPathMatcherRawIterator()
+
 	def testIteratorPrune( self ) :
 
 		GafferSceneTest.testPathMatcherIteratorPrune()

--- a/python/GafferSceneTest/PathMatcherTest.py
+++ b/python/GafferSceneTest/PathMatcherTest.py
@@ -42,6 +42,7 @@ import IECore
 
 import Gaffer
 import GafferScene
+import GafferSceneTest
 
 class PathMatcherTest( unittest.TestCase ) :
 
@@ -718,10 +719,21 @@ class PathMatcherTest( unittest.TestCase ) :
 		m.addPath( "/" )
 		self.assertEqual( m.paths(), [ "/" ] )
 
+	def testPathsWithRootTerminatorAndDescendant( self ) :
+
+		m = GafferScene.PathMatcher()
+		m.addPath( "/" )
+		m.addPath( "/a/b/c" )
+		self.assertEqual( m.paths(), [ "/", "/a/b/c" ] )
+
 	def testEmptyPaths( self ) :
 
 		m = GafferScene.PathMatcher()
 		self.assertEqual( m.paths(), [] )
+
+	def testIteratorPrune( self ) :
+
+		GafferSceneTest.testPathMatcherIteratorPrune()
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/PathMatcherTest.py
+++ b/python/GafferSceneTest/PathMatcherTest.py
@@ -712,5 +712,16 @@ class PathMatcherTest( unittest.TestCase ) :
 
 		self.assertEqual( m.match( "/b"), GafferScene.Filter.Result.ExactMatch )
 
+	def testPathsWithRootTerminator( self ) :
+
+		m = GafferScene.PathMatcher()
+		m.addPath( "/" )
+		self.assertEqual( m.paths(), [ "/" ] )
+
+	def testEmptyPaths( self ) :
+
+		m = GafferScene.PathMatcher()
+		self.assertEqual( m.paths(), [] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/PathMatcher.cpp
+++ b/src/GafferScene/PathMatcher.cpp
@@ -50,18 +50,18 @@ static IECore::InternedString g_ellipsis( "..." );
 //////////////////////////////////////////////////////////////////////////
 
 inline PathMatcher::Name::Name( IECore::InternedString name )
-	: name( name ), hasWildcards( name == g_ellipsis || Gaffer::hasWildcards( name.c_str() ) )
+	: name( name ), type( name == g_ellipsis || Gaffer::hasWildcards( name.c_str() ) ? Wildcarded : Plain )
 {
 }
 
-inline PathMatcher::Name::Name( IECore::InternedString name, bool hasWildcards )
-	: name( name ), hasWildcards( hasWildcards )
+inline PathMatcher::Name::Name( IECore::InternedString name, Type type )
+	: name( name ), type( type )
 {
 }
 
 inline bool PathMatcher::Name::operator < ( const Name &other ) const
 {
-	return hasWildcards < other.hasWildcards || ( ( hasWildcards == other.hasWildcards ) && name < other.name );
+	return type < other.type || ( ( type == other.type ) && name < other.name );
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -92,7 +92,7 @@ inline PathMatcher::Node::ConstChildMapIterator PathMatcher::Node::wildcardsBegi
 {
 	// The value for name used here will never be inserted in the map,
 	// but it marks the transition from non-wildcarded to wildcarded names.
-	return children.lower_bound( Name( IECore::InternedString(), true ) );
+	return children.lower_bound( Name( IECore::InternedString(), Name::Boundary ) );
 }
 
 inline PathMatcher::Node *PathMatcher::Node::child( const Name &name )
@@ -270,7 +270,7 @@ void PathMatcher::matchWalk( const Node *node, const NameIterator &start, const 
 	// not interested in finding a child with wildcards here - this avoids
 	// a call to hasWildcards() and gives us a decent little performance boost.
 
-	Node::ConstChildMapIterator childIt = node->children.find( Name( *start, false ) );
+	Node::ConstChildMapIterator childIt = node->children.find( Name( *start, Name::Plain ) );
 	const Node::ConstChildMapIterator childItEnd = node->children.end();
 	if( childIt != childItEnd )
 	{

--- a/src/GafferScene/PathMatcher.cpp
+++ b/src/GafferScene/PathMatcher.cpp
@@ -96,12 +96,12 @@ struct PathMatcher::Node
 	typedef ChildMap::const_iterator ConstChildMapIterator;
 
 	Node()
-		:	terminator( false ), ellipsis( 0 )
+		:	terminator( false ), ellipsis( NULL )
 	{
 	}
 
 	Node( const Node &other )
-		:	terminator( other.terminator ), ellipsis( other.ellipsis ? new Node( *(other.ellipsis) ) : 0 )
+		:	terminator( other.terminator ), ellipsis( other.ellipsis ? new Node( *(other.ellipsis) ) : NULL )
 	{
 		ChildMapIterator hint = children.begin();
 		for( ConstChildMapIterator it = other.children.begin(), eIt = other.children.end(); it != eIt; it++ )
@@ -383,7 +383,7 @@ bool PathMatcher::addPath( const NameIterator &start, const NameIterator &end )
 	Node *node = m_root.get();
 	for( NameIterator it = start; it != end; ++it )
 	{
-		Node *nextNode = 0;
+		Node *nextNode = NULL;
 		const Name name( *it );
 		if( name.name == g_ellipsis )
 		{
@@ -466,7 +466,7 @@ void PathMatcher::removeWalk( Node *node, const NameIterator &start, const NameI
 
 	const IECore::InternedString name( *start );
 	Node::ChildMapIterator childIt = node->children.end();
-	Node *childNode = 0;
+	Node *childNode = NULL;
 	if( name == g_ellipsis )
 	{
 		childNode = node->ellipsis;
@@ -496,7 +496,7 @@ void PathMatcher::removeWalk( Node *node, const NameIterator &start, const NameI
 		}
 		else
 		{
-			node->ellipsis = 0;
+			node->ellipsis = NULL;
 		}
 	}
 }

--- a/src/GafferScene/PathMatcher.cpp
+++ b/src/GafferScene/PathMatcher.cpp
@@ -404,14 +404,14 @@ bool PathMatcher::prune( const std::vector<IECore::InternedString> &path )
 	return result;
 }
 
-PathMatcher::Iterator PathMatcher::begin() const
+PathMatcher::RawIterator PathMatcher::begin() const
 {
-	return Iterator( *this, false );
+	return RawIterator( *this, false );
 }
 
-PathMatcher::Iterator PathMatcher::end() const
+PathMatcher::RawIterator PathMatcher::end() const
 {
-	return Iterator( *this, true );
+	return RawIterator( *this, true );
 }
 
 template<typename NameIterator>

--- a/src/GafferScene/PathMatcher.cpp
+++ b/src/GafferScene/PathMatcher.cpp
@@ -38,6 +38,7 @@
 #include "Gaffer/StringAlgo.h"
 
 #include "GafferScene/PathMatcher.h"
+#include "GafferScene/ScenePlug.h"
 
 using namespace std;
 using namespace GafferScene;
@@ -190,7 +191,11 @@ bool PathMatcher::isEmpty() const
 
 void PathMatcher::paths( std::vector<std::string> &paths ) const
 {
-	pathsWalk( m_root.get(), "/", paths );
+	for( Iterator it = begin(), eIt = end(); it != eIt; ++it )
+	{
+		paths.push_back( std::string() );
+		ScenePlug::pathToString( *it, paths.back() );
+	}
 }
 
 bool PathMatcher::operator == ( const PathMatcher &other ) const
@@ -399,6 +404,16 @@ bool PathMatcher::prune( const std::vector<IECore::InternedString> &path )
 	return result;
 }
 
+PathMatcher::Iterator PathMatcher::begin() const
+{
+	return Iterator( *this, false );
+}
+
+PathMatcher::Iterator PathMatcher::end() const
+{
+	return Iterator( *this, true );
+}
+
 template<typename NameIterator>
 void PathMatcher::removeWalk( Node *node, const NameIterator &start, const NameIterator &end, const bool prune, bool &removed )
 {
@@ -488,21 +503,3 @@ bool PathMatcher::removePathsWalk( Node *node, const Node *srcNode )
 	return result;
 }
 
-void PathMatcher::pathsWalk( Node *node, const std::string &path, std::vector<std::string> &paths ) const
-{
-	if( node->terminator )
-	{
-		paths.push_back( path );
-	}
-
-	for( Node::ChildMapIterator it = node->children.begin(), eIt = node->children.end(); it != eIt; it++ )
-	{
-		std::string childPath = path;
-		if( node != m_root.get() )
-		{
-			childPath += "/";
-		}
-		childPath += it->first.name;
-		pathsWalk( it->second, childPath, paths );
-	}
-}

--- a/src/GafferSceneTest/CompoundObjectSource.cpp
+++ b/src/GafferSceneTest/CompoundObjectSource.cpp
@@ -177,6 +177,16 @@ void CompoundObjectSource::hashGlobals( const Gaffer::Context *context, const Ga
 
 IECore::ConstCompoundObjectPtr CompoundObjectSource::computeGlobals( const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const
 {
+	ConstCompoundObjectPtr compoundObject = runTimeCast<const CompoundObject>( inPlug()->getValue() );
+	if( !compoundObject )
+	{
+		throw Exception( "Input value is not a CompoundObject" );
+	}
+
+	if( ConstCompoundObjectPtr globals = compoundObject->member<CompoundObject>( "globals" ) )
+	{
+		return globals;
+	}
 	return outPlug()->globalsPlug()->defaultValue();
 }
 
@@ -185,7 +195,7 @@ IECore::ConstCompoundObjectPtr CompoundObjectSource::entryForPath( const ScenePa
 	ConstCompoundObjectPtr result = runTimeCast<const CompoundObject>( inPlug()->getValue() );
 	if( !result )
 	{
-		throw Exception( "Input plug has no value" );
+		throw Exception( "Input value is not a CompoundObject" );
 	}
 
 	for( ScenePath::const_iterator it=path.begin(); it!=path.end(); it++ )

--- a/src/GafferSceneTest/CompoundObjectSource.cpp
+++ b/src/GafferSceneTest/CompoundObjectSource.cpp
@@ -84,43 +84,16 @@ void CompoundObjectSource::hashBound( const ScenePath &path, const Gaffer::Conte
 	inPlug()->hash( h );
 }
 
+Imath::Box3f CompoundObjectSource::computeBound( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const
+{
+	return entryForPath( path )->member<Box3fData>( "bound", true /* throw exceptions */ )->readable();
+}
+
 void CompoundObjectSource::hashTransform( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const
 {
 	SceneNode::hashTransform( path, context, parent, h );
 	h.append( &path.front(), path.size() );
 	inPlug()->hash( h );
-}
-
-void CompoundObjectSource::hashAttributes( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const
-{
-	SceneNode::hashAttributes( path, context, parent, h );
-	h.append( &path.front(), path.size() );
-	inPlug()->hash( h );
-}
-
-void CompoundObjectSource::hashObject( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const
-{
-	SceneNode::hashObject( path, context, parent, h );
-	h.append( &path.front(), path.size() );
-	inPlug()->hash( h );
-}
-
-void CompoundObjectSource::hashChildNames( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const
-{
-	SceneNode::hashChildNames( path, context, parent, h );
-	h.append( &path.front(), path.size() );
-	inPlug()->hash( h );
-}
-
-void CompoundObjectSource::hashGlobals( const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const
-{
-	SceneNode::hashGlobals( context, parent, h );
-	inPlug()->hash( h );
-}
-
-Imath::Box3f CompoundObjectSource::computeBound( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const
-{
-	return entryForPath( path )->member<Box3fData>( "bound", true /* throw exceptions */ )->readable();
 }
 
 Imath::M44f CompoundObjectSource::computeTransform( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const
@@ -131,6 +104,13 @@ Imath::M44f CompoundObjectSource::computeTransform( const ScenePath &path, const
 		return transform->readable();
 	}
 	return Imath::M44f();
+}
+
+void CompoundObjectSource::hashAttributes( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const
+{
+	SceneNode::hashAttributes( path, context, parent, h );
+	h.append( &path.front(), path.size() );
+	inPlug()->hash( h );
 }
 
 IECore::ConstCompoundObjectPtr CompoundObjectSource::computeAttributes( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const
@@ -146,6 +126,13 @@ IECore::ConstCompoundObjectPtr CompoundObjectSource::computeAttributes( const Sc
 	}
 }
 
+void CompoundObjectSource::hashObject( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const
+{
+	SceneNode::hashObject( path, context, parent, h );
+	h.append( &path.front(), path.size() );
+	inPlug()->hash( h );
+}
+
 IECore::ConstObjectPtr CompoundObjectSource::computeObject( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const
 {
 	ConstObjectPtr o = entryForPath( path )->member<Object>( "object" );
@@ -157,6 +144,13 @@ IECore::ConstObjectPtr CompoundObjectSource::computeObject( const ScenePath &pat
 	{
 		return outPlug()->objectPlug()->defaultValue();
 	}
+}
+
+void CompoundObjectSource::hashChildNames( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const
+{
+	SceneNode::hashChildNames( path, context, parent, h );
+	h.append( &path.front(), path.size() );
+	inPlug()->hash( h );
 }
 
 IECore::ConstInternedStringVectorDataPtr CompoundObjectSource::computeChildNames( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const
@@ -173,6 +167,12 @@ IECore::ConstInternedStringVectorDataPtr CompoundObjectSource::computeChildNames
 		result->writable().push_back( it->first.value() );
 	}
 	return result;
+}
+
+void CompoundObjectSource::hashGlobals( const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const
+{
+	SceneNode::hashGlobals( context, parent, h );
+	inPlug()->hash( h );
 }
 
 IECore::ConstCompoundObjectPtr CompoundObjectSource::computeGlobals( const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const

--- a/src/GafferSceneTest/PathMatcherTest.cpp
+++ b/src/GafferSceneTest/PathMatcherTest.cpp
@@ -48,6 +48,38 @@ using namespace boost;
 using namespace IECore;
 using namespace GafferScene;
 
+void GafferSceneTest::testPathMatcherRawIterator()
+{
+	vector<InternedString> root;
+	vector<InternedString> a = assign::list_of( "a" );
+	vector<InternedString> ab = assign::list_of( "a" )( "b" );
+	vector<InternedString> abc = assign::list_of( "a" )( "b" )( "c" );
+
+	PathMatcher m;
+	PathMatcher::RawIterator it = m.begin();
+	GAFFERTEST_ASSERT( it == m.end() );
+
+	m.addPath( abc );
+	it = m.begin();
+	GAFFERTEST_ASSERT( *it == root );
+	GAFFERTEST_ASSERT( it.exactMatch() == false );
+	GAFFERTEST_ASSERT( it != m.end() );
+	++it;
+	GAFFERTEST_ASSERT( *it == a );
+	GAFFERTEST_ASSERT( it.exactMatch() == false );
+	GAFFERTEST_ASSERT( it != m.end() );
+	++it;
+	GAFFERTEST_ASSERT( *it == ab );
+	GAFFERTEST_ASSERT( it.exactMatch() == false );
+	GAFFERTEST_ASSERT( it != m.end() );
+	++it;
+	GAFFERTEST_ASSERT( *it == abc );
+	GAFFERTEST_ASSERT( it.exactMatch() == true );
+	GAFFERTEST_ASSERT( it != m.end() );
+	++it;
+	GAFFERTEST_ASSERT( it == m.end() );
+}
+
 void GafferSceneTest::testPathMatcherIteratorPrune()
 {
 	vector<InternedString> root;

--- a/src/GafferSceneTestModule/GafferSceneTestModule.cpp
+++ b/src/GafferSceneTestModule/GafferSceneTestModule.cpp
@@ -67,6 +67,7 @@ BOOST_PYTHON_MODULE( _GafferSceneTest )
 	def( "traverseScene", &traverseSceneWrapper );
 	def( "testManyStringToPathCalls", &testManyStringToPathCalls );
 
+	def( "testPathMatcherRawIterator", &testPathMatcherRawIterator );
 	def( "testPathMatcherIteratorPrune", &testPathMatcherIteratorPrune );
 
 }


### PR DESCRIPTION
This improves our implementation of sets, yielding a 60% reduction in globals computation runtime for a heavy production benchmark, as well as reducing total memory usage by about 10%.

Prior to this, `PathMatcher` (the data structure behind sets) was largely opaque, and the only way to query the contents was via a very expensive `paths()` method which copied the paths out into a vector of strings. We now have `PathMatcher::Iterator` to allow direct iteration over the paths instead, and reimplementing all our sets computations to use that gives us the performance improvements.

Having iterators also sets us up a bit better for future sets optimisations where we share PathMatcher::Nodes between PathMatcher instances using lazy-copy-on-write, because the iterators can be thought of as providing public handles to the internal private nodes.