### PR TITLE
SceneHierarchy expansion bugfix

### DIFF
--- a/python/GafferSceneUITest/SceneHierarchyTest.py
+++ b/python/GafferSceneUITest/SceneHierarchyTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,12 +34,60 @@
 #
 ##########################################################################
 
-from SceneViewTest import SceneViewTest
-from ShaderAssignmentUITest import ShaderAssignmentUITest
-from StandardGraphLayoutTest import StandardGraphLayoutTest
-from SceneGadgetTest import SceneGadgetTest
-from SceneInspectorTest import SceneInspectorTest
-from SceneHierarchyTest import SceneHierarchyTest
+import IECore
+
+import Gaffer
+import GafferUITest
+import GafferScene
+import GafferSceneUI
+
+class SceneHierarchyTest( GafferUITest.TestCase ) :
+
+	def assertExpanded( self, context, path, expanded ) :
+
+		e = False
+		if "ui:scene:expandedPaths" in context :
+			if context["ui:scene:expandedPaths"].value.match( path ) & GafferScene.Filter.Result.ExactMatch :
+				e = True
+
+		self.assertEqual( e, expanded )
+
+	def testNoUnwantedExpansion( self ) :
+
+		# Make a small scene, and view it with a SceneHierarchy editor.
+
+		script = Gaffer.ScriptNode()
+		
+		script["plane"] = GafferScene.Plane()
+		script["group"] = GafferScene.Group()
+		script["group"]["in"].setInput( script["plane"]["out"] )
+
+		sceneHierarchy = GafferSceneUI.SceneHierarchy( script )
+		script.selection().add( script["group"] )
+
+		self.waitForIdle( 1000 )
+		self.assertExpanded( script.context(), "/group", False )
+
+		# Expand the root, and select /group.
+
+		script.context()["ui:scene:expandedPaths"] = GafferScene.PathMatcherData( GafferScene.PathMatcher( [ "/" ] ) )
+		script.context()["ui:scene:selectedPaths"] = IECore.StringVectorData( [ "/group"] )
+
+		self.waitForIdle( 1000 )
+
+		self.assertExpanded( script.context(), "/", True )
+		self.assertExpanded( script.context(), "/group", False )
+
+		# Tweak the scene to change the name of a
+		# non-expanded location. We expect the expansion to
+		# remain the same.
+
+		script["plane"]["name"].setValue( "jane" )
+
+		self.waitForIdle( 1000 )
+		self.assertExpanded( script.context(), "/", True )
+		self.assertExpanded( script.context(), "/group", False )
 
 if __name__ == "__main__":
 	unittest.main()
+

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -437,7 +437,7 @@ class PathListingWidget( GafferUI.Widget ) :
 
 		if not self.__pathChangedUpdatePending :
 			self.__pathChangedUpdatePending = True
-			GafferUI.EventLoop.addIdleCallback( self.__pathChangedUpdate )
+			GafferUI.EventLoop.addIdleCallback( Gaffer.WeakMethod( self.__pathChangedUpdate, fallbackResult = False ) )
 
 	def __pathChangedUpdate( self ) :
 

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -385,7 +385,7 @@ class PathListingWidget( GafferUI.Widget ) :
 			if expandedPaths is not None :
 				self.setExpandedPaths( expandedPaths )
 
-			self.setSelectedPaths( selectedPaths, scrollToFirst = False )
+			self.setSelectedPaths( selectedPaths, scrollToFirst = False, expandNonLeaf = False )
 
 			self.__currentDir = dirPath
 

--- a/python/GafferUITest/PathListingWidgetTest.py
+++ b/python/GafferUITest/PathListingWidgetTest.py
@@ -164,6 +164,40 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 		# once it has processed things, the expansion should be exactly as it was.
 		self.assertEqual( w.getPathExpanded( p1 ), True )
 
+	def testExpandedPathsWhenPathChangesWithSelection( self ) :
+
+		d = {
+			"a" : {
+				"e" : 10,
+			},
+			"b" : {
+				"f" : "g",
+			},
+		}
+
+		p = Gaffer.DictPath( d, "/" )
+		pa = Gaffer.DictPath( d, "/a" )
+		pae = Gaffer.DictPath( d, "/a/e" )
+		w = GafferUI.PathListingWidget( p, displayMode = GafferUI.PathListingWidget.DisplayMode.Tree )
+
+		self.assertEqual( w.getPathExpanded( pa ), False )
+		self.assertEqual( w.getPathExpanded( pae ), False )
+
+		w.setSelectedPaths( [ pa ], expandNonLeaf = False )
+		self.assertEqual( w.getPathExpanded( pa ), False )
+		self.assertEqual( w.getPathExpanded( pae ), False )
+
+		# fake a change to the path
+		p.pathChangedSignal()( p )
+
+		# because the PathListingWidget only updates on idle events, we have
+		# to run the event loop to get it to process the path changed signal.
+		self.waitForIdle( 100 )
+
+		# once it has processed things, the expansion should be exactly as it was.
+		self.assertEqual( w.getPathExpanded( pa ), False )
+		self.assertEqual( w.getPathExpanded( pae ), False )
+
 	def testHeaderVisibility( self ) :
 
 		with GafferUI.ListContainer() as c :

--- a/python/GafferUITest/PathListingWidgetTest.py
+++ b/python/GafferUITest/PathListingWidgetTest.py
@@ -41,8 +41,9 @@ import Gaffer
 import GafferTest
 
 import GafferUI
+import GafferUITest
 
-class PathListingWidgetTest( unittest.TestCase ) :
+class PathListingWidgetTest( GafferUITest.TestCase ) :
 
 	def testExpandedPaths( self ) :
 
@@ -158,12 +159,7 @@ class PathListingWidgetTest( unittest.TestCase ) :
 
 		# because the PathListingWidget only updates on idle events, we have
 		# to run the event loop to get it to process the path changed signal.
-		def stop() :
-			GafferUI.EventLoop.mainEventLoop().stop()
-			return False
-
-		GafferUI.EventLoop.addIdleCallback( stop )
-		GafferUI.EventLoop.mainEventLoop().start()
+		self.waitForIdle( 100 )
 
 		# once it has processed things, the expansion should be exactly as it was.
 		self.assertEqual( w.getPathExpanded( p1 ), True )


### PR DESCRIPTION
This fixes a bug whereby the currently selected item in the SceneHierarchy would expand without being asked when the scene was dirtied.