### PR TITLE
GafferScene documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ script:
     - ./install/gaffer-*/bin/gaffer test GafferSceneTest
     - ./install/gaffer-*/bin/gaffer test GafferSceneUITest
     - ./install/gaffer-*/bin/gaffer test GafferOSLTest
+    - ./install/gaffer-*/bin/gaffer test GafferOSLUITest
     - ./install/gaffer-*/bin/gaffer test GafferRenderManTest
 
 compiler:

--- a/SConstruct
+++ b/SConstruct
@@ -1084,6 +1084,8 @@ libraries = {
 		"requiredOptions" : [ "OSL_SRC_DIR" ],
 	},
 
+	"GafferOSLUITest" : {},
+
 	"GafferAppleseed" : {
 		"envAppends" : {
 			"CPPPATH" : [ "$APPLESEED_INCLUDE_PATH" ],

--- a/include/GafferScene/MapProjection.h
+++ b/include/GafferScene/MapProjection.h
@@ -43,6 +43,11 @@ namespace GafferScene
 {
 
 /// Applies texture coordinates via a camera projection.
+/// \todo At some point I suspect we should move to storing
+/// texture coordinates as a single V2fVectorData primitive
+/// variable. It would be better to replace sNamePlug() and
+/// tNamePlug() with a single plug specifying a prefix (now)
+/// and the name of the primitive variable itself (later).
 class MapProjection : public SceneElementProcessor
 {
 

--- a/python/GafferOSLUI/OSLImageUI.py
+++ b/python/GafferOSLUI/OSLImageUI.py
@@ -43,17 +43,34 @@ import GafferOSL
 # Metadata
 ##########################################################################
 
-Gaffer.Metadata.registerNodeDescription(
+Gaffer.Metadata.registerNode(
 
-GafferOSL.OSLImage,
+	GafferOSL.OSLImage,
 
-"""Executes OSL shaders to perform image processing.""",
+	"description",
+	"""
+	Executes OSL shaders to perform image processing. Use the shaders from
+	the OSL/ImageProcessing menu to read values from the input image and
+	then write values back to it.
+	""",
 
-"shader",
-{
-	"description" : "The shader to be executed - connect the output from an OSL network here.",
-	"nodeGadget:nodulePosition" : "left",
-}
+	plugs = {
+
+		"shader" : [
+
+			"description",
+			"""
+			The shader to be executed - connect the output from an OSL network here.
+			A typical shader network to process RGB would look like this :
+
+				InLayer->ProcessingNodes->OutLayer->OutImage
+			""",
+
+			"nodeGadget:nodulePosition", "left",
+
+		],
+
+	}
 
 )
 

--- a/python/GafferOSLUI/OSLObjectUI.py
+++ b/python/GafferOSLUI/OSLObjectUI.py
@@ -43,18 +43,35 @@ import GafferOSL
 # Metadata
 ##########################################################################
 
-Gaffer.Metadata.registerNodeDescription(
+Gaffer.Metadata.registerNode(
 
-GafferOSL.OSLObject,
+	GafferOSL.OSLObject,
 
-"""Executes OSL shaders to perform object processing.""",
+	"description",
+	"""
+	Executes OSL shaders to perform object processing. Use the shaders from
+	the OSL/ObjectProcessing menu to read primitive variables from the input
+	object and then write primitive variables back to it.
+	""",
 
-"shader",
-{
-	"description" : "The shader to be executed - connect the output from an OSL network here.",
-	"nodeGadget:nodulePosition" : "left",
-}
+	plugs = {
 
+		"shader" : [
+		
+			"description",
+			"""
+			The shader to be executed - connect the output from an OSL network here.
+			A minimal shader network to process P would look like this :
+			
+				InPoint->ProcessingNodes->OutPoint->OutObject
+			""",
+			
+			"nodeGadget:nodulePosition", "left",
+	
+		],
+
+	}
+	
 )
 
 ##########################################################################

--- a/python/GafferOSLUITest/DocumentationTest.py
+++ b/python/GafferOSLUITest/DocumentationTest.py
@@ -1,0 +1,57 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import GafferUITest
+
+import GafferImage
+import GafferImageUI
+import GafferScene
+import GafferSceneUI
+import GafferOSL
+import GafferOSLUI
+
+class DocumentationTest( GafferUITest.TestCase ) :
+
+	def test( self ) :
+
+		self.maxDiff = None
+		self.assertNodesAreDocumented(
+			GafferOSL,
+			additionalTerminalPlugTypes = ( GafferScene.ScenePlug, GafferImage.ImagePlug )
+		)
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferOSLUITest/__init__.py
+++ b/python/GafferOSLUITest/__init__.py
@@ -1,0 +1,40 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+from DocumentationTest import DocumentationTest
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneUI/AimConstraintUI.py
+++ b/python/GafferSceneUI/AimConstraintUI.py
@@ -1,7 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2012, John Haddon. All rights reserved.
-#  Copyright (c) 2012-2014, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -35,68 +34,43 @@
 #
 ##########################################################################
 
-from _GafferSceneUI import *
+import Gaffer
+import GafferScene
 
-from SceneHierarchy import SceneHierarchy
-from SceneInspector import SceneInspector
-from FilterPlugValueWidget import FilterPlugValueWidget
-import SceneNodeUI
-import SceneReaderUI
-import SceneProcessorUI
-import FilteredSceneProcessorUI
-import PruneUI
-import SubTreeUI
-import OutputsUI
-import OptionsUI
-import OpenGLAttributesUI
-import SceneContextVariablesUI
-import SceneWriterUI
-import StandardOptionsUI
-import StandardAttributesUI
-import ShaderUI
-import OpenGLShaderUI
-import ObjectSourceUI
-import TransformUI
-import AttributesUI
-import LightUI
-import InteractiveRenderUI
-import SphereUI
-import MapProjectionUI
-import MapOffsetUI
-import CustomAttributesUI
-import CustomOptionsUI
-import SceneViewToolbar
-import SceneSwitchUI
-import ShaderSwitchUI
-import ShaderAssignmentUI
-import ParentConstraintUI
-import ParentUI
-import PrimitiveVariablesUI
-import DuplicateUI
-import GridUI
-import SetFilterUI
-import DeleteGlobalsUI
-import DeleteOptionsUI
-import DeleteSetsUI
-import ExternalProceduralUI
-import ExecutableRenderUI
-import IsolateUI
-import SelectionToolUI
-import CropWindowToolUI
-import CameraUI
-import SetUI
-import ClippingPlaneUI
-import FilterUI
-import FilterSwitchUI
-import PointsTypeUI
-import ParametersUI
-import TextUI
-import AimConstraintUI
+Gaffer.Metadata.registerNode(
 
-# then all the PathPreviewWidgets. note that the order
-# of import controls the order of display.
+	GafferScene.AimConstraint,
 
-from AlembicPathPreview import AlembicPathPreview
-from SceneReaderPathPreview import SceneReaderPathPreview
+	"description",
+	"""
+	Transforms objects so that they are aimed at
+	a specified target.
+	""",
 
-__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", {}, subdirectory = "GafferSceneUI" )
+	plugs = {
+
+		"aim" : [
+
+			"description",
+			"""
+			The aim vector, specified in object space. The
+			object will be transformed so that this vector
+			points at the target.
+			""",
+
+		],
+
+		"up" : [
+
+			"description",
+			"""
+			The up vector, specified in object space. The
+			object will be transformed so that this vector
+			points up in world space, as far as is possible.
+			""",
+
+		],
+
+	}
+
+)

--- a/python/GafferSceneUI/AlembicSourceUI.py
+++ b/python/GafferSceneUI/AlembicSourceUI.py
@@ -1,0 +1,107 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferUI
+import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.AlembicSource,
+
+	"description",
+	"""
+	Loads Alembic caches. Please note that Gaffer requires
+	a bounding box to be computable for every location in the
+	scene. Alembic files can store such bounding boxes, but
+	in practice they often don't. In this case Gaffer must perform
+	a full scene traversal to compute the appropriate bounding box.
+	It is recommended that if performance is a priority, bounding
+	boxes should be stored explicitly in the Alembic cache, or the
+	Cortex SceneCache (.scc) format should be used instead, since it
+	always stores accurate bounds.
+	""",
+
+	plugs = {
+
+		"fileName" : [
+
+			"description",
+			"""
+			The path to the .abc file to load. Both
+			older HDF5 and newer Ogawa caches are supported.
+			""",
+
+		],
+
+		"refreshCount" : [
+
+			"description",
+			"""
+			Can be incremented to invalidate Gaffer's memory
+			cache and force a reload if the .abc file is
+			changed on disk.
+			""",
+
+		],
+
+	}
+
+)
+
+##########################################################################
+# PlugValueWidgets
+##########################################################################
+
+GafferUI.PlugValueWidget.registerCreator(
+	GafferScene.AlembicSource,
+	"fileName",
+	lambda plug : GafferUI.PathPlugValueWidget( plug,
+		path = Gaffer.FileSystemPath( "/", filter = Gaffer.FileSystemPath.createStandardFilter( extensions = [ "abc" ] ) ),
+		pathChooserDialogueKeywords = {
+			"bookmarks" : GafferUI.Bookmarks.acquire( plug, category = "sceneCache" ),
+			"leaf" : True,
+		},
+	)
+)
+
+GafferUI.PlugValueWidget.registerCreator(
+	GafferScene.AlembicSource,
+	"refreshCount",
+	GafferUI.IncrementingPlugValueWidget,
+	label = "Refresh",
+	undoable = False
+)

--- a/python/GafferSceneUI/BranchCreatorUI.py
+++ b/python/GafferSceneUI/BranchCreatorUI.py
@@ -1,7 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2012, John Haddon. All rights reserved.
-#  Copyright (c) 2013-2014, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -35,92 +34,38 @@
 #
 ##########################################################################
 
-import fnmatch
-
-import IECore
-
 import Gaffer
 import GafferUI
-
 import GafferScene
-import GafferSceneUI
 
-# SceneNode
+##########################################################################
+# Metadata
+##########################################################################
 
-Gaffer.Metadata.registerNodeDescription(
+Gaffer.Metadata.registerNode(
 
-GafferScene.SceneNode,
+	GafferScene.BranchCreator,
 
-"""The base type for all nodes which are capable of generating a hierarchical scene.""",
+	"description",
+	"""
+	Base class for nodes creating a new branch in the scene hierarchy.
+	""",
 
-"out",
-"""The output scene.""",
-
-"enabled",
-"""The on/off state of the node. When it is off, the node outputs an empty scene.""",
+	# Deliberately not documenting parent plug, so that
+	# is given documentation more specific to each
+	# derived class.
 
 )
 
-def __noduleCreator( plug ) :
-
-	if isinstance( plug, GafferScene.ScenePlug ) :
-		return GafferUI.StandardNodule( plug )
-
-	return None
-
-GafferUI.Nodule.registerNodule( GafferScene.SceneNode, fnmatch.translate( "*" ), __noduleCreator )
-GafferUI.PlugValueWidget.registerType( GafferScene.ScenePlug, None )
-
-Gaffer.Metadata.registerPlugValue( GafferScene.SceneNode, "enabled", "nodeUI:section", "Node" )
-
-# Constraint
+##########################################################################
+# Widgets and nodules
+##########################################################################
 
 GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.Constraint,
-	"target",
+	GafferScene.BranchCreator,
+	"parent",
 	lambda plug : GafferUI.PathPlugValueWidget(
 		plug,
 		path = GafferScene.ScenePath( plug.node()["in"], plug.node().scriptNode().context(), "/" ),
 	),
-)
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.Constraint,
-	"targetMode",
-	GafferUI.EnumPlugValueWidget,
-	labelsAndValues = (
-		( "Origin", GafferScene.Constraint.TargetMode.Origin ),
-		( "BoundMin", GafferScene.Constraint.TargetMode.BoundMin ),
-		( "BoundMax", GafferScene.Constraint.TargetMode.BoundMax ),
-		( "BoundCenter", GafferScene.Constraint.TargetMode.BoundCenter ),
-	)
-)
-
-# Plane
-
-Gaffer.Metadata.registerNodeDescription(
-
-GafferScene.Plane,
-
-"""A node which produces scenes containing a plane.""",
-
-"dimensions",
-"Controls size of the plane in X and Y.",
-
-"divisions",
-"Controls tesselation of the plane.",
-
-)
-
-# Cube
-
-Gaffer.Metadata.registerNodeDescription(
-
-GafferScene.Cube,
-
-"""A node which produces scenes containing a cube.""",
-
-"dimensions",
-"Controls size of the cube.",
-
 )

--- a/python/GafferSceneUI/CameraUI.py
+++ b/python/GafferSceneUI/CameraUI.py
@@ -42,8 +42,53 @@ import GafferScene
 # Metadata
 ##########################################################################
 
-Gaffer.Metadata.registerPlugValue( GafferScene.Camera, "projection", "preset:Perspective", "perspective" )
-Gaffer.Metadata.registerPlugValue( GafferScene.Camera, "projection", "preset:Orthographic", "orthographic" )
+Gaffer.Metadata.registerNode(
+
+	GafferScene.Camera,
+
+	"description",
+	"""
+	Produces scenes containing a camera. To choose which camera is
+	used for rendering, use a StandardOptions node.
+	""",
+
+	plugs = {
+
+		"projection" : [
+
+			"description",
+			"""
+			The basic camera type.
+			""",
+
+			"preset:Perspective", "perspective",
+			"preset:Orthographic", "orthographic",
+
+		],
+
+		"fieldOfView" : [
+
+			"description",
+			"""
+			The field of view, specified in degrees, and interpreted
+			as defined in the RenderMan specification. This is only
+			relevant for perspective cameras.
+			""",
+
+		],
+
+		"clippingPlanes" : [
+
+			"description",
+			"""
+			The near and far clipping planes.
+			""",
+
+		],
+
+	}
+
+)
 
 ##########################################################################
 # Widgets and nodules

--- a/python/GafferSceneUI/ConstraintUI.py
+++ b/python/GafferSceneUI/ConstraintUI.py
@@ -1,0 +1,116 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferUI
+import GafferScene
+
+##########################################################################
+# Metadata
+##########################################################################
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.Constraint,
+
+	"description",
+	"""
+	Base type for nodes which constrain objects to a target
+	object by manipulating their transform.
+	""",
+
+	plugs = {
+
+		"target" : [
+
+			"description",
+			"""
+			The scene location to which the objects are constrained.
+			The world space transform of this location forms the basis
+			of the constraint target, but is modified by the targetMode
+			and targetOffset values before the constraint is applied.
+			""",
+
+		],
+
+		"targetMode" : [
+
+			"description",
+			"""
+			The precise location of the target transform - this can be
+			derived from the origin or bounding box of the target location.
+			""",
+
+			"preset:Origin", GafferScene.Constraint.TargetMode.Origin,
+			"preset:BoundMin", GafferScene.Constraint.TargetMode.BoundMin,
+			"preset:BoundMax", GafferScene.Constraint.TargetMode.BoundMax,
+			"preset:BoundCenter", GafferScene.Constraint.TargetMode.BoundCenter,
+
+		],
+
+		"targetOffset" : [
+
+			"description",
+			"""
+			An offset applied to the target transform before the constraint
+			is applied. The offset is measured in the object space of the
+			target location.
+			""",
+
+		],
+
+	},
+
+)
+
+##########################################################################
+# PlugValueWidgets
+##########################################################################
+
+GafferUI.PlugValueWidget.registerCreator(
+	GafferScene.Constraint,
+	"target",
+	lambda plug : GafferUI.PathPlugValueWidget(
+		plug,
+		path = GafferScene.ScenePath( plug.node()["in"], plug.node().scriptNode().context(), "/" ),
+	),
+)
+
+GafferUI.PlugValueWidget.registerCreator(
+	GafferScene.Constraint,
+	"targetMode",
+	GafferUI.PresetsPlugValueWidget,
+)

--- a/python/GafferSceneUI/CoordinateSystemUI.py
+++ b/python/GafferSceneUI/CoordinateSystemUI.py
@@ -1,0 +1,57 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.CoordinateSystem,
+
+	"description",
+	"""
+	Produces scenes containing a coordinate system. Coordinate systems
+	have two main uses :
+
+	- To visualise the transform at a particular location. In this
+	  respect they're similar to locators or nulls in other packages.
+	- To define a named coordinate system to be used in shaders at
+	  render time. This is useful for defining projections or procedural
+	  solid textures. The full path to the location of the coordinate
+	  system should be used to refer to it within shaders.
+	""",
+
+)

--- a/python/GafferSceneUI/CubeUI.py
+++ b/python/GafferSceneUI/CubeUI.py
@@ -1,7 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2012, John Haddon. All rights reserved.
-#  Copyright (c) 2013-2014, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -35,40 +34,29 @@
 #
 ##########################################################################
 
-import fnmatch
-
-import IECore
-
 import Gaffer
-import GafferUI
-
 import GafferScene
-import GafferSceneUI
 
-# SceneNode
+Gaffer.Metadata.registerNode(
 
-Gaffer.Metadata.registerNodeDescription(
+	GafferScene.Cube,
 
-GafferScene.SceneNode,
+	"description",
+	"""
+	Produces scenes containing a cube.
+	""",
 
-"""The base type for all nodes which are capable of generating a hierarchical scene.""",
+	plugs = {
 
-"out",
-"""The output scene.""",
+		"dimensions" : [
 
-"enabled",
-"""The on/off state of the node. When it is off, the node outputs an empty scene.""",
+			"description",
+			"""
+			The size of the cube.
+			""",
+
+		],
+
+	}
 
 )
-
-def __noduleCreator( plug ) :
-
-	if isinstance( plug, GafferScene.ScenePlug ) :
-		return GafferUI.StandardNodule( plug )
-
-	return None
-
-GafferUI.Nodule.registerNodule( GafferScene.SceneNode, fnmatch.translate( "*" ), __noduleCreator )
-GafferUI.PlugValueWidget.registerType( GafferScene.ScenePlug, None )
-
-Gaffer.Metadata.registerPlugValue( GafferScene.SceneNode, "enabled", "nodeUI:section", "Node" )

--- a/python/GafferSceneUI/DeleteAttributesUI.py
+++ b/python/GafferSceneUI/DeleteAttributesUI.py
@@ -1,0 +1,79 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+##########################################################################
+# Metadata
+##########################################################################
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.DeleteAttributes,
+
+	"description",
+	"""
+	Deletes attributes from locations within the scene.
+	Those locations will then inherit the attribute
+	values from ancestor locations instead, or will fall
+	back to using the default attribute value.
+	""",
+
+	plugs = {
+
+		"names" : [
+
+			"description",
+			"""
+			The names of attributes to be removed. Names should be
+			separated by spaces and can use Gaffer's standard wildcards.
+			""",
+
+		],
+
+		"invertNames" : [
+
+			"description",
+			"""
+			When on, matching names are kept, and non-matching names are removed.
+			""",
+
+		],
+
+	}
+
+)

--- a/python/GafferSceneUI/DeleteGlobalsUI.py
+++ b/python/GafferSceneUI/DeleteGlobalsUI.py
@@ -41,6 +41,48 @@ import GafferUI
 import GafferScene
 
 ##########################################################################
+# Metadata
+##########################################################################
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.DeleteGlobals,
+
+	"description",
+	"""
+	A node which removes named items from the globals.
+	To delete outputs or options specifically, prefer
+	the DeleteOutputs and DeleteOptions nodes respectively,
+	as they provide improved interfaces for their specific
+	tasks.
+	""",
+
+	plugs = {
+
+		"names" : [
+
+			"description",
+			"""
+			The names of globals to be removed. Names should be
+			separated by spaces and can use Gaffer's standard wildcards.
+			""",
+
+		],
+
+		"invertNames" : [
+
+			"description",
+			"""
+			When on, matching names are kept, and non-matching names are removed.
+			""",
+
+		],
+
+	}
+
+)
+
+##########################################################################
 # Right click menu for names
 ##########################################################################
 

--- a/python/GafferSceneUI/DeleteOptionsUI.py
+++ b/python/GafferSceneUI/DeleteOptionsUI.py
@@ -41,16 +41,36 @@ import GafferScene
 # Metadata
 ##########################################################################
 
-Gaffer.Metadata.registerNodeDescription(
+Gaffer.Metadata.registerNode(
 
-GafferScene.DeleteOptions,
+	GafferScene.DeleteOptions,
 
-"""A node which removes options from the globals.""",
+	"description",
+	"""
+	A node which removes options from the globals.
+	""",
 
-"names",
-"The names of options to be removed.",
+	plugs = {
 
-"invertNames",
-"When on, matching names are kept, and non-matching names are removed.",
+		"names" : [
+
+			"description",
+			"""
+			The names of options to be removed. Names should be
+			separated by spaces and can use Gaffer's standard wildcards.
+			""",
+
+		],
+
+		"invertNames" : [
+
+			"description",
+			"""
+			When on, matching names are kept, and non-matching names are removed.
+			""",
+
+		],
+
+	}
 
 )

--- a/python/GafferSceneUI/DeleteOutputsUI.py
+++ b/python/GafferSceneUI/DeleteOutputsUI.py
@@ -1,0 +1,76 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+##########################################################################
+# Metadata
+##########################################################################
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.DeleteOutputs,
+
+	"description",
+	"""
+	A node which removes outputs from the globals.
+	""",
+
+	plugs = {
+
+		"names" : [
+
+			"description",
+			"""
+			The names of outputs to be removed. Names should be
+			separated by spaces and can use Gaffer's standard wildcards.
+			""",
+
+		],
+
+		"invertNames" : [
+
+			"description",
+			"""
+			When on, matching names are kept, and non-matching names are removed.
+			""",
+
+		],
+
+	}
+
+)

--- a/python/GafferSceneUI/DeletePrimitiveVariablesUI.py
+++ b/python/GafferSceneUI/DeletePrimitiveVariablesUI.py
@@ -1,0 +1,76 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.DeletePrimitiveVariables,
+
+	"description",
+	"""
+	Deletes primitive variables from objects. The primitive
+	variables to be deleted are chosen based on name.
+	""",
+
+	plugs = {
+
+		"names" : [
+
+			"description",
+			"""
+			The names of the primitive variables to be deleted.
+			Names should be specified by spaces, and Gaffer's
+			standard wildcard characters may be used.
+			""",
+
+		],
+
+		"invertNames" : [
+
+			"description",
+			"""
+			When on, the primitive variables matched by names
+			are kept, and the non-matching primitive variables
+			are deleted.
+			""",
+
+		],
+
+	}
+
+)

