### PR TITLE
Improved scene path dialogues

### DIFF
--- a/include/GafferScene/SceneFilterPathFilter.h
+++ b/include/GafferScene/SceneFilterPathFilter.h
@@ -1,0 +1,80 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENE_SCENEFILTERPATHFILTER_H
+#define GAFFERSCENE_SCENEFILTERPATHFILTER_H
+
+#include "Gaffer/PathFilter.h"
+#include "Gaffer/Plug.h"
+
+#include "GafferScene/TypeIds.h"
+
+namespace GafferScene
+{
+
+IE_CORE_FORWARDDECLARE( Filter )
+
+/// Filters a ScenePath using a GafferScene::Filter node.
+class SceneFilterPathFilter : public Gaffer::PathFilter
+{
+
+	public :
+
+		SceneFilterPathFilter( FilterPtr sceneFilter, IECore::CompoundDataPtr userData = NULL );
+		virtual ~SceneFilterPathFilter();
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::SceneFilterPathFilter, SceneFilterPathFilterTypeId, Gaffer::PathFilter );
+
+	protected :
+
+		virtual void doFilter( std::vector<Gaffer::PathPtr> &paths ) const;
+
+	private :
+
+		void plugDirtied( const Gaffer::Plug *plug );
+
+		struct Remove;
+
+		FilterPtr m_sceneFilter;
+		boost::signals::scoped_connection m_plugDirtiedConnection;
+
+};
+
+IE_CORE_DECLAREPTR( SceneFilterPathFilter )
+
+} // namespace GafferScene
+
+#endif // GAFFERSCENE_SCENEFILTERPATHFILTER_H

--- a/include/GafferScene/ScenePath.h
+++ b/include/GafferScene/ScenePath.h
@@ -81,6 +81,8 @@ class ScenePath : public Gaffer::Path
 		virtual bool isLeaf() const;
 		virtual Gaffer::PathPtr copy() const;
 
+		static Gaffer::PathFilterPtr createStandardFilter( const std::vector<std::string> &setNames = std::vector<std::string>(), const std::string &setsLabel = "" );
+
 	protected :
 
 		virtual void doChildren( std::vector<Gaffer::PathPtr> &children ) const;

--- a/include/GafferScene/ScenePath.h
+++ b/include/GafferScene/ScenePath.h
@@ -69,6 +69,10 @@ class ScenePath : public Gaffer::Path
 
 		virtual ~ScenePath();
 
+		void setScene( ScenePlugPtr scene );
+		ScenePlug *getScene();
+		const ScenePlug *getScene() const;
+
 		void setContext( Gaffer::ContextPtr context );
 		Gaffer::Context *getContext();
 		const Gaffer::Context *getContext() const;

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -123,6 +123,7 @@ enum TypeId
 	FilterSwitchTypeId = 110578,
 	DeleteSetsTypeId = 110579,
 	ParametersTypeId = 110580,
+	SceneFilterPathFilterTypeId = 110581,
 
 	LastTypeId = 110650
 };

--- a/include/GafferSceneBindings/SceneFilterPathFilterBinding.h
+++ b/include/GafferSceneBindings/SceneFilterPathFilterBinding.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENEBINDINGS_SCENEFILTERPATHFILTERBINDING_H
+#define GAFFERSCENEBINDINGS_SCENEFILTERPATHFILTERBINDING_H
+
+namespace GafferSceneBindings
+{
+
+void bindSceneFilterPathFilter();
+
+} // namespace GafferSceneBindings
+
+#endif // GAFFERSCENEBINDINGS_SCENEFILTERPATHFILTERBINDING_H

