### PR TITLE
Fixed ParameterisedHolder::setParameterised to keep the parameter and plug values in sync.

### DIFF
--- a/python/GafferCortexTest/ParameterisedHolderTest.py
+++ b/python/GafferCortexTest/ParameterisedHolderTest.py
@@ -426,6 +426,7 @@ class ParameterisedHolderTest( GafferTest.TestCase ) :
 
 		self.assertEqual( parameterised[1:], classSpec )
 		self.assertEqual( parameterised[0].typeName(), "SequenceRenumberOp" )
+		self.assertEqual( parameterised[0].parameters()["offset"].getTypedValue(), 21 )
 		self.assertEqual( s["n"]["parameters"]["offset"].getValue(), 21 )
 
 	def testKeepExistingValues( self ) :
@@ -441,6 +442,7 @@ class ParameterisedHolderTest( GafferTest.TestCase ) :
 		ph["parameters"]["lift"].setValue( IECore.Color3f( 1, 0, 0 ) )
 		ph.setParameterised( IECore.Grade(), keepExistingValues=True )
 		self.assertEqual( ph["parameters"]["lift"].getValue(), IECore.Color3f( 1, 0, 0 ) )
+		self.assertEqual( ph.getParameterised()[0].parameters()["lift"].getTypedValue(), IECore.Color3f( 1, 0, 0 ) )
 
 	def testDateTimeParameter( self ) :
 

--- a/src/GafferCortex/ParameterisedHolder.cpp
+++ b/src/GafferCortex/ParameterisedHolder.cpp
@@ -87,7 +87,11 @@ void ParameterisedHolder<BaseType>::setParameterised( IECore::RunTimeTypedPtr pa
 		m_parameterHandler->restore( this );
 	}
 	m_parameterHandler->setupPlug( this );
-	if( !keepExistingValues )
+	if( keepExistingValues )
+	{
+		m_parameterHandler->setParameterValue();
+	}
+	else
 	{
 		m_parameterHandler->setPlugValue();
 	}


### PR DESCRIPTION
I ran into this when writing my own `ExecutableOpHolder` derived class, as I had forgotten to call `parameterHandler().setParameterValue()` explicitly. I don't actually need this merged for my node, now that I've corrected that mistake, but I thought I'd make a pull request anyways, since the bug was fairly non-obvious.

My background dispatching was failing, with errors that sounded like the op was broken, but calling `node.getOp()` from the ScriptEditor showed all parameter values as I'd expect (since I had set a bool plug during that session, which forced the sync). To debug further, I re-opened the script and called `node.getOp()` without touching any plugs interactively, and the parameter values didn't match the plug values this time. At that point, I realized the bug in my `execute()` code.

Anyways, I know it's my fault for trying to access the op parameters without making sure they were synced up, but when opening a fresh script it feels more natural to me if they start off synced up.