--- a/python/GafferSceneUI/DuplicateUI.py
+++ b/python/GafferSceneUI/DuplicateUI.py
@@ -56,6 +56,15 @@ Gaffer.Metadata.registerNode(
 
 	plugs = {
 
+		"parent" : [
+
+			"description",
+			"""
+			For internal use only.
+			""",
+
+		],
+
 		"target" : [
 
 			"description",

--- a/python/GafferSceneUI/FilterMixinBaseUI.py
+++ b/python/GafferSceneUI/FilterMixinBaseUI.py
@@ -1,0 +1,62 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.FilterMixinBase,
+
+	"description",
+	"""
+	Base class used for implementing FilterSwitch.
+	""",
+
+	plugs = {
+
+		"in" : [
+
+			"description",
+			"""
+			The input filter.
+			""",
+
+		]
+
+	}
+
+)

--- a/python/GafferSceneUI/FilterSwitchUI.py
+++ b/python/GafferSceneUI/FilterSwitchUI.py
@@ -48,6 +48,22 @@ Gaffer.Metadata.registerNode(
 	filter through to the output.
 	""",
 
+	plugs = {
+
+		"index" : [
+
+			"description",
+			"""
+			The index of the input which is passed through. A value
+			of 0 chooses the first input, 1 the second and so on. Values
+			larger than the number of available inputs wrap back around to
+			the beginning.
+			"""
+
+		],
+
+	},
+
 )
 
 GafferUI.Nodule.registerNodule( GafferScene.Filter, "index", lambda plug : None )

--- a/python/GafferSceneUI/FreezeTransformUI.py
+++ b/python/GafferSceneUI/FreezeTransformUI.py
@@ -1,0 +1,53 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.FreezeTransform,
+
+	"description",
+	"""
+	Resets the transforms at the specified scene locations,
+	baking the old transforms into the vertices of any child objects
+	so that they remain the same in world space. Essentially this
+	turns transforms in the hierarchy into rigid deformations of
+	the objects.
+	""",
+
+)

--- a/python/GafferSceneUI/GridUI.py
+++ b/python/GafferSceneUI/GridUI.py
@@ -38,20 +38,126 @@ import Gaffer
 import GafferScene
 import GafferUI
 
-Gaffer.Metadata.registerNodeDescription(
+Gaffer.Metadata.registerNode(
 
-GafferScene.Grid,
-"A grid.",
+	GafferScene.Grid,
 
-"name",
-"The name of the grid.",
+	"description",
+	""""
+	A grid. This is used to draw the grid in the viewer,
+	but is also included as a node in case it might be
+	useful, perhaps for placing a grid in renders done
+	using the OpenGLRender node.
+	""",
 
-"transform",
-{
+	plugs = {
 
-	"description" : "The transform applied to the grid.",
-	"nodeUI:section" : "Transform",
-}
+		"name" : [
+
+			"description",
+			"""
+			The name of the grid.
+			""",
+
+		],
+
+		"transform" : [
+
+			"description",
+			"""
+			The transform applied to the grid.
+			""",
+
+			"nodeUI:section", "Transform",
+
+		],
+
+		"dimensions" : [
+
+			"description",
+			"""
+			The size of the grid in the x and y
+			axes. Use the transform to rotate the
+			grid into a different plane.
+			""",
+
+		],
+
+		"spacing" : [
+
+			"description",
+			"""
+			The size of the space between adjacent lines
+			in the grid.
+			"""
+
+		],
+
+		"gridColor" : [
+
+			"description",
+			"""
+			The colour of the lines forming the main part
+			of the grid.
+			"""
+
+		],
+
+		"centerColor" : [
+
+			"description",
+			"""
+			The colour of the two lines forming the central
+			cross of the grid.
+			"""
+
+		],
+
+		"borderColor" : [
+
+			"description",
+			"""
+			The colour of the lines forming the border
+			of the grid.
+			"""
+
+		],
+
+		"gridPixelWidth" : [
+
+			"description",
+			"""
+			The width of the lines forming the main part
+			of the grid. This width applies only to the
+			OpenGL representation of the grid.
+			"""
+
+		],
+
+
+		"centerPixelWidth" : [
+
+			"description",
+			"""
+			The width of the two lines forming the central
+			cross of the grid. This width applies only to the
+			OpenGL representation of the grid.
+			"""
+
+		],
+
+		"borderPixelWidth" : [
+
+			"description",
+			"""
+			The width of the lines forming the border
+			of the grid. This width applies only to the
+			OpenGL representation of the grid.
+			"""
+
+		],
+
+	}
 
 )
 

--- a/python/GafferSceneUI/GroupUI.py
+++ b/python/GafferSceneUI/GroupUI.py
@@ -1,0 +1,89 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferUI
+import GafferScene
+
+##########################################################################
+# Metadata
+##########################################################################
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.Group,
+
+	"description",
+	"""
+	Groups together several input scenes under a new parent.
+	If the input scenes contain locations with identical names,
+	they are automatically renamed to make them unique in the
+	output scene.
+	""",
+
+	plugs = {
+
+		"name" : [
+
+			"description",
+			"""
+			The name of the group to be created. All the input
+			scenes will be parented under this group.
+			""",
+
+		],
+
+		"transform" : [
+
+			"description",
+			"""
+			The transform for the group itself. This will be
+			inherited by the objects parented under it.
+			""",
+
+		],
+
+	}
+
+)
+
+##########################################################################
+# Widgets and nodules
+##########################################################################
+
+
+GafferUI.PlugValueWidget.registerCreator( GafferScene.Group, "in[0-9]*", None )
+GafferUI.PlugValueWidget.registerCreator( GafferScene.Group, "transform", GafferUI.TransformPlugValueWidget, collapsed=None )

--- a/python/GafferSceneUI/InstancerUI.py
+++ b/python/GafferSceneUI/InstancerUI.py
@@ -1,0 +1,114 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferUI
+import GafferScene
+
+##########################################################################
+# Metadata
+##########################################################################
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.Instancer,
+
+	"description",
+	"""
+	Instances an input scene onto the vertices of a target
+	object, making one copy per vertex. Note that in Gaffer,
+	the instances are not limited to being a single object,
+	and each instance need not be identical. Instances can
+	instead include entire hierarchies and can be varied
+	from point to point, and individual instances may be
+	modified downstream without affecting the others. Gaffer
+	ensure's that where instances happen to be identical,
+	they share memory, and performs automatic instancing at
+	the object level when exporting to the renderer (this
+	occurs for all nodes, not just the Instancer).
+
+	Per-instance variation can be achieved using the
+	${instancer:id} variable in the upstream instance graph.
+	A common use case is to use this to randomise the index
+	on a SceneSwitch node, to choose randomly between several
+	instances, but it can be used to drive _any_ property of
+	the upstream graph.
+	""",
+
+	plugs = {
+
+		"parent" : [
+
+			"description",
+			"""
+			The object on which to make the instances. This
+			must have a "P" primitive variable specifying the
+			location of each instance.
+			"""
+
+		],
+
+		"name" : [
+
+			"description",
+			"""
+			The name of the location the instances will be
+			generated below. This will be parented directly
+			under the parent location.
+			"""
+
+		],
+
+		"instance" : [
+
+			"description",
+			"""
+			The scene to be instanced. Use the ${instancer:id}
+			variable in the upstream graph to create per-instance
+			variations.
+			""",
+
+		],
+
+	}
+
+)
+
+##########################################################################
+# Widgets and nodules
+##########################################################################
+
+GafferUI.PlugValueWidget.registerCreator( GafferScene.Instancer, "instance", None )

--- a/python/GafferSceneUI/IsolateUI.py
+++ b/python/GafferSceneUI/IsolateUI.py
@@ -43,14 +43,41 @@ import GafferScene
 # Metadata
 ##########################################################################
 
-Gaffer.Metadata.registerNodeDescription(
+Gaffer.Metadata.registerNode(
 
-GafferScene.Isolate,
+	GafferScene.Isolate,
 
-"""Isolates objects by removing paths not matching a filter from the scene.""",
+	"description",
+	"""
+	Isolates objects by removing paths not matching a filter from the scene.
+	""",
 
-"from",
-"The ancestor to isolate the objects from. Only locations below this will be removed.",
+	plugs = {
+
+		"from" : [
+
+			"description",
+			"""
+			The ancestor to isolate the objects from. Only locations below
+			this will be removed.
+			""",
+
+		],
+
+		"adjustBounds" : [
+
+			"description",
+			"""
+			By default, the bounding boxes of ancestor locations are
+			automatically updated when children are removed. This can
+			be turned off if necessary to get improved performance - in
+			this case the bounding boxes will still wholly contain the
+			contents at each location, but may be bigger than necessary.
+			""",
+
+		],
+
+	}
 
 )
 

--- a/python/GafferSceneUI/MapProjectionUI.py
+++ b/python/GafferSceneUI/MapProjectionUI.py
@@ -38,6 +38,64 @@ import Gaffer
 import GafferUI
 import GafferScene
 
+##########################################################################
+# Metadata
+##########################################################################
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.MapProjection,
+
+	"description",
+	"""
+	Applies texture coordinates to meshes via a camera projection.
+	In Gaffer, texture coordinates (commonly referred to as UVs)
+	are represented as primitive variables named "s" and "t".
+	""",
+
+	plugs = {
+
+		"camera" : [
+
+			"description",
+			"""
+			The location of the camera to use for the projection.
+			""",
+
+		],
+
+		"sName" : [
+
+			"description",
+			"""
+			The name of the primitive variable to store the s
+			coordinate of the projected texture coordinates.
+			This may be changed in order to store multiple
+			sets of texture coordinates on a single mesh.
+			""",
+
+		],
+
+		"tName" : [
+
+			"description",
+			"""
+			The name of the primitive variable to store the t
+			coordinate of the projected texture coordinates.
+			This may be changed in order to store multiple
+			sets of texture coordinates on a single mesh.
+			""",
+
+		],
+
+	}
+
+)
+
+##########################################################################
+# PlugValueWidgets
+##########################################################################
+
 GafferUI.PlugValueWidget.registerCreator(
 	GafferScene.MapProjection,
 	"camera",

--- a/python/GafferSceneUI/MeshTypeUI.py
+++ b/python/GafferSceneUI/MeshTypeUI.py
@@ -1,0 +1,108 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferUI
+import GafferScene
+
+##########################################################################
+# Metadata
+##########################################################################
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.MeshType,
+
+	"description",
+	"""
+	Changes between polygon and subdivision representations
+	for mesh objects, and optionally recalculates vertex
+	normals for polygon meshes.
+
+	Note that currently the Gaffer viewport does not display
+	subdivision meshes with smoothing, so the results of using
+	this node will not be seen until a render is performed.
+	""",
+
+	plugs = {
+
+		"meshType" : [
+
+			"description",
+			"""
+			The interpolation type to apply to the mesh.
+			""",
+
+			"preset:Unchanged", "",
+			"preset:Polygon", "linear",
+			"preset:Subdivision Surface", "catmullClark",
+
+		],
+
+		"calculatePolygonNormals" : [
+
+			"description",
+			"""
+			Causes new vertex normals to be calculated for
+			polygon meshes. Has no effect for subdivision
+			surfaces, since those are naturally smooth and do
+			not require surface normals. Vertex normals are
+			represented as primitive variables named "N".
+			""",
+
+		],
+
+		"overwriteExistingNormals" : [
+
+			"description",
+			"""
+			By default, vertex normals will only be calculated for
+			polygon meshes which don't already have them. Turning
+			this on will force new normals to be calculated even for
+			meshes which had them already.
+			""",
+
+		],
+
+	}
+
+)
+
+##########################################################################
+# Widgets and nodules
+##########################################################################
+
+GafferUI.PlugValueWidget.registerCreator( GafferScene.MeshType, "meshType", GafferUI.PresetsPlugValueWidget )

--- a/python/GafferSceneUI/ObjectSourceUI.py
+++ b/python/GafferSceneUI/ObjectSourceUI.py
@@ -38,20 +38,38 @@ import Gaffer
 import GafferScene
 import GafferUI
 
-Gaffer.Metadata.registerNodeDescription(
+Gaffer.Metadata.registerNode(
 
-GafferScene.ObjectSource,
-"A node which produces scenes with exactly one object in them.",
+	GafferScene.ObjectSource,
 
-"name",
-"The name of the object in the output scene.",
+	"description",
+	"""
+	A node which produces scenes with exactly one object in them.
+	""",
 
-"transform",
-{
+	plugs = {
 
-	"description" : "The transform applied to the object.",
-	"nodeUI:section" : "Transform",
-}
+		"name" : [
+
+			"description",
+			"""
+			The name of the object in the output scene.
+			""",
+
+		],
+
+		"transform" : [
+
+			"description",
+			"""
+			The transform applied to the object.
+			""",
+
+			"nodeUI:section", "Transform",
+
+		],
+
+	}
 
 )
 

--- a/python/GafferSceneUI/ObjectToSceneUI.py
+++ b/python/GafferSceneUI/ObjectToSceneUI.py
@@ -1,0 +1,76 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferUI
+import GafferScene
+
+##########################################################################
+# Metadata
+##########################################################################
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.ObjectToScene,
+
+	"description",
+	"""
+	Converts objects to be used with the nodes in the
+	GafferScene module. Typically these objects would
+	come from a GafferCortex OpHolder node or ObjectReader
+	node.
+	""",
+
+	plugs = {
+
+		"object" : [
+
+			"description",
+			"""
+			The object to be placed in the output scene.
+			""",
+
+		],
+
+	}
+
+)
+
+##########################################################################
+# Widgets and nodules
+##########################################################################
+
+GafferUI.Nodule.registerNodule( GafferScene.ObjectToScene, "object", GafferUI.StandardNodule )

--- a/python/GafferSceneUI/OpenGLAttributesUI.py
+++ b/python/GafferSceneUI/OpenGLAttributesUI.py
@@ -38,6 +38,227 @@ import Gaffer
 import GafferUI
 import GafferScene
 
+##########################################################################
+# Metadata
+##########################################################################
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.OpenGLAttributes,
+
+	"description",
+	"""
+	Applies attributes to modify the appearance of objects in
+	the viewport and in renders done by the OpenGLRender node.
+	""",
+
+	plugs = {
+
+		# General drawing plugs
+
+		"attributes.primitiveSolid" : [
+
+			"description",
+			"""
+			Whether or not the object is rendered solid, in which
+			case the assigned GLSL shader will be used to perform
+			the shading.
+			""",
+
+		],
+
+		"attributes.primitiveWireframe" : [
+
+			"description",
+			"""
+			Whether or not the object is rendered as a wireframe.
+			Use the primitiveWireframeColor and primitiveWireframeWidth
+			plugs for finer control of the wireframe appearance.
+			""",
+
+		],
+
+		"attributes.primitiveWireframeColor" : [
+
+			"description",
+			"""
+			The colour to use for the wireframe rendering. Only
+			meaningful if wireframe rendering is turned on.
+			""",
+
+		],
+
+		"attributes.primitiveWireframeWidth" : [
+
+			"description",
+			"""
+			The width in pixels of the wireframe rendering. Only
+			meaningful if wireframe rendering is turned on.
+			""",
+
+		],
+
+		"attributes.primitiveOutline" : [
+
+			"description",
+			"""
+			Whether or not an outline is drawn around the object.
+			Use the primitiveOutlineColor and primitiveOutlineWidth
+			plugs for finer control of the outline.
+			""",
+
+		],
+
+		"attributes.primitiveOutlineColor" : [
+
+			"description",
+			"""
+			The colour to use for the outline. Only
+			meaningful if outline rendering is turned on.
+			""",
+
+		],
+
+		"attributes.primitiveOutlineWidth" : [
+
+			"description",
+			"""
+			The width in pixels of the outline. Only
+			meaningful if outline rendering is turned on.
+			""",
+
+		],
+
+		"attributes.primitivePoint" : [
+
+			"description",
+			"""
+			Whether or not the individual points (vertices) of the
+			object are drawn. Use the primitivePointColor and primitivePointWidth
+			plugs for finer control of the point rendering.
+			""",
+
+		],
+
+		"attributes.primitivePointColor" : [
+
+			"description",
+			"""
+			The colour to use for the point rendering. Only
+			meaningful if point rendering is turned on.
+			""",
+
+		],
+
+		"attributes.primitivePointWidth" : [
+
+			"description",
+			"""
+			The width in pixels of the points. Only
+			meaningful if point rendering is turned on.
+			""",
+
+		],
+
+		"attributes.primitiveBound" : [
+
+			"description",
+			"""
+			Whether or not the bounding box of the object is drawn.
+			This is in addition to any drawing of unexpanded bounding
+			boxes that the viewer performs. Use the primitiveBoundColor
+			plug to change the colour of the bounding box.
+			""",
+
+		],
+
+		"attributes.primitiveBoundColor" : [
+
+			"description",
+			"""
+			The colour to use for the bounding box rendering. Only
+			meaningful if bounding box rendering is turned on.
+			""",
+
+		],
+
+		# Points primitive drawing plugs
+
+		"attributes.pointsPrimitiveUseGLPoints" : [
+
+			"description",
+			"""
+			Points primitives have a render type (set by the PointsType
+			node) which allows them to be rendered as particles, disks,
+			spheres etc. This attribute overrides that type for OpenGL
+			only, allowing a much faster rendering as raw OpenGL points.
+			""",
+
+		],
+
+		"attributes.pointsPrimitiveUseGLPoints.value" : [
+
+			"preset:For GL Points", "forGLPoints",
+			"preset:For Particles And Disks", "forParticlesAndDisks",
+			"preset:For All", "forAll",
+
+		],
+
+		"attributes.pointsPrimitiveGLPointWidth" : [
+
+			"description",
+			"""
+			The width in pixels of the GL points rendered when
+			the pointsPrimitiveUseGLPoints plug has overridden
+			the point type.
+			""",
+
+		],
+
+		# Curves primitive drawing plugs
+
+		"attributes.curvesPrimitiveUseGLLines" : [
+
+			"description",
+			"""
+			Curves primitives are typically rendered as ribbons
+			and as such have an associated width in object space.
+			This attribute overrides that for OpenGL only, allowing
+			a much faster rendering as raw OpenGL lines.
+			""",
+
+		],
+
+		"attributes.curvesPrimitiveGLLineWidth" : [
+
+			"description",
+			"""
+			The width in pixels of the GL lines rendered when
+			the curvesPrimitiveUseGLLines plug has overridden
+			the drawing to use lines.
+			""",
+
+		],
+
+		"attributes.curvesPrimitiveIgnoreBasis" : [
+
+			"description",
+			"""
+			Turns off interpolation for cubic curves, just
+			rendering straight lines between the vertices
+			instead.
+			""",
+
+		],
+
+	}
+
+)
+
+##########################################################################
+# PlugValueWidgets
+##########################################################################
+
 def __drawingSummary( plug ) :
 
 	info = []
@@ -143,10 +364,5 @@ GafferUI.PlugValueWidget.registerCreator(
 GafferUI.PlugValueWidget.registerCreator(
 	GafferScene.OpenGLAttributes,
 	"attributes.pointsPrimitiveUseGLPoints.value",
-	GafferUI.EnumPlugValueWidget,
-	labelsAndValues = (
-		( "For GL Points", "forGLPoints" ),
-		( "For Particles And Disks", "forParticlesAndDisks" ),
-		( "For All", "forAll" ),
-	),
+	GafferUI.PresetsPlugValueWidget
 )

--- a/python/GafferSceneUI/OpenGLRenderUI.py
+++ b/python/GafferSceneUI/OpenGLRenderUI.py
@@ -1,0 +1,55 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+##########################################################################
+# Metadata
+##########################################################################
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.OpenGLRender,
+
+	"description",
+	"""
+	Renders scenes using the same OpenGL engine as is used in the viewer.
+	Use the OpenGLShader and OpenGLAttributes nodes to specify the appearance
+	of objects within the render.
+	""",
+
+)

--- a/python/GafferSceneUI/OpenGLShaderUI.py
+++ b/python/GafferSceneUI/OpenGLShaderUI.py
@@ -40,10 +40,30 @@ import string
 
 import IECore
 
+import Gaffer
+import GafferUI
 import GafferImage
 import GafferScene
 
-import GafferUI
+##########################################################################
+# Metadata
+##########################################################################
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.OpenGLShader,
+
+	"description",
+	"""
+	Loads GLSL shaders for use in the viewer and the OpenGLRender node.
+	GLSL shaders are loaded from *.frag and *.vert files in directories
+	specified by the IECOREGL_SHADER_PATH environment variable.
+
+	Use the ShaderAssignment node to assign shaders to objects in the
+	scene.
+	""",
+
+)
 
 ##########################################################################
 # Nodules

--- a/python/GafferSceneUI/OutputsUI.py
+++ b/python/GafferSceneUI/OutputsUI.py
@@ -47,6 +47,52 @@ import GafferScene
 import GafferSceneUI
 
 ##########################################################################
+# Metadata
+##########################################################################
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.Outputs,
+
+	"description",
+	"""
+	Defines the image outputs to be created by the renderer. Arbitrary
+	outputs can be defined within the UI and also via the
+	`Outputs::addOutput()` API. Commonly used outputs may also
+	be predefined at startup via a config file - see
+	$GAFFER_ROOT/startup/gui/outputs.py for an example.
+	""",
+
+	plugs = {
+
+		"outputs" : [
+
+			"description",
+			"""
+			The outputs defined by this node.
+			""",
+
+		],
+
+		"outputs.*.parameters.quantize.value" : [
+
+			"description",
+			"""
+			The bit depth of the image.
+			""",
+
+			"preset:8 bit", IECore.IntVectorData( [ 0, 255, 0, 255 ] ),
+			"preset:16 bit", IECore.IntVectorData( [ 0, 65535, 0, 65535 ] ),
+			"preset:Float", IECore.IntVectorData( [ 0, 0, 0, 0 ] ),
+
+
+		],
+
+	}
+
+)
+
+##########################################################################
 # Custom PlugValueWidgets for listing outputs
 ##########################################################################
 
@@ -213,12 +259,7 @@ GafferUI.PlugValueWidget.registerCreator(
 GafferUI.PlugValueWidget.registerCreator(
 	GafferScene.Outputs,
 	re.compile( "outputs.*.parameters.quantize" ),
-	GafferUI.EnumPlugValueWidget,
-	labelsAndValues = [
-		( "8 bit", IECore.IntVectorData( [ 0, 255, 0, 255 ] ) ),
-		( "16 bit", IECore.IntVectorData( [ 0, 65535, 0, 65535 ] ) ),
-		( "Float", IECore.IntVectorData( [ 0, 0, 0, 0 ] ) ),
-	]
+	GafferUI.PresetsPlugValueWidget
 )
 
 GafferUI.PlugValueWidget.registerCreator(

--- a/python/GafferSceneUI/ParentUI.py
+++ b/python/GafferSceneUI/ParentUI.py
@@ -43,14 +43,36 @@ import GafferScene
 # Metadata
 ##########################################################################
 
-Gaffer.Metadata.registerNodeDescription(
+Gaffer.Metadata.registerNode(
 
-GafferScene.Parent,
+	GafferScene.Parent,
 
-"""Parents one scene hierarchy into another.""",
+	"description",
+	"""
+	Parents one scene hierarchy into another.
+	""",
 
-"child",
-"The child hierarchy to be parented.",
+	plugs = {
+
+		"parent" : [
+
+			"description",
+			"""
+			The location which the child is parented under.
+			""",
+
+		],
+
+		"child" : [
+
+			"description",
+			"""
+			The child hierarchy to be parented.
+			""",
+
+		],
+
+	}
 
 )
 

--- a/python/GafferSceneUI/PathFilterUI.py
+++ b/python/GafferSceneUI/PathFilterUI.py
@@ -1,0 +1,109 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferUI
+
+import GafferScene
+
+##########################################################################
+# Metadata
+##########################################################################
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.PathFilter,
+
+	"description",
+	"""
+	Chooses locations by matching them against a list of
+	paths.
+	""",
+
+	plugs = {
+
+		"paths" : [
+
+			"description",
+			"""
+			The list of paths to the locations to be matched by the filter.
+			A path is formed by a sequence of names separated by '/', and
+			specifies the hierarchical position of a location within the scene.
+			Paths may use Gaffer's standard wildcard characters to match
+			multiple locations.
+
+			The '*' wildcard matches any sequence of characters within
+			an individual name, but never matches across names separated
+			by a '/'.
+
+			 - /robot/*Arm matches /robot/leftArm, /robot/rightArm and
+			   /robot/Arm. But does not match /robot/limbs/leftArm or
+			   /robot/arm.
+
+			The "..." wildcard matches any sequence of names, and can be
+			used to match locations no matter where they are parented in
+			the hierarchy.
+
+			 - /.../house matches /house, /street/house and /city/street/house.
+			""",
+
+		],
+
+	}
+
+)
+
+##########################################################################
+# Widgets and nodules
+##########################################################################
+
+def __pathsPlugWidgetCreator( plug ) :
+
+	result = GafferUI.VectorDataPlugValueWidget( plug )
+	result.vectorDataWidget().setDragPointer( "objects" )
+	return result
+
+GafferUI.PlugValueWidget.registerCreator(
+	GafferScene.PathFilter,
+	"paths",
+	__pathsPlugWidgetCreator,
+)
+
+GafferUI.Nodule.registerNodule(
+	GafferScene.PathFilter,
+	"paths",
+	lambda plug : None,
+)

--- a/python/GafferSceneUI/PlaneUI.py
+++ b/python/GafferSceneUI/PlaneUI.py
@@ -1,7 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2012, John Haddon. All rights reserved.
-#  Copyright (c) 2013-2014, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -35,53 +34,39 @@
 #
 ##########################################################################
 
-import fnmatch
-
-import IECore
-
 import Gaffer
-import GafferUI
-
 import GafferScene
-import GafferSceneUI
 
-# SceneNode
+Gaffer.Metadata.registerNode(
 
-Gaffer.Metadata.registerNodeDescription(
+	GafferScene.Plane,
 
-GafferScene.SceneNode,
+	"description",
+	"""
+	Produces scenes containing a plane.
+	""",
 
-"""The base type for all nodes which are capable of generating a hierarchical scene.""",
+	plugs = {
 
-"out",
-"""The output scene.""",
+		"dimensions" : [
 
-"enabled",
-"""The on/off state of the node. When it is off, the node outputs an empty scene.""",
+			"description",
+			"""
+			The size of the plane in the X and Y directions.
+			""",
 
-)
+		],
 
-def __noduleCreator( plug ) :
+		"divisions" : [
 
-	if isinstance( plug, GafferScene.ScenePlug ) :
-		return GafferUI.StandardNodule( plug )
+			"description",
+			"""
+			The number of subdivisions of the plane in the
+			X and Y directions.
+			""",
 
-	return None
+		],
 
-GafferUI.Nodule.registerNodule( GafferScene.SceneNode, fnmatch.translate( "*" ), __noduleCreator )
-GafferUI.PlugValueWidget.registerType( GafferScene.ScenePlug, None )
-
-Gaffer.Metadata.registerPlugValue( GafferScene.SceneNode, "enabled", "nodeUI:section", "Node" )
-
-# Cube
-
-Gaffer.Metadata.registerNodeDescription(
-
-GafferScene.Cube,
-
-"""A node which produces scenes containing a cube.""",
-
-"dimensions",
-"Controls size of the cube.",
+	}
 
 )

--- a/python/GafferSceneUI/PointConstraintUI.py
+++ b/python/GafferSceneUI/PointConstraintUI.py
@@ -1,0 +1,92 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.PointConstraint,
+
+	"description",
+	"""
+	Translates objects so that they are constrained to
+	the world space position of the target. Leaves the
+	scale and orientation of the object untouched.
+	""",
+
+	plugs = {
+
+		"offset" : [
+
+			"description",
+			"""
+			A world space translation offset applied on top
+			of the target position.
+			""",
+
+		],
+
+		"xEnabled" : [
+
+			"description",
+			"""
+			Enables the constraint in the world space x axis.
+			""",
+
+		],
+
+		"yEnabled" : [
+
+			"description",
+			"""
+			Enables the constraint in the world space y axis.
+			""",
+
+		],
+
+		"zEnabled" : [
+
+			"description",
+			"""
+			Enables the constraint in the world space z axis.
+			""",
+
+		],
+
+	}
+
+)

--- a/python/GafferSceneUI/SceneContextVariablesUI.py
+++ b/python/GafferSceneUI/SceneContextVariablesUI.py
@@ -34,7 +34,33 @@
 #
 ##########################################################################
 
+import Gaffer
 import GafferUI
 import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.SceneContextVariables,
+
+	"description",
+	"""
+	Adds variables which can be referenced by upstream expressions.
+	""",
+
+	plugs = {
+
+		"variables" : [
+
+			"description",
+			"""
+			The variables to be added - arbitrary numbers of variables
+			can be added here.
+			"""
+
+		]
+
+	}
+
+)
 
 GafferUI.PlugValueWidget.registerCreator( GafferScene.SceneContextVariables, "variables", GafferUI.CompoundDataPlugValueWidget, collapsed=None )

--- a/python/GafferSceneUI/SceneElementProcessorUI.py
+++ b/python/GafferSceneUI/SceneElementProcessorUI.py
@@ -1,0 +1,51 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.SceneElementProcessor,
+
+	"description",
+	"""
+	Base class for nodes which modify individual scene
+	locations, but do not alter the hierarchy in any
+	way.
+	""",
+
+)

--- a/python/GafferSceneUI/SceneMixinBaseUI.py
+++ b/python/GafferSceneUI/SceneMixinBaseUI.py
@@ -1,0 +1,49 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.SceneMixinBase,
+
+	"description",
+	"""
+	Base class used for implementing SceneSwitch, SceneTimeWarp etc.
+	""",
+
+)

--- a/python/GafferSceneUI/SceneNodeUI.py
+++ b/python/GafferSceneUI/SceneNodeUI.py
@@ -37,27 +37,46 @@
 
 import fnmatch
 
-import IECore
-
 import Gaffer
 import GafferUI
 
 import GafferScene
-import GafferSceneUI
 
-# SceneNode
+Gaffer.Metadata.registerNode(
 
-Gaffer.Metadata.registerNodeDescription(
+	GafferScene.SceneNode,
 
-GafferScene.SceneNode,
+	"description",
+	"""
+	The base type for all nodes which are capable of generating a
+	hierarchical scene.
+	""",
 
-"""The base type for all nodes which are capable of generating a hierarchical scene.""",
+	plugs = {
 
-"out",
-"""The output scene.""",
+		"out" : [
 
-"enabled",
-"""The on/off state of the node. When it is off, the node outputs an empty scene.""",
+			"description",
+			"""
+			The output scene.
+			""",
+
+		],
+
+
+		"enabled" : [
+
+			"description",
+			"""
+			The on/off state of the node. When it is off, the node outputs
+			an empty scene.
+			""",
+
+			"nodeUI:section", "Node",
+
+		],
+
+	}
 
 )
 
@@ -70,5 +89,3 @@ def __noduleCreator( plug ) :
 
 GafferUI.Nodule.registerNodule( GafferScene.SceneNode, fnmatch.translate( "*" ), __noduleCreator )
 GafferUI.PlugValueWidget.registerType( GafferScene.ScenePlug, None )
-
-Gaffer.Metadata.registerPlugValue( GafferScene.SceneNode, "enabled", "nodeUI:section", "Node" )

--- a/python/GafferSceneUI/SceneNodeUI.py
+++ b/python/GafferSceneUI/SceneNodeUI.py
@@ -115,19 +115,6 @@ GafferUI.PlugValueWidget.registerCreator(
 	)
 )
 
-# MeshType
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.MeshType,
-	"meshType",
-	GafferUI.EnumPlugValueWidget,
-	labelsAndValues = (
-		( "Unchanged", "" ),
-		( "Poly", "linear" ),
-		( "Subdiv", "catmullClark" ),
-	),
-)
-
 # Plane
 
 Gaffer.Metadata.registerNodeDescription(

--- a/python/GafferSceneUI/SceneNodeUI.py
+++ b/python/GafferSceneUI/SceneNodeUI.py
@@ -73,29 +73,6 @@ GafferUI.PlugValueWidget.registerType( GafferScene.ScenePlug, None )
 
 Gaffer.Metadata.registerPlugValue( GafferScene.SceneNode, "enabled", "nodeUI:section", "Node" )
 
-# Constraint
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.Constraint,
-	"target",
-	lambda plug : GafferUI.PathPlugValueWidget(
-		plug,
-		path = GafferScene.ScenePath( plug.node()["in"], plug.node().scriptNode().context(), "/" ),
-	),
-)
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.Constraint,
-	"targetMode",
-	GafferUI.EnumPlugValueWidget,
-	labelsAndValues = (
-		( "Origin", GafferScene.Constraint.TargetMode.Origin ),
-		( "BoundMin", GafferScene.Constraint.TargetMode.BoundMin ),
-		( "BoundMax", GafferScene.Constraint.TargetMode.BoundMax ),
-		( "BoundCenter", GafferScene.Constraint.TargetMode.BoundCenter ),
-	)
-)
-
 # Plane
 
 Gaffer.Metadata.registerNodeDescription(

--- a/python/GafferSceneUI/SceneNodeUI.py
+++ b/python/GafferSceneUI/SceneNodeUI.py
@@ -81,28 +81,6 @@ GafferUI.PlugValueWidget.registerCreator( GafferScene.Instancer, "instance", Non
 
 GafferUI.Nodule.registerNodule( GafferScene.ObjectToScene, "object", GafferUI.StandardNodule )
 
-# AlembicSource
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.AlembicSource,
-	"fileName",
-	lambda plug : GafferUI.PathPlugValueWidget( plug,
-		path = Gaffer.FileSystemPath( "/", filter = Gaffer.FileSystemPath.createStandardFilter( extensions = [ "abc" ] ) ),
-		pathChooserDialogueKeywords = {
-			"bookmarks" : GafferUI.Bookmarks.acquire( plug, category = "sceneCache" ),
-			"leaf" : True,
-		},
-	)
-)
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.AlembicSource,
-	"refreshCount",
-	GafferUI.IncrementingPlugValueWidget,
-	label = "Refresh",
-	undoable = False
-)
-
 # BranchCreator
 
 GafferUI.PlugValueWidget.registerCreator(

--- a/python/GafferSceneUI/SceneNodeUI.py
+++ b/python/GafferSceneUI/SceneNodeUI.py
@@ -73,10 +73,6 @@ GafferUI.PlugValueWidget.registerType( GafferScene.ScenePlug, None )
 
 Gaffer.Metadata.registerPlugValue( GafferScene.SceneNode, "enabled", "nodeUI:section", "Node" )
 
-# ObjectToScene
-
-GafferUI.Nodule.registerNodule( GafferScene.ObjectToScene, "object", GafferUI.StandardNodule )
-
 # BranchCreator
 
 GafferUI.PlugValueWidget.registerCreator(

--- a/python/GafferSceneUI/SceneNodeUI.py
+++ b/python/GafferSceneUI/SceneNodeUI.py
@@ -181,17 +181,3 @@ GafferUI.Nodule.registerNodule(
 	"paths",
 	lambda plug : None,
 )
-
-# UnionFilter
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.UnionFilter,
-	"in",
-	None,
-)
-
-GafferUI.Nodule.registerNodule(
-	GafferScene.UnionFilter,
-	"in",
-	GafferUI.CompoundNodule
-)

--- a/python/GafferSceneUI/SceneNodeUI.py
+++ b/python/GafferSceneUI/SceneNodeUI.py
@@ -161,23 +161,3 @@ GafferScene.Cube,
 "Controls size of the cube.",
 
 )
-
-# PathFilter
-
-def __pathsPlugWidgetCreator( plug ) :
-
-	result = GafferUI.VectorDataPlugValueWidget( plug )
-	result.vectorDataWidget().setDragPointer( "objects" )
-	return result
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.PathFilter,
-	"paths",
-	__pathsPlugWidgetCreator,
-)
-
-GafferUI.Nodule.registerNodule(
-	GafferScene.PathFilter,
-	"paths",
-	lambda plug : None,
-)

--- a/python/GafferSceneUI/SceneNodeUI.py
+++ b/python/GafferSceneUI/SceneNodeUI.py
@@ -92,11 +92,6 @@ GafferUI.PlugValueWidget.registerCreator(
 	),
 )
 
-# Group
-
-GafferUI.PlugValueWidget.registerCreator( GafferScene.Group, "in[0-9]*", None )
-GafferUI.PlugValueWidget.registerCreator( GafferScene.Group, "transform", GafferUI.TransformPlugValueWidget, collapsed=None )
-
 # Constraint
 
 GafferUI.PlugValueWidget.registerCreator(

--- a/python/GafferSceneUI/SceneNodeUI.py
+++ b/python/GafferSceneUI/SceneNodeUI.py
@@ -73,10 +73,6 @@ GafferUI.PlugValueWidget.registerType( GafferScene.ScenePlug, None )
 
 Gaffer.Metadata.registerPlugValue( GafferScene.SceneNode, "enabled", "nodeUI:section", "Node" )
 
-# Instancer
-
-GafferUI.PlugValueWidget.registerCreator( GafferScene.Instancer, "instance", None )
-
 # ObjectToScene
 
 GafferUI.Nodule.registerNodule( GafferScene.ObjectToScene, "object", GafferUI.StandardNodule )

--- a/python/GafferSceneUI/SceneReaderUI.py
+++ b/python/GafferSceneUI/SceneReaderUI.py
@@ -44,17 +44,59 @@ import GafferScene
 # Metadata
 ##########################################################################
 
-Gaffer.Metadata.registerNodeDescription(
+Gaffer.Metadata.registerNode(
 
-GafferScene.SceneReader,
+	GafferScene.SceneReader,
 
-"""Reads scenes in any of the formats supported by Cortex's SceneInterface.""",
+	"description",
+	"""
+	Reads scenes in any of the formats supported by Cortex's SceneInterface.
+	""",
 
-"tags",
-"Limits the parts of the scene loaded to only those with a specific set of tags.",
+	plugs = {
 
-"sets",
-"Specifies a list of tags to be loaded and converted into gaffer sets.",
+		"fileName" : [
+
+			"description",
+			"""
+			The name of the file to be loaded. The file can be
+			in any of the formats supported by Cortex's SceneInterfaces.
+			""",
+
+		],
+
+		"refreshCount" : [
+
+			"description",
+			"""
+			May be incremented to force a reload if the file has
+			changed on disk - otherwise old contents may still
+			be loaded via Gaffer's cache.
+			""",
+
+		],
+
+		"tags" : [
+
+			"description",
+			"""
+			Limits the parts of the scene loaded to only those
+			with a specific set of tags.
+			""",
+
+		],
+
+		"sets" : [
+
+			"description",
+			"""
+			Specifies a list of tags to be loaded and converted
+			into gaffer sets.
+			""",
+
+		],
+
+	}
 
 )
 

--- a/python/GafferSceneUI/SceneSwitchUI.py
+++ b/python/GafferSceneUI/SceneSwitchUI.py
@@ -34,7 +34,37 @@
 #
 ##########################################################################
 
+import Gaffer
 import GafferUI
 import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.SceneSwitch,
+
+	"description",
+	"""
+	Chooses between multiple input scene, passing through the
+	chosen input to the output.
+	""",
+
+	plugs = {
+
+		"index" : [
+
+			"description",
+			"""
+			The index of the input which is passed through. A value
+			of 0 chooses the first input, 1 the second and so on. Values
+			larger than the number of available inputs wrap back around to
+			the beginning.
+			"""
+
+		]
+
+	}
+
+)
+
 
 GafferUI.PlugValueWidget.registerCreator( GafferScene.SceneSwitch, "in[0-9]*", None )

--- a/python/GafferSceneUI/SceneTimeWarpUI.py
+++ b/python/GafferSceneUI/SceneTimeWarpUI.py
@@ -1,0 +1,74 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.SceneTimeWarp,
+
+	"description",
+	"""
+	Changes the time at which upstream nodes are evaluated using
+	the following formula :
+
+	`upstreamFrame = frame * speed + offset`
+	""",
+
+	plugs = {
+
+		"speed" : [
+
+			"description",
+			"""
+			Multiplies the current frame value.
+			"""
+
+		],
+
+		"offset" : [
+
+			"description",
+			"""
+			Adds to the current frame value (after multiplication with speed).
+			"""
+
+		],
+
+	}
+
+)

--- a/python/GafferSceneUI/SceneWriterUI.py
+++ b/python/GafferSceneUI/SceneWriterUI.py
@@ -34,15 +34,69 @@
 #
 ##########################################################################
 
+import IECore
+
 import Gaffer
 import GafferUI
 import GafferScene
 
+Gaffer.Metadata.registerNode(
+
+	GafferScene.SceneWriter,
+
+	"description",
+	"""
+	Writes scenes to disk. Supports all formats for which a
+	writeable Cortex SceneInterface exists.
+	""",
+
+	plugs = {
+
+		"fileName" : [
+
+			"description",
+			"""
+			The name of the file to be written. Note that unlike
+			image sequences, many scene formats write animation into
+			a single file, so using # characters to specify a frame
+			number is generally not necessary.
+			"""
+
+		],
+
+		"in" : [
+
+			"description",
+			"""
+			The scene to be written.
+			"""
+
+		],
+
+		"out" : [
+
+			"description",
+			"""
+			A direct pass-through of the input scene.
+			"""
+
+		],
+
+	}
+
+)
+
 GafferUI.PlugValueWidget.registerCreator(
 	GafferScene.SceneWriter,
 	"fileName",
-	lambda plug : GafferUI.PathPlugValueWidget( plug,
-		path = Gaffer.FileSystemPath( "/", filter = Gaffer.FileSystemPath.createStandardFilter() ),
+	lambda plug : GafferUI.PathPlugValueWidget(
+		plug,
+		path = Gaffer.FileSystemPath(
+			"/",
+			filter = Gaffer.FileSystemPath.createStandardFilter(
+				extensions = IECore.SceneInterface.supportedExtensions( IECore.IndexedIO.OpenMode.Write )
+			)
+		),
 		pathChooserDialogueKeywords = {
 			"bookmarks" : GafferUI.Bookmarks.acquire( plug, category = "sceneCache" ),
 			"leaf" : True,

--- a/python/GafferSceneUI/SeedsUI.py
+++ b/python/GafferSceneUI/SeedsUI.py
@@ -1,0 +1,109 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferUI
+import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.Seeds,
+
+	"description",
+	"""
+	Scatters points evenly over the surface of meshes.
+	This can be particularly useful in conjunction with
+	the Instancer, which can then apply instances to
+	each point.
+	""",
+
+	plugs = {
+
+		"parent" : [
+
+			"description",
+			"""
+			The location of the mesh to scatter the
+			points over. The generated points will
+			be parented under this location.
+			""",
+
+		],
+
+		"name" : [
+
+			"description",
+			"""
+			The name given to the object generated -
+			this will be placed under the parent in
+			the scene hierarchy.
+			""",
+
+		],
+
+		"density" : [
+
+			"description",
+			"""
+			The number of points per unit area of the mesh,
+			measured in object space.
+			""",
+
+		],
+
+		"pointType" : [
+
+			"description",
+			"""
+			The render type of the points. This defaults to
+			"gl:point" so that the points are rendered in a
+			lightweight manner in the viewport.
+			""",
+
+			"preset:GL Point", "gl:point",
+			"preset:Particle", "particle",
+			"preset:Sphere", "sphere",
+			"preset:Disk", "disk",
+			"preset:Patch", "patch",
+			"preset:Blobby", "blobby",
+
+		]
+
+	}
+
+)
+
+GafferUI.PlugValueWidget.registerCreator( GafferScene.Seeds, "pointType", GafferUI.PresetsPlugValueWidget )

--- a/python/GafferSceneUI/ShaderSwitchUI.py
+++ b/python/GafferSceneUI/ShaderSwitchUI.py
@@ -38,6 +38,44 @@ import Gaffer
 import GafferUI
 import GafferScene
 
+Gaffer.Metadata.registerNode(
+
+	GafferScene.ShaderSwitch,
+
+	"description",
+	"""
+	Chooses between multiple input shaders, passing through the
+	chosen shader to the output. The switching is resolved
+	before rendering begins, so no per-sample overhead is
+	incurred during shading.
+	""",
+
+	plugs = {
+
+		"in" : [
+
+			"description",
+			"""
+			The first input shader - the one passed through when
+			the index is 0.
+			""",
+
+		],
+
+		"out" : [
+
+			"description",
+			"""
+			The output shader.
+			""",
+
+		],
+
+
+	},
+
+)
+
 GafferUI.Nodule.registerNodule( GafferScene.ShaderSwitch, "enabled", lambda plug : None )
 GafferUI.Nodule.registerNodule( GafferScene.ShaderSwitch, "index", lambda plug : None )
 

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -49,30 +49,67 @@ import GafferScene
 # Metadata
 ##########################################################################
 
-Gaffer.Metadata.registerNodeDescription(
+Gaffer.Metadata.registerNode(
 
-GafferScene.Shader,
+	GafferScene.Shader,
 
-"""The base type for all nodes which create shaders. Use the ShaderAssignment node to assign them to objects in the scene.""",
+	"description",
+	"""
+	The base type for all nodes which create shaders. Use the
+	ShaderAssignment node to assign them to objects in the scene.
+	""",
 
-"name",
-{
-	"description" :
-	"""The name of the shader being represented. This should be considered read-only. Use the Shader.loadShader() method to load a shader.""",
-	"nodeUI:section" : "header",
-},
+	plugs = {
 
-"parameters",
-{
-	"description" : """Where the parameters for the shader are represented.""",
-	"nodeGadget:nodulePosition" : "left",
-},
+		"name" : [
 
-"out",
-{
-	"description" : """The output from the shader.""",
-	"nodeGadget:nodulePosition" : "right",
-},
+			"description",
+			"""
+			The name of the shader being represented. This should
+			be considered read-only. Use the Shader.loadShader()
+			method to load a shader.
+			""",
+
+			"nodeUI:section", "header",
+
+		],
+
+		"type" : [
+
+			"description",
+			"""
+			The type of the shader being represented. This should
+			be considered read-only. Use the Shader.loadShader()
+			method to load a shader.
+			""",
+
+			"nodeUI:section", "header",
+
+		],
+
+		"parameters" : [
+
+			"description",
+			"""
+			Where the parameters for the shader are represented.
+			""",
+
+			"nodeGadget:nodulePosition", "left",
+
+		],
+
+		"out" : [
+
+			"description",
+			"""
+			The output from the shader.
+			""",
+
+			"nodeGadget:nodulePosition", "right",
+
+		],
+
+	}
 
 )
 

--- a/python/GafferSceneUI/SphereUI.py
+++ b/python/GafferSceneUI/SphereUI.py
@@ -42,29 +42,80 @@ import GafferUI
 # Metadata
 ##########################################################################
 
-Gaffer.Metadata.registerNodeDescription(
+Gaffer.Metadata.registerNode(
 
-GafferScene.Sphere,
+	GafferScene.Sphere,
 
-"""A node which produces scenes containing a sphere.""",
+	"description",
+	"""
+	Produces scenes containing a sphere.
+	""",
 
-"type",
-"The type of object to produce. May be a SpherePrimitive or a Mesh.",
+	plugs = {
 
-"radius",
-"Radius of the sphere.",
+		"type" : [
 
-"zMin",
-"Limits the extent of the sphere along the lower pole. Valid values are in the range [-1,1] and should always be less than zMax.",
+			"description",
+			"""
+			The type of object to produce. May be a SpherePrimitive or a Mesh.
+			""",
 
-"zMax",
-"Limits the extent of the sphere along the upper pole. Valid values are in the range [-1,1] and should always be greater than zMin.",
+			"preset:Primitive", GafferScene.Sphere.Type.Primitive,
+			"preset:Mesh", GafferScene.Sphere.Type.Mesh,
 
-"thetaMax",
-"Limits the extent of the sphere around the pole axis. Valid values are in the range [0,360].",
+		],
 
-"divisions",
-"Controls tesselation of the sphere when type is Mesh.",
+		"radius" : [
+
+			"description",
+			"""
+			Radius of the sphere.
+			""",
+
+		],
+
+		"zMin" : [
+
+			"description",
+			"""
+			Limits the extent of the sphere along the lower pole.
+			Valid values are in the range [-1,1] and should always
+			be less than zMax.
+			""",
+
+		],
+
+		"zMax" : [
+
+			"description",
+			"""
+			Limits the extent of the sphere along the upper pole.
+			Valid values are in the range [-1,1] and should always
+			be greater than zMin.
+			""",
+
+		],
+
+		"thetaMax" : [
+
+			"description",
+			"""
+			Limits the extent of the sphere around the pole axis.
+			Valid values are in the range [0,360].
+			""",
+
+		],
+
+		"divisions" : [
+
+			"description",
+			"""
+			Controls tesselation of the sphere when type is Mesh.
+			""",
+
+		],
+
+	}
 
 )
 
@@ -72,15 +123,7 @@ GafferScene.Sphere,
 # Widgets and nodules
 ##########################################################################
 
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.Sphere,
-	"type",
-	GafferUI.EnumPlugValueWidget,
-	labelsAndValues = (
-		( "Primitive", GafferScene.Sphere.Type.Primitive ),
-		( "Mesh", GafferScene.Sphere.Type.Mesh ),
-	),
-)
+GafferUI.PlugValueWidget.registerCreator( GafferScene.Sphere, "type", GafferUI.PresetsPlugValueWidget )
 
 ## \todo: Disable divisions when type is Primitive. There is a similar mechanism in RenderManShaderUI, which
 ## could be generalized on StandardNodeUI and used here.

--- a/python/GafferSceneUI/StandardAttributesUI.py
+++ b/python/GafferSceneUI/StandardAttributesUI.py
@@ -38,6 +38,104 @@ import Gaffer
 import GafferUI
 import GafferScene
 
+##########################################################################
+# Metadata
+##########################################################################
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.StandardAttributes,
+
+	"description",
+	"""
+	Modifies the standard attributes on objects - these should
+	be respected by all renderers.
+	""",
+
+	plugs = {
+
+		# visibility plugs
+
+		"attributes.visibility" : [
+
+			"description",
+			"""
+			Whether or not the object can be seen - invisible objects are
+			not sent to the renderer at all. Typically more fine
+			grained (camera, reflection etc) visibility can be
+			specified using a renderer specific attributes node.
+			Note that making a parent location invisible will
+			always make all the children invisible too, regardless
+			of their visibility settings.
+			""",
+
+		],
+
+		"attributes.doubleSided" : [
+
+			"description",
+			"""
+			Whether or not the object can be seen from both sides.
+			Single sided objects appear invisible when seen from
+			the back.
+			""",
+
+		],
+
+		# motion blur plugs
+
+		"attributes.transformBlur" : [
+
+			"description",
+			"""
+			Whether or not transformation animation on the
+			object is taken into account in the rendered image.
+			Use the transformBlurSegments plug to specify the number
+			of segments used to represent the motion.
+			""",
+
+		],
+
+		"attributes.transformBlurSegments" : [
+
+			"description",
+			"""
+			The number of segments of transform animation to
+			pass to the renderer when transformBlur is on.
+			""",
+
+		],
+
+		"attributes.deformationBlur" : [
+
+			"description",
+			"""
+			Whether or not deformation animation on the
+			object is taken into account in the rendered image.
+			Use the deformationBlurSegments plug to specify the
+			number of segments used to represent the motion.
+			""",
+
+		],
+
+		"attributes.deformationBlurSegments" : [
+
+			"description",
+			"""
+			The number of segments of transform animation to
+			pass to the renderer when transformBlur is on.
+			""",
+
+		],
+
+	}
+
+)
+
+##########################################################################
+# PlugValueWidgets
+##########################################################################
+
 def __attributesSummary( plug ) :
 
 	info = []

--- a/python/GafferSceneUI/StandardOptionsUI.py
+++ b/python/GafferSceneUI/StandardOptionsUI.py
@@ -38,6 +38,191 @@ import Gaffer
 import GafferUI
 import GafferScene
 
+##########################################################################
+# Metadata
+##########################################################################
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.StandardOptions,
+
+	"description",
+	"""
+	Specifies the standard options (global settings) for the
+	scene. These should be respected by all renderers.
+	""",
+
+	plugs = {
+
+		# camera plugs
+
+		"options.renderCamera" : [
+
+			"description",
+			"""
+			The primary camera to be used for rendering. If this
+			is not specified, then a default orthographic camera
+			positioned at the origin is used.
+			""",
+
+		],
+
+		"options.renderResolution" : [
+
+			"description",
+			"""
+			The resolution of the image to be rendered. Use the
+			resolution multiplier as a convenient way to temporarily
+			render at multiples of this resolution.
+			""",
+
+		],
+
+		"options.pixelAspectRatio" : [
+
+			"description",
+			"""
+			The aspect ratio (x/y) of the pixels in the rendered image.
+			""",
+
+		],
+
+		"options.resolutionMultiplier" : [
+
+			"description",
+			"""
+			Multiplier applied to the render resolution.
+			""",
+
+		],
+
+		"options.renderCropWindow" : [
+
+			"description",
+			"""
+			Limits the render to a region of the image. The rendered
+			image will have the same resolution as usual, but areas
+			outside the crop will be rendered black. Coordinates
+			range from 0,0 at the top left of the image to 1,1 at the
+			bottom right. The crop window tool in the viewer may be
+			used to set this interactively.
+			""",
+
+		],
+
+		"options.overscan" : [
+
+			"description",
+			"""
+			Adds extra pixels to the sides of the rendered image.
+			This can be useful when camera shake or blur will be
+			added as a post process. This plug just enables overscan
+			as a whole - use the overscanTop, overscanBottom, overscanLeft
+			and overscanRight plugs to specify the amount of overscan
+			on each side of the image.
+			""",
+
+		],
+
+		"options.overscanTop" : [
+
+			"description",
+			"""
+			The amount of overscan at the top of the image. Specified
+			as a 0-1 proportion of the original image height.
+			""",
+
+		],
+
+		"options.overscanBottom" : [
+
+			"description",
+			"""
+			The amount of overscan at the bottom of the image. Specified
+			as a 0-1 proportion of the original image height.
+			""",
+
+		],
+
+		"options.overscanLeft" : [
+
+			"description",
+			"""
+			The amount of overscan at the left of the image. Specified
+			as a 0-1 proportion of the original image width.
+			""",
+
+		],
+
+		"options.overscanRight" : [
+
+			"description",
+			"""
+			The amount of overscan at the right of the image. Specified
+			as a 0-1 proportion of the original image width.
+			""",
+
+		],
+
+		# motion blur plugs
+
+		"options.cameraBlur" : [
+
+			"description",
+			"""
+			Whether or not camera motion is taken into
+			account in the renderered image. To specify the
+			number of segments to use for camera motion, use
+			a StandardAttributes node filtered for the camera.
+			""",
+
+		],
+
+		"options.transformBlur" : [
+
+			"description",
+			"""
+			Whether or not transform motion is taken into
+			account in the renderered image. To specify the
+			number of transform segments to use for each
+			object in the scene, use a StandardAttributes node
+			with appropriate filters.
+			""",
+
+		],
+
+		"options.deformationBlur" : [
+
+			"description",
+			"""
+			Whether or not deformation motion is taken into
+			account in the renderered image. To specify the
+			number of deformation segments to use for each
+			object in the scene, use a StandardAttributes node
+			with appropriate filters.
+			""",
+
+		],
+
+		"options.shutter" : [
+
+			"description",
+			"""
+			The interval over which the camera shutter is open.
+			Measured in frames, and specified relative to the
+			frame being rendered.
+			""",
+
+		],
+
+	}
+
+)
+
+##########################################################################
+# PlugValueWidgets
+##########################################################################
+
 ## \todo This is getting used in a few places now - maybe put it in one
 # place? Maybe a static method on NumericWidget?
 def __floatToString( f ) :

--- a/python/GafferSceneUI/SubTreeUI.py
+++ b/python/GafferSceneUI/SubTreeUI.py
@@ -44,14 +44,42 @@ import GafferSceneUI
 # Metadata
 ##########################################################################
 
-Gaffer.Metadata.registerNodeDescription(
+Gaffer.Metadata.registerNode(
 
-GafferScene.SubTree,
+	GafferScene.SubTree,
 
-"""A node for extracting a specific branch from a scene.""",
+	"description",
+	"""A node for extracting a specific branch from a scene.""",
 
-"root",
-"""The location to become the new root for the output scene. All locations below this will be kept, and all others will be discarded.""",
+	plugs = {
+
+		"root" : [
+
+			"description",
+			"""
+			The location to become the new root for the output scene.
+			All locations below this will be kept, and all others will
+			be discarded.
+			""",
+
+		],
+
+		"includeRoot" : [
+
+			"description",
+			"""
+			Causes the root location to also be kept in the
+			output scene, in addition to its children. For
+			instance, if the scene contains only
+			/city/street/house and the root is set to /city/street,
+			then the new scene will by default contain only /house -
+			but the includeRoot setting will cause it to contain
+			/street/house instead.
+			""",
+
+		]
+
+	}
 
 )
 

--- a/python/GafferSceneUI/TextUI.py
+++ b/python/GafferSceneUI/TextUI.py
@@ -1,7 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2012, John Haddon. All rights reserved.
-#  Copyright (c) 2012-2014, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -35,67 +34,64 @@
 #
 ##########################################################################
 
-from _GafferSceneUI import *
+import Gaffer
+import GafferUI
+import GafferScene
 
-from SceneHierarchy import SceneHierarchy
-from SceneInspector import SceneInspector
-from FilterPlugValueWidget import FilterPlugValueWidget
-import SceneNodeUI
-import SceneReaderUI
-import SceneProcessorUI
-import FilteredSceneProcessorUI
-import PruneUI
-import SubTreeUI
-import OutputsUI
-import OptionsUI
-import OpenGLAttributesUI
-import SceneContextVariablesUI
-import SceneWriterUI
-import StandardOptionsUI
-import StandardAttributesUI
-import ShaderUI
-import OpenGLShaderUI
-import ObjectSourceUI
-import TransformUI
-import AttributesUI
-import LightUI
-import InteractiveRenderUI
-import SphereUI
-import MapProjectionUI
-import MapOffsetUI
-import CustomAttributesUI
-import CustomOptionsUI
-import SceneViewToolbar
-import SceneSwitchUI
-import ShaderSwitchUI
-import ShaderAssignmentUI
-import ParentConstraintUI
-import ParentUI
-import PrimitiveVariablesUI
-import DuplicateUI
-import GridUI
-import SetFilterUI
-import DeleteGlobalsUI
-import DeleteOptionsUI
-import DeleteSetsUI
-import ExternalProceduralUI
-import ExecutableRenderUI
-import IsolateUI
-import SelectionToolUI
-import CropWindowToolUI
-import CameraUI
-import SetUI
-import ClippingPlaneUI
-import FilterUI
-import FilterSwitchUI
-import PointsTypeUI
-import ParametersUI
-import TextUI
+##########################################################################
+# Metadata
+##########################################################################
 
-# then all the PathPreviewWidgets. note that the order
-# of import controls the order of display.
+Gaffer.Metadata.registerNode(
 
-from AlembicPathPreview import AlembicPathPreview
-from SceneReaderPathPreview import SceneReaderPathPreview
+	GafferScene.Text,
 
-__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", {}, subdirectory = "GafferSceneUI" )
+	"description",
+	"""
+	Creates an object containing a polygon representation
+	of an arbitrary string of text.
+	""",
+
+	plugs = {
+
+		"text" : [
+
+			"description",
+			"""
+			The text to output. This is triangulated into a mesh
+			representation using the specified font.
+			""",
+
+		],
+
+		"font" : [
+
+			"description",
+			"""
+			The font to use - this should be a .ttf font file which
+			is located on the paths specified by the IECORE_FONT_PATHS
+			environment variable.
+			""",
+
+		],
+
+	}
+
+)
+
+GafferUI.PlugValueWidget.registerCreator(
+	GafferScene.Text,
+	"font",
+	lambda plug : GafferUI.PathPlugValueWidget( plug,
+		path = Gaffer.FileSystemPath(
+			"/",
+			filter = Gaffer.FileSystemPath.createStandardFilter(
+				extensions = [ "ttf" ],
+			)
+		),
+		pathChooserDialogueKeywords = {
+			"bookmarks" : GafferUI.Bookmarks.acquire( plug, category = "font" ),
+			"leaf" : True,
+		},
+	)
+)

--- a/python/GafferSceneUI/UnionFilterUI.py
+++ b/python/GafferSceneUI/UnionFilterUI.py
@@ -1,0 +1,77 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferUI
+import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.UnionFilter,
+
+	"description",
+	"""
+	Combines several input filters, matching the union
+	of all the locations matched by them.
+	""",
+
+	plugs = {
+
+		"in" : [
+
+			"description",
+			"""
+			The filters to be combined. Any number
+			of inputs may be added here.
+			""",
+
+		],
+
+	}
+
+)
+
+GafferUI.PlugValueWidget.registerCreator(
+	GafferScene.UnionFilter,
+	"in",
+	None,
+)
+
+GafferUI.Nodule.registerNodule(
+	GafferScene.UnionFilter,
+	"in",
+	GafferUI.CompoundNodule
+)

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -92,6 +92,7 @@ import PointsTypeUI
 import ParametersUI
 import TextUI
 import AimConstraintUI
+import AlembicSourceUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -111,6 +111,7 @@ import PointConstraintUI
 import SceneTimeWarpUI
 import FilterMixinBaseUI
 import SceneMixinBaseUI
+import BranchCreatorUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -99,6 +99,7 @@ import SeedsUI
 import UnionFilterUI
 import PathFilterUI
 import GroupUI
+import OpenGLRenderUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -100,6 +100,7 @@ import UnionFilterUI
 import PathFilterUI
 import GroupUI
 import OpenGLRenderUI
+import DeletePrimitiveVariablesUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -104,6 +104,7 @@ import DeletePrimitiveVariablesUI
 import MeshTypeUI
 import DeleteOutputsUI
 import InstancerUI
+import ObjectToSceneUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -93,6 +93,7 @@ import ParametersUI
 import TextUI
 import AimConstraintUI
 import AlembicSourceUI
+import CoordinateSystemUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -94,6 +94,7 @@ import TextUI
 import AimConstraintUI
 import AlembicSourceUI
 import CoordinateSystemUI
+import DeleteAttributesUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -96,6 +96,7 @@ import AlembicSourceUI
 import CoordinateSystemUI
 import DeleteAttributesUI
 import SeedsUI
+import UnionFilterUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -109,6 +109,7 @@ import FreezeTransformUI
 import SceneElementProcessorUI
 import PointConstraintUI
 import SceneTimeWarpUI
+import FilterMixinBaseUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -105,6 +105,7 @@ import MeshTypeUI
 import DeleteOutputsUI
 import InstancerUI
 import ObjectToSceneUI
+import FreezeTransformUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -108,6 +108,7 @@ import ObjectToSceneUI
 import FreezeTransformUI
 import SceneElementProcessorUI
 import PointConstraintUI
+import SceneTimeWarpUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -102,6 +102,7 @@ import GroupUI
 import OpenGLRenderUI
 import DeletePrimitiveVariablesUI
 import MeshTypeUI
+import DeleteOutputsUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -110,6 +110,7 @@ import SceneElementProcessorUI
 import PointConstraintUI
 import SceneTimeWarpUI
 import FilterMixinBaseUI
+import SceneMixinBaseUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -97,6 +97,7 @@ import CoordinateSystemUI
 import DeleteAttributesUI
 import SeedsUI
 import UnionFilterUI
+import PathFilterUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -101,6 +101,7 @@ import PathFilterUI
 import GroupUI
 import OpenGLRenderUI
 import DeletePrimitiveVariablesUI
+import MeshTypeUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -106,6 +106,7 @@ import DeleteOutputsUI
 import InstancerUI
 import ObjectToSceneUI
 import FreezeTransformUI
+import SceneElementProcessorUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -95,6 +95,7 @@ import AimConstraintUI
 import AlembicSourceUI
 import CoordinateSystemUI
 import DeleteAttributesUI
+import SeedsUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -114,6 +114,7 @@ import SceneMixinBaseUI
 import BranchCreatorUI
 import ConstraintUI
 import PlaneUI
+import CubeUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -107,6 +107,7 @@ import InstancerUI
 import ObjectToSceneUI
 import FreezeTransformUI
 import SceneElementProcessorUI
+import PointConstraintUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -112,6 +112,7 @@ import SceneTimeWarpUI
 import FilterMixinBaseUI
 import SceneMixinBaseUI
 import BranchCreatorUI
+import ConstraintUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -103,6 +103,7 @@ import OpenGLRenderUI
 import DeletePrimitiveVariablesUI
 import MeshTypeUI
 import DeleteOutputsUI
+import InstancerUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -98,6 +98,7 @@ import DeleteAttributesUI
 import SeedsUI
 import UnionFilterUI
 import PathFilterUI
+import GroupUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -113,6 +113,7 @@ import FilterMixinBaseUI
 import SceneMixinBaseUI
 import BranchCreatorUI
 import ConstraintUI
+import PlaneUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUITest/DocumentationTest.py
+++ b/python/GafferSceneUITest/DocumentationTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,13 +34,21 @@
 #
 ##########################################################################
 
-from SceneViewTest import SceneViewTest
-from ShaderAssignmentUITest import ShaderAssignmentUITest
-from StandardGraphLayoutTest import StandardGraphLayoutTest
-from SceneGadgetTest import SceneGadgetTest
-from SceneInspectorTest import SceneInspectorTest
-from SceneHierarchyTest import SceneHierarchyTest
-from DocumentationTest import DocumentationTest
+import GafferUITest
+
+import Gaffer
+import GafferScene
+import GafferSceneUI
+
+class DocumentationTest( GafferUITest.TestCase ) :
+
+	def test( self ) :
+
+		self.maxDiff = None
+		self.assertNodesAreDocumented(
+			GafferScene,
+			additionalTerminalPlugTypes = ( GafferScene.ScenePlug, Gaffer.CompoundDataPlug.MemberPlug )
+		)
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferUI/Nodule.cpp
+++ b/src/GafferUI/Nodule.cpp
@@ -35,10 +35,11 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "GafferUI/Nodule.h"
-
 #include "Gaffer/Plug.h"
 #include "Gaffer/Node.h"
+#include "Gaffer/Metadata.h"
+
+#include "GafferUI/Nodule.h"
 
 using namespace GafferUI;
 using namespace Imath;
@@ -140,10 +141,16 @@ std::string Nodule::getToolTip( const IECore::LineSegment3f &line ) const
 	}
 
 	result = m_plug->fullName();
-	Gaffer::NodePtr node = m_plug->ancestor<Gaffer::Node>();
-	if( node )
+	if( const Gaffer::Node *node = m_plug->node() )
 	{
 		result = m_plug->relativeName( node->parent<Gaffer::GraphComponent>() );
+	}
+
+	result = "<h3>" + result + "</h3>";
+	std::string description = Gaffer::Metadata::plugDescription( m_plug.get() );
+	if( description.size() )
+	{
+		result += "\n\n" + description;
 	}
 
 	return result;

--- a/startup/gui/bookmarks.py
+++ b/startup/gui/bookmarks.py
@@ -42,3 +42,6 @@ bookmarks = GafferUI.Bookmarks.acquire( application )
 bookmarks.setDefault( os.getcwd() )
 bookmarks.add( "Home", os.path.expandvars( "$HOME" ) )
 bookmarks.add( "Desktop", os.path.expandvars( "$HOME/Desktop" ) )
+
+fontBookmarks = GafferUI.Bookmarks.acquire( application, category="font" )
+fontBookmarks.add( "Gaffer Fonts", os.path.expandvars( "$GAFFER_ROOT/fonts" ) )


### PR DESCRIPTION
This fills in all the metadata description strings for the GafferScene module, getting us a lot closer to completing #1162. There's still GafferRenderMan, GafferArnold, GafferAppleseed and GafferOSL to go, but those are small in comparison to GafferScene.