### PR TITLE
InteractiveRender early out for empty scenes

### DIFF
--- a/python/GafferRenderManTest/InteractiveRenderManRenderTest.py
+++ b/python/GafferRenderManTest/InteractiveRenderManRenderTest.py
@@ -885,8 +885,8 @@ class InteractiveRenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		for p in [
 			IECore.V2f( 0.5 ),
-			IECore.V2f( 0.1 ),
-			IECore.V2f( 0.9 ),
+			IECore.V2f( 0.15 ),
+			IECore.V2f( 0.85 ),
 		] :
 			c = self.__colorAtUV(
 				IECore.ImageDisplayDriver.storedImage( "myLovelyPlane" ),

--- a/src/GafferScene/InteractiveRender.cpp
+++ b/src/GafferScene/InteractiveRender.cpp
@@ -344,11 +344,6 @@ class InteractiveRender::ChildNamesUpdateTask : public tbb::task
 
 void InteractiveRender::plugDirtied( const Gaffer::Plug *plug )
 {
-	if( inPlug()->childNames( ScenePlug::ScenePath() )->readable().empty() )
-	{
-		stop();
-		return;
-	}
 
 	if(
 		plug == inPlug()->transformPlug() ||
@@ -407,6 +402,12 @@ void InteractiveRender::plugDirtied( const Gaffer::Plug *plug )
 	{
 		try
 		{
+			// no point doing an update if the scene's empty
+			if( inPlug()->childNames( ScenePlug::ScenePath() )->readable().empty() )
+			{
+				stop();
+				return;
+			}
 			update();
 		}
 		catch( const std::exception &e )

--- a/src/GafferScene/InteractiveRender.cpp
+++ b/src/GafferScene/InteractiveRender.cpp
@@ -344,6 +344,12 @@ class InteractiveRender::ChildNamesUpdateTask : public tbb::task
 
 void InteractiveRender::plugDirtied( const Gaffer::Plug *plug )
 {
+	if( inPlug()->childNames( ScenePlug::ScenePath() )->readable().empty() )
+	{
+		stop();
+		return;
+	}
+
 	if(
 		plug == inPlug()->transformPlug() ||
 		plug == inPlug()->globalsPlug()


### PR DESCRIPTION
This saves a bit of pointless fiddling and reduces the number of error messages you get running the unit tests. It also prevents a crash when deleting a running InteractiveRenderManRender node in maya.