--- a/python/GafferSceneTest/SceneFilterPathFilterTest.py
+++ b/python/GafferSceneTest/SceneFilterPathFilterTest.py
@@ -1,0 +1,102 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferTest
+import GafferScene
+import GafferSceneTest
+
+class SceneFilterPathFilterTest( GafferSceneTest.SceneTestCase ) :
+
+	def test( self ) :
+
+		camera = GafferScene.Camera()
+		plane = GafferScene.Plane()
+		group = GafferScene.Group()
+		group["in"].setInput( camera["out"] )
+		group["in1"].setInput( plane["out"] )
+
+		path = GafferScene.ScenePath( group["out"], Gaffer.Context(), "/group" )
+		self.assertEqual( set( [ str( c ) for c in path.children() ] ), { "/group/camera", "/group/plane" } )
+
+		setFilter = GafferScene.SetFilter()
+		setFilter["set"].setValue( "__cameras" )
+		pathFilter = GafferScene.SceneFilterPathFilter( setFilter )
+
+		path.setFilter( pathFilter )
+		self.assertEqual( set( [ str( c ) for c in path.children() ] ), { "/group/camera" } )
+
+		cs = GafferTest.CapturingSlot( pathFilter.changedSignal() )
+
+		setFilter["set"].setValue( "" )
+		self.assertEqual( len( cs ), 1 )
+		self.assertEqual( path.children(), [] )
+
+	def testManyPaths( self ) :
+
+		plane = GafferScene.Plane()
+		plane["divisions"].setValue( IECore.V2i( 500 ) )
+
+		sphere = GafferScene.Sphere()
+
+		instancer = GafferScene.Instancer()
+		instancer["in"].setInput( plane["out"] )
+		instancer["parent"].setValue( "/plane" )
+		instancer["instance"].setInput( sphere["out"] )
+
+		scenePathFilter = GafferScene.PathFilter()
+		scenePathFilter["paths"].setValue( IECore.StringVectorData( [ "/plane/instances/*" ] ) )
+
+		path = GafferScene.ScenePath(
+			instancer["out"],
+			Gaffer.Context(),
+			"/plane/instances",
+			GafferScene.SceneFilterPathFilter( scenePathFilter )
+		)
+
+		t = IECore.Timer()
+		self.assertEqual( len( path.children() ), 251001 )
+
+		# This test can be useful when benchmarking SceneFilterPathFilter
+		# performance. Uncomment to get timing information.
+		# print t.stop()
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneTest/ScenePathTest.py
+++ b/python/GafferSceneTest/ScenePathTest.py
@@ -193,6 +193,21 @@ class ScenePathTest( unittest.TestCase ) :
 		s1["name"].setValue( "b" )
 		self.assertEqual( len( cs ), 0 )
 
+	def testStandardFilter( self ) :
+
+		camera = GafferScene.Camera()
+		plane = GafferScene.Plane()
+		parent = GafferScene.Parent()
+		parent["in"].setInput( camera["out"] )
+		parent["child"].setInput( plane["out"] )
+		parent["parent"].setValue( "/" )
+
+		path = GafferScene.ScenePath( parent["out"], Gaffer.Context(), "/" )
+		self.assertEqual( { str( c ) for c in path.children() }, { "/camera", "/plane" } )
+
+		path.setFilter( GafferScene.ScenePath.createStandardFilter( [ "__cameras" ] ) )
+		self.assertEqual( { str( c ) for c in path.children() }, { "/camera" } )
+
 if __name__ == "__main__":
 	unittest.main()
 

--- a/python/GafferSceneTest/ScenePathTest.py
+++ b/python/GafferSceneTest/ScenePathTest.py
@@ -162,6 +162,37 @@ class ScenePathTest( unittest.TestCase ) :
 		# trigger plug dirtied on the Box
 		box["p"].setValue( 10 )
 
+	def testSceneAccessors( self ) :
+
+		s1 = GafferScene.Plane()
+		s2 = GafferScene.Plane()
+
+		path = GafferScene.ScenePath( s1["out"], Gaffer.Context(), "/" )
+		self.assertTrue( path.getScene().isSame( s1["out"] ) )
+
+		cs = GafferTest.CapturingSlot( path.pathChangedSignal() )
+
+		s1["name"].setValue( "p" )
+		self.assertEqual( len( cs ), 1 )
+		del cs[:]
+
+		path.setScene( s1["out"] )
+		self.assertEqual( len( cs ), 0 )
+		self.assertTrue( path.getScene().isSame( s1["out"] ) )
+		s1["name"].setValue( "pp" )
+		self.assertEqual( len( cs ), 1 )
+		del cs[:]
+
+		path.setScene( s2["out"] )
+		self.assertEqual( len( cs ), 1 )
+		self.assertTrue( path.getScene().isSame( s2["out"] ) )
+		s2["name"].setValue( "a" )
+		self.assertEqual( len( cs ), 2 )
+		del cs[:]
+
+		s1["name"].setValue( "b" )
+		self.assertEqual( len( cs ), 0 )
+
 if __name__ == "__main__":
 	unittest.main()
 

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -106,6 +106,7 @@ from ClippingPlaneTest import ClippingPlaneTest
 from FilterSwitchTest import FilterSwitchTest
 from PointsTypeTest import PointsTypeTest
 from ParametersTest import ParametersTest
