### PR TITLE
Released GIL for CompoundNumericPlug gang() and ungang() calls.

### DIFF
--- a/src/GafferBindings/CompoundNumericPlugBinding.cpp
+++ b/src/GafferBindings/CompoundNumericPlugBinding.cpp
@@ -105,6 +105,24 @@ typename T::ValueType getValue( const T *plug )
 }
 
 template<typename T>
+void gang( T *plug )
+{
+	// Must release GIL in case this triggers a graph evaluation
+	// which wants to enter Python on another thread.
+	IECorePython::ScopedGILRelease r;
+	plug->gang();
+}
+
+template<typename T>
+void ungang( T *plug )
+{
+	// Must release GIL in case this triggers a graph evaluation
+	// which wants to enter Python on another thread.
+	IECorePython::ScopedGILRelease r;
+	plug->ungang();
+}
+
+template<typename T>
 void bind()
 {
 	typedef typename T::ValueType V;
@@ -129,9 +147,9 @@ void bind()
 		.def( "setValue", &setValue<T> )
 		.def( "getValue", &getValue<T> )
 		.def( "canGang", &T::canGang )
-		.def( "gang", &T::gang )
+		.def( "gang", &gang<T> )
 		.def( "isGanged", &T::isGanged )
-		.def( "ungang", &T::ungang )
+		.def( "ungang", &ungang<T> )
 	;
 
 	Serialisation::registerSerialiser( T::staticTypeId(), new CompoundNumericPlugSerialiser<T>() );


### PR DESCRIPTION
Because they modify connections, they will trigger dirty propagation, and therefore could trigger a graph evaluation, which could enter another thread, which might want to use Python.

This is motivated by IE internal ticket INC1026278. I suspect that because in practice ganging happens inside an UndoContext, #1273 on its own is actually sufficient, but if you _did_ call the methods without using an UndoContext, this fix might be necessary too.