### PR TITLE
FilteredSceneProcessor : Promoted filters now work with Reference nodes.

### DIFF
--- a/src/GafferScene/FilteredSceneProcessor.cpp
+++ b/src/GafferScene/FilteredSceneProcessor.cpp
@@ -35,7 +35,7 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "Gaffer/Box.h"
+#include "Gaffer/SubGraph.h"
 #include "Gaffer/Dot.h"
 
 #include "Gaffer/Context.h"
@@ -118,12 +118,12 @@ bool FilteredSceneProcessor::acceptsInput( const Gaffer::Plug *plug, const Gaffe
 
 	if( plug == filterPlug() )
 	{
-		// we only want to accept inputs from Filter nodes, but we accept
-		// them from Boxes too, because the intermediate plugs there can
-		// be used to later connect a filter in from the outside. likewise
-		// with dots.
+		// We only want to accept inputs from Filter nodes, but we accept
+		// them from SubGraphs too, because the intermediate plugs there can
+		// be used to later connect a filter in from the outside. Likewise
+		// with Dots.
 		const Node *n = inputPlug->source<Plug>()->node();
-		return runTimeCast<const Filter>( n ) || runTimeCast<const Box>( n ) || runTimeCast<const Dot>( n );
+		return runTimeCast<const Filter>( n ) || runTimeCast<const SubGraph>( n ) || runTimeCast<const Dot>( n );
 	}
 	return true;
 }


### PR DESCRIPTION
We were allowing an intermediate filter input to come from a plug on a Box, to allow promotion of filters. But then when the Box was exported and imported as a Reference,
we were not matching that behaviour. This prevented the Reference from loading successfully.