+from SceneFilterPathFilterTest import SceneFilterPathFilterTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferSceneUI/BranchCreatorUI.py
+++ b/python/GafferSceneUI/BranchCreatorUI.py
@@ -37,6 +37,7 @@
 import Gaffer
 import GafferUI
 import GafferScene
+import GafferSceneUI
 
 ##########################################################################
 # Metadata
@@ -64,8 +65,5 @@ Gaffer.Metadata.registerNode(
 GafferUI.PlugValueWidget.registerCreator(
 	GafferScene.BranchCreator,
 	"parent",
-	lambda plug : GafferUI.PathPlugValueWidget(
-		plug,
-		path = GafferScene.ScenePath( plug.node()["in"], plug.node().scriptNode().context(), "/" ),
-	),
+	GafferSceneUI.ScenePathPlugValueWidget
 )

--- a/python/GafferSceneUI/ConstraintUI.py
+++ b/python/GafferSceneUI/ConstraintUI.py
@@ -37,6 +37,7 @@
 import Gaffer
 import GafferUI
 import GafferScene
+import GafferSceneUI
 
 ##########################################################################
 # Metadata
@@ -103,10 +104,7 @@ Gaffer.Metadata.registerNode(
 GafferUI.PlugValueWidget.registerCreator(
 	GafferScene.Constraint,
 	"target",
-	lambda plug : GafferUI.PathPlugValueWidget(
-		plug,
-		path = GafferScene.ScenePath( plug.node()["in"], plug.node().scriptNode().context(), "/" ),
-	),
+	GafferSceneUI.ScenePathPlugValueWidget
 )
 
 GafferUI.PlugValueWidget.registerCreator(

--- a/python/GafferSceneUI/DuplicateUI.py
+++ b/python/GafferSceneUI/DuplicateUI.py
@@ -38,6 +38,7 @@ import Gaffer
 import GafferUI
 
 import GafferScene
+import GafferSceneUI
 
 ##########################################################################
 # Metadata
@@ -124,10 +125,7 @@ GafferUI.PlugValueWidget.registerCreator( GafferScene.Duplicate, "parent", None 
 GafferUI.PlugValueWidget.registerCreator(
 	GafferScene.Duplicate,
 	"target",
-	lambda plug : GafferUI.PathPlugValueWidget(
-		plug,
-		path = GafferScene.ScenePath( plug.node()["in"], plug.node().scriptNode().context(), "/" ),
-	),
+	GafferSceneUI.ScenePathPlugValueWidget
 )
 
 GafferUI.PlugValueWidget.registerCreator( GafferScene.Duplicate, "transform", GafferUI.TransformPlugValueWidget, collapsed=None )

--- a/python/GafferSceneUI/IsolateUI.py
+++ b/python/GafferSceneUI/IsolateUI.py
@@ -38,6 +38,7 @@ import Gaffer
 import GafferUI
 
 import GafferScene
+import GafferSceneUI
 
 ##########################################################################
 # Metadata
@@ -88,8 +89,5 @@ Gaffer.Metadata.registerNode(
 GafferUI.PlugValueWidget.registerCreator(
 	GafferScene.Isolate,
 	"from",
-	lambda plug : GafferUI.PathPlugValueWidget(
-		plug,
-		path = GafferScene.ScenePath( plug.node()["in"], plug.node().scriptNode().context(), "/" ),
-	),
+	GafferSceneUI.ScenePathPlugValueWidget
 )

--- a/python/GafferSceneUI/MapProjectionUI.py
+++ b/python/GafferSceneUI/MapProjectionUI.py
@@ -34,9 +34,12 @@
 #
 ##########################################################################
 
+import IECore
+
 import Gaffer
 import GafferUI
 import GafferScene
+import GafferSceneUI
 
 ##########################################################################
 # Metadata
@@ -99,8 +102,17 @@ Gaffer.Metadata.registerNode(
 GafferUI.PlugValueWidget.registerCreator(
 	GafferScene.MapProjection,
 	"camera",
-	lambda plug : GafferUI.PathPlugValueWidget(
-		plug,
-		path = GafferScene.ScenePath( plug.node()["in"], plug.node().scriptNode().context(), "/" ),
-	),
+	GafferSceneUI.ScenePathPlugValueWidget
+)
+
+Gaffer.Metadata.registerPlugValue(
+	GafferScene.MapProjection,
+	"camera",
+	"scenePathPlugValueWidget:setNames", IECore.StringVectorData( [ "__cameras" ] )
+)
+
+Gaffer.Metadata.registerPlugValue(
+	GafferScene.MapProjection,
+	"camera",
+	"scenePathPlugValueWidget:setsLabel", "Show only cameras"
 )

--- a/python/GafferSceneUI/ScenePathPlugValueWidget.py
+++ b/python/GafferSceneUI/ScenePathPlugValueWidget.py
@@ -1,0 +1,86 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import IECore
+
+import Gaffer
+import GafferUI
+import GafferScene
+
+class ScenePathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
+
+	def __init__( self, plug, path = None, **kw ) :
+
+		if path is None :
+
+			filter = None
+			sets = Gaffer.Metadata.plugValue( plug, "scenePathPlugValueWidget:setNames" )
+			if sets :
+				filter = GafferScene.ScenePath.createStandardFilter(
+					list( sets ),
+					Gaffer.Metadata.plugValue( plug, "scenePathPlugValueWidget:setsLabel" )
+				)
+
+			path = GafferScene.ScenePath(
+				plug.node()["in"],
+				plug.node().scriptNode().context(),
+				"/",
+				filter = filter
+			)
+
+		GafferUI.PathPlugValueWidget.__init__( self, plug, path, **kw )
+
+	def _pathChooserDialogue( self ) :
+
+		dialogue = GafferUI.PathPlugValueWidget._pathChooserDialogue( self )
+
+		# Unsorted tree view with only a name column - like the SceneHierarchy.
+		dialogue.pathChooserWidget().pathListingWidget().setDisplayMode( GafferUI.PathListingWidget.DisplayMode.Tree )
+		dialogue.pathChooserWidget().pathListingWidget().setColumns( ( GafferUI.PathListingWidget.defaultNameColumn, ) )
+		dialogue.pathChooserWidget().pathListingWidget().setSortable( False )
+
+		# View relative to the root, rather than the current location.
+		## \todo The save/restore of pathNames is to work around the PathChooserWidget
+		# truncating the path when the root directory changes. I don't think that
+		# behaviour makes sense in tree view mode, so we should probably fix it there.
+		dirPath = dialogue.pathChooserWidget().directoryPathWidget().getPath()
+		if len( dirPath ) :
+			path = dialogue.pathChooserWidget().pathWidget().getPath()
+			pathNames = path[:]
+			del dirPath[:]
+			path[:] = pathNames
+
+		return dialogue

--- a/python/GafferSceneUI/SceneViewToolbar.py
+++ b/python/GafferSceneUI/SceneViewToolbar.py
@@ -98,9 +98,14 @@ class _LookThroughPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		with row :
 			self.__enabledWidget = GafferUI.BoolPlugValueWidget( plug["enabled"], displayMode=GafferUI.BoolWidget.DisplayMode.Switch )
-			self.__cameraWidget = GafferUI.PathPlugValueWidget(
+			self.__cameraWidget = GafferSceneUI.ScenePathPlugValueWidget(
 				plug["camera"],
-				path = GafferScene.ScenePath( plug.node()["in"], plug.node().getContext(), "/" ),
+				path = GafferScene.ScenePath(
+					plug.node()["in"],
+					plug.node().getContext(),
+					"/",
+					filter = GafferScene.ScenePath.createStandardFilter( [ "__cameras" ], "Show only cameras" )
+				),
 			)
 			self.__cameraWidget.pathWidget().setFixedCharacterWidth( 13 )
 			if hasattr( self.__cameraWidget.pathWidget()._qtWidget(), "setPlaceholderText" ) :

--- a/python/GafferSceneUI/StandardOptionsUI.py
+++ b/python/GafferSceneUI/StandardOptionsUI.py
@@ -34,9 +34,12 @@
 #
 ##########################################################################
 
+import IECore
+
 import Gaffer
 import GafferUI
 import GafferScene
+import GafferSceneUI
 
 ##########################################################################
 # Metadata
@@ -307,8 +310,17 @@ GafferUI.PlugValueWidget.registerCreator(
 GafferUI.PlugValueWidget.registerCreator(
 	GafferScene.StandardOptions,
 	"options.renderCamera.value",
-	lambda plug : GafferUI.PathPlugValueWidget(
-		plug,
-		path = GafferScene.ScenePath( plug.node()["in"], plug.node().scriptNode().context(), "/" ),
-	),
+	GafferSceneUI.ScenePathPlugValueWidget
+)
+
+Gaffer.Metadata.registerPlugValue(
+	GafferScene.StandardOptions,
+	"options.renderCamera.value",
+	"scenePathPlugValueWidget:setNames", IECore.StringVectorData( [ "__cameras" ] )
+)
+
+Gaffer.Metadata.registerPlugValue(
+	GafferScene.StandardOptions,
+	"options.renderCamera.value",
+	"scenePathPlugValueWidget:setsLabel", "Show only cameras"
 )

--- a/python/GafferSceneUI/SubTreeUI.py
+++ b/python/GafferSceneUI/SubTreeUI.py
@@ -90,8 +90,5 @@ Gaffer.Metadata.registerNode(
 GafferUI.PlugValueWidget.registerCreator(
 	GafferScene.SubTree,
 	"root",
-	lambda plug : GafferUI.PathPlugValueWidget(
-		plug,
-		path = GafferScene.ScenePath( plug.node()["in"], plug.node().scriptNode().context(), "/" ),
-	),
+	GafferSceneUI.ScenePathPlugValueWidget
 )

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -40,6 +40,8 @@ from _GafferSceneUI import *
 from SceneHierarchy import SceneHierarchy
 from SceneInspector import SceneInspector
 from FilterPlugValueWidget import FilterPlugValueWidget
+from ScenePathPlugValueWidget import ScenePathPlugValueWidget
+
 import SceneNodeUI
 import SceneReaderUI
 import SceneProcessorUI

--- a/python/GafferTest/PathTest.py
+++ b/python/GafferTest/PathTest.py
@@ -286,6 +286,25 @@ class PathTest( GafferTest.TestCase ) :
 		self.assertEqual( p.property( "name"), "c" )
 		self.assertEqual( p.property( "fullName"), "/a/b/c" )
 
+	def testDisconnectFromFilterChangedOnDestruct( self ) :
+
+		# make a path with a filter
+		f = Gaffer.FileNamePathFilter( [ "*.gfr" ] )
+		p = Gaffer.FileSystemPath( "/a/b/c", filter = f )
+
+		# force the path to connect to the
+		# filter's changed signal.
+		c = p.pathChangedSignal()
+
+		# delete the path
+		del p
+		del c
+
+		# edit the filter
+		f.setEnabled( False )
+
+		# we should not crash
+
 if __name__ == "__main__":
 	unittest.main()
 

--- a/python/GafferUI/MatchPatternPathFilterWidget.py
+++ b/python/GafferUI/MatchPatternPathFilterWidget.py
@@ -52,10 +52,10 @@ class MatchPatternPathFilterWidget( GafferUI.PathFilterWidget ) :
 			self.__enabledWidget = GafferUI.BoolWidget()
 			self.__enabledStateChangedConnection = self.__enabledWidget.stateChangedSignal().connect( Gaffer.WeakMethod( self.__enabledStateChanged ) )
 
-			self.__attributeButton = GafferUI.MenuButton(
+			self.__propertyButton = GafferUI.MenuButton(
 				image = "collapsibleArrowDown.png",
 				hasFrame = False,
-				menu = GafferUI.Menu( Gaffer.WeakMethod( self.__attributeMenuDefinition ) ),
+				menu = GafferUI.Menu( Gaffer.WeakMethod( self.__propertyMenuDefinition ) ),
 			)
 
 			self.__patternWidget = GafferUI.TextWidget()
@@ -76,7 +76,7 @@ class MatchPatternPathFilterWidget( GafferUI.PathFilterWidget ) :
 			editable = self.pathFilter().userData()["UI"]["editable"].value
 
 		self.__enabledWidget.setVisible( not editable )
-		self.__attributeButton.setVisible( editable )
+		self.__propertyButton.setVisible( editable )
 		self.__patternWidget.setVisible( editable )
 
 		label = str( self.pathFilter() )
@@ -129,29 +129,29 @@ class MatchPatternPathFilterWidget( GafferUI.PathFilterWidget ) :
 			self.pathFilter().setMatchPatterns( patterns )
 			self.pathFilter().setEnabled( len( patterns ) )
 
-	def __attributeMenuDefinition( self ) :
+	def __propertyMenuDefinition( self ) :
 
 		## \todo Make this configurable
-		attributesAndLabels = (
+		propertiesAndLabels = (
 			( "name", "Name" ),
 			( "fileSystem:owner", "Owner" ),
 		)
 
 		menuDefinition = IECore.MenuDefinition()
-		for attribute, label in attributesAndLabels :
+		for property, label in propertiesAndLabels :
 			menuDefinition.append(
 				"/" + label,
 				{
-					"command" : IECore.curry( Gaffer.WeakMethod( self.__setAttributeName ), attribute ),
-					"checkBox" : attribute == self.pathFilter().getAttributeName()
+					"command" : IECore.curry( Gaffer.WeakMethod( self.__setPropertyName ), property ),
+					"checkBox" : property == self.pathFilter().getPropertyName()
 				}
 			)
 
 		return menuDefinition
 
-	def __setAttributeName( self, attribute, checked ) :
+	def __setPropertyName( self, property, checked ) :
 
 		with Gaffer.BlockedConnection( self._pathFilterChangedConnection() ) :
-			self.pathFilter().setAttributeName( attribute )
+			self.pathFilter().setPropertyName( property )
 
 GafferUI.PathFilterWidget.registerType( Gaffer.MatchPatternPathFilter, MatchPatternPathFilterWidget )

--- a/python/GafferUI/PathChooserDialogue.py
+++ b/python/GafferUI/PathChooserDialogue.py
@@ -113,6 +113,10 @@ class PathChooserDialogue( GafferUI.Dialogue ) :
 
 		return None
 
+	def pathChooserWidget( self ) :
+
+		return self.__pathChooserWidget
+
 	def __result( self ) :
 
 		result = self.__pathChooserWidget.pathListingWidget().getSelectedPaths()

--- a/src/Gaffer/Path.cpp
+++ b/src/Gaffer/Path.cpp
@@ -77,6 +77,15 @@ Path::Path( const Names &names, const IECore::InternedString &root, PathFilterPt
 
 Path::~Path()
 {
+	if( havePathChangedSignal() && m_filter )
+	{
+		// In an ideal world, we'd derive from boost::signals::trackable, and wouldn't
+		// need to do this manual connection management. But we construct a lot of Path
+		// instances and trackable has significant overhead so we must avoid it. We must
+		// disconnect somehow though, otherwise when the filter changes, filterChanged()
+		// will be called on a dead Path instance.
+		m_filter->changedSignal().disconnect( boost::bind( &Path::filterChanged, this ) );
+	}
 	delete m_pathChangedSignal;
 }
 

--- a/src/GafferScene/SceneFilterPathFilter.cpp
+++ b/src/GafferScene/SceneFilterPathFilter.cpp
@@ -1,0 +1,122 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/bind.hpp"
+
+#include "Gaffer/Context.h"
+
+#include "GafferScene/SceneFilterPathFilter.h"
+#include "GafferScene/ScenePath.h"
+#include "GafferScene/Filter.h"
+#include "GafferScene/ScenePlug.h"
+
+using namespace GafferScene;
+
+SceneFilterPathFilter::SceneFilterPathFilter( FilterPtr sceneFilter, IECore::CompoundDataPtr userData )
+	:	PathFilter( userData ), m_sceneFilter( sceneFilter )
+{
+	m_plugDirtiedConnection = sceneFilter->plugDirtiedSignal().connect(
+		boost::bind( &SceneFilterPathFilter::plugDirtied, this, ::_1 )
+	);
+}
+
+SceneFilterPathFilter::~SceneFilterPathFilter()
+{
+}
+
+struct SceneFilterPathFilter::Remove
+{
+
+	Remove( const Filter *filter )
+		:	m_filter( filter )
+	{
+	}
+
+	bool operator () ( const  Gaffer::PathPtr &path )
+	{
+		const ScenePath *scenePath = IECore::runTimeCast<const ScenePath>( path.get() );
+		if( !scenePath )
+		{
+			return false;
+		}
+
+		// We need to construct a new context based on the ScenePath context.
+		// Constructing contexts does have an associated cost though, so we
+		// only reconstruct when absolutely necessary - generally all the paths
+		// we visit will be using the exact same context and we need construct
+		// only once.
+		const Gaffer::Context *pathContext = scenePath->getContext();
+		if( m_baseContext != pathContext )
+		{
+			m_baseContext = pathContext;
+			m_context = new Gaffer::Context( *pathContext, Gaffer::Context::Borrowed );
+		}
+
+		// Set context up so we can evaluate the scene filter, and return
+		// based on that.
+		Filter::setInputScene( m_context.get(), scenePath->getScene() );
+		m_context->set( ScenePlug::scenePathContextName, path->names() );
+		Gaffer::Context::Scope s( m_context.get() );
+		return !( m_filter->outPlug()->getValue() & ( Filter::DescendantMatch | Filter::ExactMatch ) );
+	}
+
+	private :
+
+		const Filter *m_filter;
+		Gaffer::ConstContextPtr m_baseContext;
+		Gaffer::ContextPtr m_context;
+
+};
+
+void SceneFilterPathFilter::doFilter( std::vector<Gaffer::PathPtr> &paths ) const
+{
+	paths.erase(
+		std::remove_if(
+			paths.begin(),
+			paths.end(),
+			Remove( m_sceneFilter.get() )
+		),
+		paths.end()
+	);
+}
+
+void SceneFilterPathFilter::plugDirtied( const Gaffer::Plug *plug )
+{
+	if( plug == m_sceneFilter->outPlug() )
+	{
+		changedSignal()( this );
+	}
+}

--- a/src/GafferScene/ScenePath.cpp
+++ b/src/GafferScene/ScenePath.cpp
@@ -79,6 +79,39 @@ ScenePath::~ScenePath()
 	}
 }
 
+void ScenePath::setScene( ScenePlugPtr scene )
+{
+	if( m_scene == scene )
+	{
+		return;
+	}
+
+	if( havePathChangedSignal() )
+	{
+		m_node->plugDirtiedSignal().disconnect( boost::bind( &ScenePath::plugDirtied, this, ::_1 ) );
+	}
+
+	m_scene = scene;
+	m_node = scene->node();
+
+	if( m_node && havePathChangedSignal() )
+	{
+		m_node->plugDirtiedSignal().connect( boost::bind( &ScenePath::plugDirtied, this, ::_1 ) );
+	}
+
+	emitPathChanged();
+}
+
+ScenePlug *ScenePath::getScene()
+{
+	return m_scene.get();
+}
+
+const ScenePlug *ScenePath::getScene() const
+{
+	return m_scene.get();
+}
+
 void ScenePath::setContext( Gaffer::ContextPtr context )
 {
 	if( m_context == context )

--- a/src/GafferSceneBindings/SceneFilterPathFilterBinding.cpp
+++ b/src/GafferSceneBindings/SceneFilterPathFilterBinding.cpp
@@ -1,0 +1,57 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "IECorePython/RunTimeTypedBinding.h"
+
+#include "GafferScene/Filter.h"
+#include "GafferScene/SceneFilterPathFilter.h"
+
+#include "GafferSceneBindings/SceneFilterPathFilterBinding.h"
+
+using namespace boost::python;
+using namespace IECorePython;
+using namespace GafferScene;
+
+void GafferSceneBindings::bindSceneFilterPathFilter()
+{
+
+	RunTimeTypedClass<SceneFilterPathFilter>()
+		.def( init<FilterPtr, IECore::CompoundDataPtr>( ( arg( "filter" ), arg( "userData" ) = object() ) ) )
+	;
+
+}

--- a/src/GafferSceneBindings/ScenePathBinding.cpp
+++ b/src/GafferSceneBindings/ScenePathBinding.cpp
@@ -70,6 +70,8 @@ void GafferSceneBindings::bindScenePath()
 				arg( "filter" ) = object()
 			) )
 		)
+		.def( "setScene", &ScenePath::setScene )
+		.def( "getScene", (ScenePlug *(ScenePath::*)())&ScenePath::getScene, return_value_policy<CastToIntrusivePtr>() )
 		.def( "setContext", &ScenePath::setContext )
 		.def( "getContext", (Context *(ScenePath::*)())&ScenePath::getContext, return_value_policy<CastToIntrusivePtr>() )
 	;

--- a/src/GafferSceneBindings/ScenePathBinding.cpp
+++ b/src/GafferSceneBindings/ScenePathBinding.cpp
@@ -35,6 +35,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "boost/python.hpp"
+#include "boost/python/suite/indexing/container_utils.hpp"
 
 #include "Gaffer/Context.h"
 #include "Gaffer/PathFilter.h"
@@ -50,6 +51,18 @@ using namespace IECorePython;
 using namespace Gaffer;
 using namespace GafferBindings;
 using namespace GafferScene;
+
+namespace
+{
+
+PathFilterPtr createStandardFilter( list pythonSetNames, const std::string &setsLabel )
+{
+	std::vector<std::string> setNames;
+	boost::python::container_utils::extend_container( setNames, pythonSetNames );
+	return ScenePath::createStandardFilter( setNames, setsLabel );
+}
+
+} // namespace
 
 void GafferSceneBindings::bindScenePath()
 {
@@ -74,6 +87,12 @@ void GafferSceneBindings::bindScenePath()
 		.def( "getScene", (ScenePlug *(ScenePath::*)())&ScenePath::getScene, return_value_policy<CastToIntrusivePtr>() )
 		.def( "setContext", &ScenePath::setContext )
 		.def( "getContext", (Context *(ScenePath::*)())&ScenePath::getContext, return_value_policy<CastToIntrusivePtr>() )
+		.def( "createStandardFilter", &createStandardFilter, (
+				arg( "setNames" ) = list(),
+				arg( "setsLabel" ) = ""
+			)
+		)
+		.staticmethod( "createStandardFilter" )
 	;
 
 }

--- a/src/GafferSceneModule/GafferSceneModule.cpp
+++ b/src/GafferSceneModule/GafferSceneModule.cpp
@@ -94,6 +94,7 @@
 #include "GafferSceneBindings/ExternalProceduralBinding.h"
 #include "GafferSceneBindings/GroupBinding.h"
 #include "GafferSceneBindings/ScenePathBinding.h"
+#include "GafferSceneBindings/SceneFilterPathFilterBinding.h"
 #include "GafferSceneBindings/ClippingPlaneBinding.h"
 #include "GafferSceneBindings/FilterSwitchBinding.h"
 #include "GafferSceneBindings/PointsTypeBinding.h"
@@ -173,6 +174,7 @@ BOOST_PYTHON_MODULE( _GafferScene )
 	bindCoordinateSystem();
 	bindExternalProcedural();
 	bindScenePath();
+	bindSceneFilterPathFilter();
 	bindClippingPlane();
 	bindFilterSwitch();
 	bindPointsType();


### PR DESCRIPTION
This implements Mathias' request to filter the path chooser to only show cameras when picking the render camera. It turned out to be a bit more involved than I thought it might, but along the way I've fixed a couple of important bugs that cropped up in the paths framework, and improved the path choosers for all scene paths. The "filtering paths based on a Filter node" functionality also gives us the basis for #48.