### PR TITLE
Dispatcher now throws when it detects cycles in the batch tree

### DIFF
--- a/include/Gaffer/Dispatcher.h
+++ b/include/Gaffer/Dispatcher.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2013-2014, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2013-2015, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -261,7 +261,7 @@ class Dispatcher : public Node
 		// Tasks with otherwise identical Contexts also be grouped into batches of frames. Nodes
 		// which require sequence execution will be grouped together as well.
 		static TaskBatchPtr batchTasks( const ExecutableNode::Tasks &tasks );
-		static void batchTasksWalk( TaskBatchPtr parent, const ExecutableNode::Task &task, BatchMap &currentBatches, TaskToBatchMap &tasksToBatches );
+		static void batchTasksWalk( TaskBatchPtr parent, const ExecutableNode::Task &task, BatchMap &currentBatches, TaskToBatchMap &tasksToBatches, std::vector<const TaskBatch *> &required );
 		static TaskBatchPtr acquireBatch( const ExecutableNode::Task &task, BatchMap &currentBatches, TaskToBatchMap &tasksToBatches );
 		static IECore::MurmurHash batchHash( const ExecutableNode::Task &task );
 

--- a/include/GafferBindings/ExecutableNodeBinding.inl
+++ b/include/GafferBindings/ExecutableNodeBinding.inl
@@ -51,7 +51,7 @@ template<typename T>
 boost::python::list requirements( T &n, Gaffer::Context *context )
 {
 	Gaffer::ExecutableNode::Tasks tasks;
-	n.requirements( context, tasks );
+	n.T::requirements( context, tasks );
 	boost::python::list result;
 	for( Gaffer::ExecutableNode::Tasks::const_iterator tIt = tasks.begin(); tIt != tasks.end(); ++tIt )
 	{


### PR DESCRIPTION
`Dispatcher` now throws when it detects cycles in the batch tree. This can be caused by a cycle in the node graph directly, or it can be caused when the dispatcher collapses identical tasks into the same Batch.

I originally tried adding this as a post validation after `batchTasksWalk`, but the direct cycle case causes an infinite loop in `batchTasksWalk` itself, so the validation had to happen during that process. Once I made that change, it was catching all my other cases as well, so I removed the post-validation step as it seemed redundant.

I've also fixed the `ExecutableNode::requirements()` binding, and added a test for an `ExecutableNode` which requires itself, as that's why I started down this path in the first place.