### PR TITLE
Avoiding menu recomputation

### DIFF
--- a/python/GafferUI/MenuBar.py
+++ b/python/GafferUI/MenuBar.py
@@ -86,17 +86,9 @@ class _MenuBar( QtGui.QMenuBar ) :
 
 		self.setSizePolicy( QtGui.QSizePolicy( QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Fixed ) )
 		
-		self.__computeMenu = True
-
 		# disable menu merging on mac
 		self.setNativeMenuBar( False )
 		
-	def setParent(self, parent):
-
-		# every time that the ownership changes we need to recompute the menu which is made through the show event
-		self.__computeMenu = True
-		super(_MenuBar, self).setParent(parent)
-
 	def showEvent( self, event ) :
 
 		# normally, Menus aren't populated with items until they're shown,
@@ -105,11 +97,12 @@ class _MenuBar( QtGui.QMenuBar ) :
 		# know then that we're parented below a Window, and many of our menu
 		# commands and status items we use need to find their parent ScriptWindow
 		# before they work properly.
-		if self.__computeMenu :
-			for subMenu in GafferUI.Widget._owner( self )._subMenus :
+
+		for subMenu in GafferUI.Widget._owner( self )._subMenus :
+			
+			# in order to avoid the potential overhead caused by building the submenus
+			# fully every time the showEvent is triggered we just do it once
+			if subMenu._qtWidget().isEmpty() :
 				subMenu._buildFully()
 			
-			# we don't want to re-compute it every time that the menu gets its visibility restored (for example from the minimized state) 
-			self.__computeMenu = False
-
 		return QtGui.QMenuBar.showEvent( self, event )

--- a/python/GafferUI/MenuBar.py
+++ b/python/GafferUI/MenuBar.py
@@ -85,10 +85,10 @@ class _MenuBar( QtGui.QMenuBar ) :
 		QtGui.QMenuBar.__init__( self, parent )
 
 		self.setSizePolicy( QtGui.QSizePolicy( QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Fixed ) )
-		
+
 		# disable menu merging on mac
 		self.setNativeMenuBar( False )
-		
+
 	def showEvent( self, event ) :
 
 		# normally, Menus aren't populated with items until they're shown,

--- a/python/GafferUI/MenuBar.py
+++ b/python/GafferUI/MenuBar.py
@@ -85,9 +85,17 @@ class _MenuBar( QtGui.QMenuBar ) :
 		QtGui.QMenuBar.__init__( self, parent )
 
 		self.setSizePolicy( QtGui.QSizePolicy( QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Fixed ) )
+		
+		self.__computeMenu = True
 
 		# disable menu merging on mac
 		self.setNativeMenuBar( False )
+		
+	def setParent(self, parent):
+
+		# every time that the ownership changes we need to recompute the menu which is made through the show event
+		self.__computeMenu = True
+		super(_MenuBar, self).setParent(parent)
 
 	def showEvent( self, event ) :
 
@@ -97,7 +105,11 @@ class _MenuBar( QtGui.QMenuBar ) :
 		# know then that we're parented below a Window, and many of our menu
 		# commands and status items we use need to find their parent ScriptWindow
 		# before they work properly.
-		for subMenu in GafferUI.Widget._owner( self )._subMenus :
-			subMenu._buildFully()
+		if self.__computeMenu :
+			for subMenu in GafferUI.Widget._owner( self )._subMenus :
+				subMenu._buildFully()
+			
+			# we don't want to re-compute it every time that the menu gets its visibility restored (for example from the minimized state) 
+			self.__computeMenu = False
 
 		return QtGui.QMenuBar.showEvent( self, event )


### PR DESCRIPTION
Hi,

Just noticed this small overhead that was happening every time that the script window was getting restored from a minimized state where it was re-computing the whole menu again. So I've changed the show event to avoid that re-computation where that will only do it once per ownership during the showEvent.

Does it have any chances of changing the menubar's qt ownership in gaffer ? if that does not happen I could remove that setParent re-implementation.

##### Change Log
- GafferUI: Avoiding menu re-computation in menu bar
