### PR TITLE
Node UI Refactoring : Part 1

### DIFF
--- a/python/GafferAppleseedUI/AppleseedAttributesUI.py
+++ b/python/GafferAppleseedUI/AppleseedAttributesUI.py
@@ -87,48 +87,107 @@ def __photonsSummary( plug ) :
 
 	return ", ".join( info )
 
-GafferUI.PlugValueWidget.registerCreator(
+Gaffer.Metadata.registerNode(
 
 	GafferAppleseed.AppleseedAttributes,
-	"attributes",
-	GafferUI.SectionedCompoundDataPlugValueWidget,
-	sections = (
-		{
-			"label" : "Visibility",
-			"summary" : __visibilitySummary,
-			"namesAndLabels" : (
-				( "as:visibility:camera", "Camera" ),
-				( "as:visibility:light", "Light" ),
-				( "as:visibility:shadow" , "Shadow" ),
-				( "as:visibility:transparency" , "Transparency" ),
-				( "as:visibility:probe" , "Probe" ),
-				( "as:visibility:diffuse", "Diffuse" ),
-				( "as:visibility:specular", "Specular" ),
-				( "as:visibility:glossy", "Glossy" ),
-			),
-		},
-		{
-			"label" : "Shading",
-			"summary" : __shadingSummary,
-			"namesAndLabels" : (
-				( "as:shading_samples", "Shading Samples" ),
-			),
-		},
-		{
-			"label" : "Alpha Map",
-			"summary" : __alphaMapSummary,
-			"namesAndLabels" : (
-				( "as:alpha_map", "Alpha Map" ),
-			),
-		},
-		{
-			"label" : "Photons",
-			"summary" : __photonsSummary,
-			"namesAndLabels" : (
-				( "as:photon_target", "Photon Target" ),
-			),
-		},
-	),
+
+	plugs = {
+
+		# Sections
+
+		"attributes" : [
+
+			"layout:section:Visibility:summary", __visibilitySummary,
+			"layout:section:Shading:summary", __shadingSummary,
+			"layout:section:Alpha Map:summary", __alphaMapSummary,
+			"layout:section:Photons:summary", __photonsSummary,
+
+		],
+
+		# Visibility
+
+		"attributes.cameraVisibility" : [
+
+			"layout:section", "Visibility",
+			"label", "Camera",
+
+		],
+
+		"attributes.lightVisibility" : [
+
+			"layout:section", "Visibility",
+			"label", "Light",
+
+		],
+
+		"attributes.shadowVisibility" : [
+
+			"layout:section", "Visibility",
+			"label", "Shadow",
+
+		],
+
+		"attributes.transparencyVisibility" : [
+
+			"layout:section", "Visibility",
+			"label", "Transparency",
+
+		],
+
+		"attributes.probeVisibility" : [
+
+			"layout:section", "Visibility",
+			"label", "Probe",
+
+		],
+
+		"attributes.diffuseVisibility" : [
+
+			"layout:section", "Visibility",
+			"label", "Diffuse",
+
+		],
+
+		"attributes.specularVisibility" : [
+
+			"layout:section", "Visibility",
+			"label", "Specular",
+
+		],
+
+		"attributes.glossyVisibility" : [
+
+			"layout:section", "Visibility",
+			"label", "Glossy",
+
+		],
+
+		# Shading
+
+		"attributes.shadingSamples" : [
+
+			"layout:section", "Shading",
+
+		],
+
+		# Alpha Map
+
+		"attributes.alphaMap" : [
+
+			"layout:section", "Alpha Map",
+
+		],
+
+		# Photons
+
+		"attributes.photonTarget" : [
+
+			"layout:section", "Photons",
+
+		],
+
+	}
+
 )
 
 GafferUI.PlugValueWidget.registerCreator(

--- a/python/GafferAppleseedUI/AppleseedOptionsUI.py
+++ b/python/GafferAppleseedUI/AppleseedOptionsUI.py
@@ -157,111 +157,377 @@ def __systemSummary( plug ) :
 
 	return ", ".join( info )
 
-GafferUI.PlugValueWidget.registerCreator(
+Gaffer.Metadata.registerNode(
 
 	GafferAppleseed.AppleseedOptions,
-	"options",
-	GafferUI.SectionedCompoundDataPlugValueWidget,
-	sections = (
-		{
-			"label" : "Main",
-			"summary" : __mainSummary,
-			"namesAndLabels" : (
-				( "as:mesh_file_format", "Mesh File Format" ),
-				( "as:cfg:generic_frame_renderer:passes", "Passes" ),
-				( "as:cfg:sampling_mode", "Sampler" ),
-				( "as:cfg:uniform_pixel_renderer:samples", "AA Samples" ),
-				( "as:cfg:uniform_pixel_renderer:force_antialiasing", "Force Antialiasing" ),
-				( "as:cfg:uniform_pixel_renderer:decorrelate_pixels", "Decorrelate Pixels" ),
-				( "as:cfg:lighting_engine", "Lighting Engine" ),
-			),
-		},
-		{
-			"label" : "Environment",
-			"summary" : __environmentSummary,
-			"namesAndLabels" : (
-				( "as:environment_edf", "Environment Light" ),
-				( "as:environment_edf_background", "Visible in Background" ),
-			),
-		},
-		{
-			"label" : "Distribution Ray Tracer",
-			"summary" : __drtSummary,
-			"namesAndLabels" : (
-				( "as:cfg:drt:enable_ibl", "Image Based Lighting" ),
-				( "as:cfg:drt:max_path_lenght", "Max Bounces" ),
-				( "as:cfg:drt:rr_min_path_length", "RR Start Bounce" ),
-				( "as:cfg:drt:dl_light_samples", "Direct Lighing Samples" ),
-				( "as:cfg:drt:ibl_env_samples", "IBL Samples" ),
-			),
-		},
-		{
-			"label" : "Unidirectional Path Tracer",
-			"summary" : __ptSummary,
-			"namesAndLabels" : (
-				( "as:cfg:pt:enable_dl", "Direct Lighting" ),
-				( "as:cfg:pt:enable_ibl", "Image Based Lighting" ),
-				( "as:cfg:pt:enable_caustics", "Caustics" ),
-				( "as:cfg:pt:max_path_lenght", "Max Bounces" ),
-				( "as:cfg:pt:rr_min_path_length", "RR Start Bounce" ),
-				( "as:cfg:pt:next_event_estimation", "Next Event Estimation" ),
-				( "as:cfg:pt:dl_light_samples", "Direct Lighing Samples" ),
-				( "as:cfg:pt:ibl_env_samples", "IBL Samples" ),
-				( "as:cfg:pt:max_ray_intensity", "Max Ray Intensity" ),
-			),
-		},
-		{
-			"label" : "SPPM",
-			"summary" : __sppmSummary,
-			"namesAndLabels" : (
-				( "as:cfg:sppm:photon_type", "Photon Type" ),
-				( "as:cfg:sppm:dl_type", "Direct Lighting" ),
-				( "as:cfg:sppm:enable_ibl", "Image Based Lighting" ),
-				( "as:cfg:sppm:enable_caustics", "Caustics" ),
-				( "as:cfg:sppm:photon_tracing_max_path_length", "Max Photon Bounces" ),
-				( "as:cfg:sppm:photon_tracing_rr_min_path_length", "Photon RR Start Bounce" ),
-				( "as:cfg:sppm:path_tracing_max_path_length", "Max Path Bounces" ),
-				( "as:cfg:sppm:path_tracing_rr_min_path_length", "Path RR Start Bounce" ),
-				( "as:cfg:sppm:light_photons_per_pass", "Light Photons" ),
-				( "as:cfg:sppm:env_photons_per_pass", "Environment Photons" ),
-				( "as:cfg:sppm:initial_radius", "Initial Radius" ),
-				( "as:cfg:sppm:max_photons_per_estimate", "Max Photons" ),
-				( "as:cfg:sppm:alpha", "Alpha" ),
-			),
-		},
-		{
-			"label" : "System",
-			"summary" : __systemSummary,
-			"namesAndLabels" : (
-				( "as:searchpath", "Searchpath" ),
-				( "as:cfg:rendering_threads", "Threads" ),
-				( "as:cfg:progressive_frame_renderer:max_fps", "Interactive Render Fps" ),
-				( "as:cfg:texture_store:max_size", "Texture Cache Size" ),
-				( "as:cfg:generic_frame_renderer:tile_ordering", "Tile Ordering" ),
-			),
-		},
-	),
+
+	plugs = {
+
+		# Sections
+
+		"options" : [
+
+			"layout:section:Main:summary", __mainSummary,
+			"layout:section:Environment:summary", __environmentSummary,
+			"layout:section:Distribution Ray Tracer:summary", __drtSummary,
+			"layout:section:Unidirectional Path Tracer:summary", __ptSummary,
+			"layout:section:SPPM:summary", __sppmSummary,
+			"layout:section:System:summary", __systemSummary,
+
+		],
+
+		# Main
+
+		"options.renderPasses" : [
+
+			"layout:section", "Main",
+			"label", "Passes",
+
+		],
+
+		"options.sampler" : [
+
+			"layout:section", "Main",
+
+		],
+
+		"options.sampler.value" : [
+
+			"preset:Random", "rng",
+			"preset:QMC", "qmc",
+
+		],
+
+		"options.aaSamples" : [
+
+			"layout:section", "Main",
+			"label", "AA Samples",
+
+		],
+
+		"options.forceAA" : [
+
+			"layout:section", "Main",
+			"label", "Force Antialiasing",
+
+		],
+
+		"options.decorrelatePixels" : [
+
+			"layout:section", "Main",
+
+		],
+
+		"options.lightingEngine" : [
+
+			"layout:section", "Main",
+
+		],
+
+		"options.lightingEngine.value" : [
+
+			"preset:Distribution Ray Tracer", "drt",
+			"preset:Unidirectional Path Tracer", "pt",
+			"preset:SPPM", "sppm",
+
+		],
+
+		"options.meshFileFormat" : [
+
+			"layout:section", "Main",
+
+		],
+
+		"options.meshFileFormat.value" : [
+
+			"preset:BinaryMesh", "binarymesh",
+			"preset:Obj", "obj",
+
+		],
+
+		# Environment
+
+		"options.environmentEDF" : [
+
+			"layout:section", "Environment",
+			"label", "Environment Light",
+
+		],
+
+		"options.environmentEDFBackground" : [
+
+			"layout:section", "Environment",
+			"label", "Visible in Background",
+
+		],
+
+		# Distribution Ray Tracer
+
+		"options.drtIBL" : [
+
+			"layout:section", "Distribution Ray Tracer",
+			"label", "Image Based Lighting",
+
+		],
+
+		"options.drtMaxBounces" : [
+
+			"layout:section", "Distribution Ray Tracer",
+			"label", "Max Bounces",
+
+		],
+
+		"options.drtRRStartBounce" : [
+
+			"layout:section", "Distribution Ray Tracer",
+			"label", "RR Start Bounce",
+
+		],
+
+		"options.drtLighingSamples" : [
+
+			"layout:section", "Distribution Ray Tracer",
+			"label", "Direct Lighting Samples",
+
+		],
+
+		"options.drtIBLSamples" : [
+
+			"layout:section", "Distribution Ray Tracer",
+			"label", "IBL Samples",
+
+		],
+
+		# Unidirectional Path Tracer
+
+		"options.ptDirectLighting" : [
+
+			"layout:section", "Unidirectional Path Tracer",
+			"label", "Direct Lighting",
+
+		],
+
+		"options.ptIBL" : [
+
+			"layout:section", "Unidirectional Path Tracer",
+			"label", "Image Based Lighting",
+
+		],
+
+		"options.ptCaustics" : [
+
+			"layout:section", "Unidirectional Path Tracer",
+			"label", "Caustics",
+
+		],
+
+		"options.ptMaxBounces" : [
+
+			"layout:section", "Unidirectional Path Tracer",
+			"label", "Max Bounces",
+
+		],
+
+		"options.ptRRStartBounce" : [
+
+			"layout:section", "Unidirectional Path Tracer",
+			"label", "RR Start Bounce",
+
+		],
+
+		"options.ptNextEvent" : [
+
+			"layout:section", "Unidirectional Path Tracer",
+			"label", "Next Event Estimation",
+
+		],
+
+		"options.ptLighingSamples" : [
+
+			"layout:section", "Unidirectional Path Tracer",
+			"label", "Direct Lighting Samples",
+
+		],
+
+		"options.ptIBLSamples" : [
+
+			"layout:section", "Unidirectional Path Tracer",
+			"label", "IBL Samples",
+
+		],
+
+		"options.ptMaxRayIntensity" : [
+
+			"layout:section", "Unidirectional Path Tracer",
+			"label", "Max Ray Intensity",
+
+		],
+
+		# SPPM
+
+		"options.photonType" : [
+
+			"layout:section", "SPPM",
+			"label", "Photon Type",
+
+		],
+
+		"options.photonType.value" : [
+
+			"preset:Monochromatic", "mono",
+			"preset:Polychromatic", "poly",
+
+		],
+
+		"options.sppmDirectLighing" : [
+
+			"layout:section", "SPPM",
+			"label", "Direct Lighting",
+
+		],
+
+		"options.sppmDirectLighing.value" : [
+
+			"preset:Ray Tracing", "rt",
+			"preset:SPPM", "sppm",
+			"preset:None", "off",
+
+		],
+
+		"options.sppmIBL" : [
+
+			"layout:section", "SPPM",
+			"label", "Image Based Lighting",
+
+		],
+
+		"options.sppmCaustics" : [
+
+			"layout:section", "SPPM",
+			"label", "Caustics",
+
+		],
+
+		"options.sppmPhotonMaxBounces" : [
+
+			"layout:section", "SPPM",
+			"label", "Max Photon Bounces",
+
+		],
+
+		"options.sppmPhotonRRStartBounce" : [
+
+			"layout:section", "SPPM",
+			"label", "Photon RR Start Bounce",
+
+		],
+
+		"options.sppmPathMaxBounces" : [
+
+			"layout:section", "SPPM",
+			"label", "Max Path Bounces",
+
+		],
+
+		"options.sppmPathRRStartBounce" : [
+
+			"layout:section", "SPPM",
+			"label", "Path RR Start Bounce",
+
+		],
+
+		"options.sppmLightPhotons" : [
+
+			"layout:section", "SPPM",
+			"label", "Light Photons",
+
+		],
+
+		"options.sppmEnvPhotons" : [
+
+			"layout:section", "SPPM",
+			"label", "Environment Photons",
+
+		],
+
+		"options.sppmInitialRadius" : [
+
+			"layout:section", "SPPM",
+			"label", "Initial Radius",
+
+		],
+
+		"options.sppmMaxPhotons" : [
+
+			"layout:section", "SPPM",
+			"label", "Max Photons",
+
+		],
+
+		"options.sppmAlpha" : [
+
+			"layout:section", "SPPM",
+			"label", "Alpha",
+
+		],
+
+		# System
+
+		"options.searchPath" : [
+
+			"layout:section", "System",
+
+		],
+
+		"options.numThreads" : [
+
+			"layout:section", "System",
+			"label", "Threads",
+
+		],
+
+		"options.interactiveRenderFps" : [
+
+			"layout:section", "System",
+
+		],
+
+		"options.textureMem" : [
+
+			"layout:section", "System",
+			"label", "Texture Cache Size",
+
+		],
+
+		"options.tileOrdering" : [
+
+			"layout:section", "System",
+
+		],
+
+		"options.tileOrdering.value" : [
+
+			"preset:Linear", "linear",
+			"preset:Spiral", "spiral",
+			"preset:Hilbert", "hilbert",
+			"preset:Random", "random",
+
+		],
+
+	}
+
 )
 
 GafferUI.PlugValueWidget.registerCreator(
 	GafferAppleseed.AppleseedOptions,
 	"options.meshFileFormat.value",
-	GafferUI.EnumPlugValueWidget,
-	labelsAndValues = (
-		( "BinaryMesh", "binarymesh" ),
-		( "Obj", "obj" ),
-	),
+	GafferUI.PresetsPlugValueWidget,
 )
 
 GafferUI.PlugValueWidget.registerCreator(
 	GafferAppleseed.AppleseedOptions,
 	"options.lightingEngine.value",
-	GafferUI.EnumPlugValueWidget,
-	labelsAndValues = (
-		( "Distribution Ray Tracer", "drt" ),
-		( "Unidirectional Path Tracer", "pt" ),
-		( "SPPM", "sppm" ),
-	),
+	GafferUI.PresetsPlugValueWidget,
 )
 
 GafferUI.PlugValueWidget.registerCreator(
@@ -276,42 +542,23 @@ GafferUI.PlugValueWidget.registerCreator(
 GafferUI.PlugValueWidget.registerCreator(
 	GafferAppleseed.AppleseedOptions,
 	"options.photonType.value",
-	GafferUI.EnumPlugValueWidget,
-	labelsAndValues = (
-		( "Monochromatic", "mono" ),
-		( "Polychromatic", "poly" ),
-	),
+	GafferUI.PresetsPlugValueWidget,
 )
 
 GafferUI.PlugValueWidget.registerCreator(
 	GafferAppleseed.AppleseedOptions,
 	"options.sppmDirectLighing.value",
-	GafferUI.EnumPlugValueWidget,
-	labelsAndValues = (
-		( "Ray Tracing", "rt" ),
-		( "SPPM", "sppm" ),
-		( "None", "off" ),
-	),
+	GafferUI.PresetsPlugValueWidget,
 )
 
 GafferUI.PlugValueWidget.registerCreator(
 	GafferAppleseed.AppleseedOptions,
 	"options.tileOrdering.value",
-	GafferUI.EnumPlugValueWidget,
-	labelsAndValues = (
-		( "Linear", "linear" ),
-		( "Spiral", "spiral" ),
-		( "Hilbert", "hilbert" ),
-		( "Random", "random" ),
-	),
+	GafferUI.PresetsPlugValueWidget,
 )
 
 GafferUI.PlugValueWidget.registerCreator(
 	GafferAppleseed.AppleseedOptions,
 	"options.sampler.value",
-	GafferUI.EnumPlugValueWidget,
-	labelsAndValues = (
-		( "Random", "rng" ),
-		( "QMC", "qmc" ),
-	),
+	GafferUI.PresetsPlugValueWidget,
 )

--- a/python/GafferArnoldUI/ArnoldAttributesUI.py
+++ b/python/GafferArnoldUI/ArnoldAttributesUI.py
@@ -71,44 +71,103 @@ def __subdivisionSummary( plug ) :
 
 	return ", ".join( info )
 
-GafferUI.PlugValueWidget.registerCreator(
+Gaffer.Metadata.registerNode(
 
 	GafferArnold.ArnoldAttributes,
-	"attributes",
-	GafferUI.SectionedCompoundDataPlugValueWidget,
-	sections = (
-		{
-			"label" : "Visibility",
-			"summary" : __visibilitySummary,
-			"namesAndLabels" : (
-				( "ai:visibility:camera", "Camera" ),
-				( "ai:visibility:shadow", "Shadow" ),
-				( "ai:visibility:reflected", "Reflections" ),
-				( "ai:visibility:refracted", "Refractions" ),
-				( "ai:visibility:diffuse", "Diffuse" ),
-				( "ai:visibility:glossy", "Glossy" ),
-			),
-		},
-		{
-			"label" : "Subdivision",
-			"summary" : __subdivisionSummary,
-			"namesAndLabels" : (
-				( "ai:polymesh:subdiv_iterations", "Iterations" ),
-				( "ai:polymesh:subdiv_pixel_error", "Pixel Error" ),
-				( "ai:polymesh:subdiv_adaptive_metric", "Adaptive Metric" ),
-			),
-		},
-	),
+
+	plugs = {
+
+		# Sections
+
+		"attributes" : [
+
+			"layout:section:Visibility:summary", __visibilitySummary,
+			"layout:section:Subdivision:summary", __subdivisionSummary,
+
+		],
+
+		# Visibility
+
+		"attributes.cameraVisibility" : [
+
+			"layout:section", "Visibility",
+			"label", "Camera",
+
+		],
+
+		"attributes.shadowVisibility" : [
+
+			"layout:section", "Visibility",
+			"label", "Shadow",
+
+		],
+
+		"attributes.reflectedVisibility" : [
+
+			"layout:section", "Visibility",
+			"label", "Reflections",
+
+		],
+
+		"attributes.refractedVisibility" : [
+
+			"layout:section", "Visibility",
+			"label", "Refractions",
+
+		],
+
+		"attributes.diffuseVisibility" : [
+
+			"layout:section", "Visibility",
+			"label", "Diffuse",
+
+		],
+
+		"attributes.glossyVisibility" : [
+
+			"layout:section", "Visibility",
+			"label", "Glossy",
+
+		],
+
+		# Subdivision
+
+		"attributes.subdivIterations" : [
+
+			"layout:section", "Subdivision",
+			"label", "Iterations",
+
+		],
+
+		"attributes.subdivPixelError" : [
+
+			"layout:section", "Subdivision",
+			"label", "Pixel Error",
+
+		],
+
+		"attributes.subdivAdaptiveMetric" : [
+
+			"layout:section", "Subdivision",
+			"label", "Adaptive Metric",
+
+		],
+
+
+		"attributes.subdivAdaptiveMetric.value" : [
+
+			"preset:Auto", "auto",
+			"preset:Edge Length", "edge_length",
+			"preset:Flatness", "flatness",
+
+		],
+
+	}
 
 )
 
 GafferUI.PlugValueWidget.registerCreator(
 	GafferArnold.ArnoldAttributes,
 	"attributes.subdivAdaptiveMetric.value",
-	GafferUI.EnumPlugValueWidget,
-	labelsAndValues = (
-		( "Auto", "auto" ),
-		( "Edge Length", "edge_length" ),
-		( "Flatness", "flatness" ),
-	),
+	GafferUI.PresetsPlugValueWidget
 )

--- a/python/GafferArnoldUI/ArnoldOptionsUI.py
+++ b/python/GafferArnoldUI/ArnoldOptionsUI.py
@@ -91,57 +91,168 @@ def __errorColorsSummary( plug ) :
 
 	return ", ".join( info )
 
-GafferUI.PlugValueWidget.registerCreator(
+Gaffer.Metadata.registerNode(
 
 	GafferArnold.ArnoldOptions,
-	"options",
-	GafferUI.SectionedCompoundDataPlugValueWidget,
-	sections = (
-		{
-			"label" : "Sampling",
-			"summary" : __samplingSummary,
-			"namesAndLabels" : (
-				( "ai:AA_samples", "AA Samples" ),
-				( "ai:GI_diffuse_samples", "Diffuse Samples" ),
-				( "ai:GI_glossy_samples", "Glossy Samples" ),
-				( "ai:GI_refraction_samples", "Refraction Samples" ),
-			),
-		},
-		{
-			"label" : "Features",
-			"summary" : __featuresSummary,
-			"namesAndLabels" : (
-				( "ai:ignore_textures", "Ignore Textures" ),
-				( "ai:ignore_shaders", "Ignore Shaders" ),
-				( "ai:ignore_atmosphere", "Ignore Atmosphere" ),
-				( "ai:ignore_lights", "Ignore Lights" ),
-				( "ai:ignore_shadows", "Ignore Shadows" ),
-				( "ai:ignore_subdivision", "Ignore Subdivision" ),
-				( "ai:ignore_displacement", "Ignore Displacement" ),
-				( "ai:ignore_bump", "Ignore Bump" ),
-				( "ai:ignore_motion_blur", "Ignore Motion Blur" ),
-				( "ai:ignore_sss", "Ignore SSS" ),
-			),
-		},
-		{
-			"label" : "Search Paths",
-			"summary" : __searchPathsSummary,
-			"namesAndLabels" : (
-				( "ai:texture_searchpath", "Textures" ),
-				( "ai:procedural_searchpath", "Procedurals" ),
-				( "ai:shader_searchpath", "Shaders" ),
-			),
-		},
-		{
-			"label" : "Error Colors",
-			"summary" : __errorColorsSummary,
-			"namesAndLabels" : (
-				( "ai:error_color_bad_texture", "Bad Texture" ),
-				( "ai:error_color_bad_mesh", "Bad Mesh" ),
-				( "ai:error_color_bad_pixel", "Bad Pixel" ),
-				( "ai:error_color_bad_shader", "Bad Shader" ),
-			),
-		},
-	),
+
+	plugs = {
+
+		# Sections
+
+		"options" : [
+
+			"layout:section:Sampling:summary", __samplingSummary,
+			"layout:section:Features:summary", __featuresSummary,
+			"layout:section:Search Paths:summary", __searchPathsSummary,
+			"layout:section:Error Colors:summary", __errorColorsSummary,
+
+		],
+
+		# Sampling
+
+		"options.aaSamples" : [
+
+			"layout:section", "Sampling",
+			"label", "AA Samples",
+
+		],
+
+		"options.giDiffuseSamples" : [
+
+			"layout:section", "Sampling",
+			"label", "Diffuse Samples",
+
+		],
+
+		"options.giGlossySamples" : [
+
+			"layout:section", "Sampling",
+			"label", "Glossy Samples",
+
+		],
+
+		"options.giRefractionSamples" : [
+
+			"layout:section", "Sampling",
+			"label", "Refraction Samples",
+
+		],
+
+		# Features
+
+		"options.ignoreTextures" : [
+
+			"layout:section", "Features",
+
+		],
+
+		"options.ignoreShaders" : [
+
+			"layout:section", "Features",
+
+		],
+
+		"options.ignoreAtmosphere" : [
+
+			"layout:section", "Features",
+
+		],
+
+		"options.ignoreLights" : [
+
+			"layout:section", "Features",
+
+		],
+
+		"options.ignoreShadows" : [
+
+			"layout:section", "Features",
+
+		],
+
+		"options.ignoreSubdivision" : [
+
+			"layout:section", "Features",
+
+		],
+
+		"options.ignoreDisplacement" : [
+
+			"layout:section", "Features",
+
+		],
+
+		"options.ignoreBump" : [
+
+			"layout:section", "Features",
+
+		],
+
+		"options.ignoreMotionBlur" : [
+
+			"layout:section", "Features",
+
+		],
+
+		"options.ignoreSSS" : [
+
+			"layout:section", "Features",
+
+		],
+
+		# Search Paths
+
+		"options.textureSearchPath" : [
+
+			"layout:section", "Search Paths",
+			"label", "Textures",
+
+		],
+
+		"options.proceduralSearchPath" : [
+
+			"layout:section", "Search Paths",
+			"label", "Procedurals",
+
+		],
+
+		"options.shaderSearchPath" : [
+
+			"layout:section", "Search Paths",
+			"label", "Shaders",
+
+		],
+
+		# Error Colors
+
+		"options.errorColorBadTexture" : [
+
+			"layout:section", "Error Colors",
+			"label", "Bad Texture",
+
+		],
+
+		"options.errorColorBadMesh" : [
+
+			"layout:section", "Error Colors",
+			"label", "Bad Mesh",
+
+		],
+
+		"options.errorColorBadPixel" : [
+
+			"layout:section", "Error Colors",
+			"label", "Bad Pixel",
+
+		],
+
+		"options.errorColorBadShader" : [
+
+			"layout:section", "Error Colors",
+			"label", "Bad Shader",
+
+		],
+
+	}
 
 )

--- a/python/GafferRenderManUI/RenderManAttributesUI.py
+++ b/python/GafferRenderManUI/RenderManAttributesUI.py
@@ -94,119 +94,228 @@ def __raytracingSummary( plug ) :
 
 	return ", ".join( info )
 
-GafferUI.PlugValueWidget.registerCreator(
+Gaffer.Metadata.registerNode(
 
 	GafferRenderMan.RenderManAttributes,
-	"attributes",
-	GafferUI.SectionedCompoundDataPlugValueWidget,
-	sections = (
 
-		{
-			"label" : "Visibility",
-			"summary" : __visibilitySummary,
-			"namesAndLabels" : (
-				( "ri:visibility:camera", "Camera" ),
-				( "ri:shade:camerahitmode", "Camera Mode" ),
+	"description",
+	"""
+	Applies RenderMan specific attributes to the scene.
+	""",
 
-				( "ri:visibility:transmission", "Transmission" ),
-				( "ri:shade:transmissionhitmode", "Transmission Mode" ),
+	plugs = {
 
-				( "ri:visibility:diffuse", "Diffuse" ),
-				( "ri:shade:diffusehitmode", "Diffuse Mode" ),
+		# Summaries
 
-				( "ri:visibility:specular", "Specular" ),
-				( "ri:shade:specularhitmode", "Specular Mode" ),
+		"attributes" : [
 
-				( "ri:visibility:photon", "Photon" ),
-				( "ri:shade:photonhitmode", "Photon Mode" ),
-			),
-		},
+			"layout:section:Visibility:summary", __visibilitySummary,
+			"layout:section:Shading:summary", __shadingSummary,
+			"layout:section:Raytracing:summary", __raytracingSummary,
 
-		{
-			"label" : "Shading",
-			"summary" : __shadingSummary,
-			"namesAndLabels" : (
-				( "ri:shadingRate", "Shading Rate" ),
-				( "ri:shade:relativeshadingrate", "Relative Shading Rate" ),
-				( "ri:matte", "Matte" ),
-				( "ri:displacementbound:sphere", "Displacement Bound" ),
-			),
-		},
+		],
 
-		{
-			"label" : "Raytracing",
-			"summary" : __raytracingSummary,
-			"namesAndLabels" : (
-				( "ri:trace:maxdiffusedepth", "Max Diffuse Depth" ),
-				( "ri:trace:maxspeculardepth", "Max Specular Depth" ),
-				( "ri:trace:displacements", "Trace Displacements" ),
-				( "ri:trace:bias", "Trace Bias" ),
-			),
-		},
+		# Visibility section
 
-	),
+		"attributes.cameraVisibility" : [
+
+			"layout:section", "Visibility",
+			"label", "Camera",
+
+		],
+
+		"attributes.cameraHitMode" : [
+
+			"layout:section", "Visibility",
+			"label", "Camera Mode",
+
+		],
+
+		"attributes.cameraHitMode.value" : [
+
+			"preset:Shader", "shader",
+			"preset:Primitive", "primitive",
+
+		],
+
+		"attributes.transmissionVisibility" : [
+
+			"layout:section", "Visibility",
+			"label", "Transmission",
+
+		],
+
+		"attributes.transmissionHitMode" : [
+
+			"layout:section", "Visibility",
+			"label", "Transmission Mode",
+
+		],
+
+		"attributes.transmissionHitMode.value" : [
+
+			"preset:Shader", "shader",
+			"preset:Primitive", "primitive",
+
+		],
+
+		"attributes.diffuseVisibility" : [
+
+			"layout:section", "Visibility",
+			"label", "Diffuse",
+
+		],
+
+		"attributes.diffuseHitMode" : [
+
+			"layout:section", "Visibility",
+			"label", "Diffuse Mode",
+
+		],
+
+		"attributes.diffuseHitMode.value" : [
+
+			"preset:Shader", "shader",
+			"preset:Primitive", "primitive",
+
+		],
+
+		"attributes.specularVisibility" : [
+
+			"layout:section", "Visibility",
+			"label", "Specular",
+
+		],
+
+		"attributes.specularHitMode" : [
+
+			"layout:section", "Visibility",
+			"label", "Specular Mode",
+
+		],
+
+		"attributes.specularHitMode.value" : [
+
+			"preset:Shader", "shader",
+			"preset:Primitive", "primitive",
+
+		],
+
+		"attributes.photonVisibility" : [
+
+			"layout:section", "Visibility",
+			"label", "Photon",
+
+		],
+
+		"attributes.photonHitMode" : [
+
+			"layout:section", "Visibility",
+			"label", "Photon Mode",
+
+		],
+
+		"attributes.photonHitMode.value" : [
+
+			"preset:Shader", "shader",
+			"preset:Primitive", "primitive",
+
+		],
+
+		# Shading section
+
+		"attributes.shadingRate" : [
+
+			"layout:section", "Shading",
+
+		],
+
+		"attributes.relativeShadingRate" : [
+
+			"layout:section", "Shading",
+
+		],
+
+		"attributes.matte" : [
+
+			"layout:section", "Shading",
+
+		],
+
+
+		"attributes.displacementBound" : [
+
+			"layout:section", "Shading",
+
+		],
+
+		# Raytracing section
+
+		"attributes.maxDiffuseDepth" : [
+
+			"layout:section", "Raytracing",
+
+		],
+
+		"attributes.maxSpecularDepth" : [
+
+			"layout:section", "Raytracing",
+
+		],
+
+		"attributes.traceDisplacements" : [
+
+			"layout:section", "Raytracing",
+
+		],
+
+		"attributes.traceBias" : [
+
+			"description",
+			"""
+			This bias value affects rays. It is an offset applied to the ray origin, moving it slightly away from the surface launch point in the ray direction. This offset can prevent blotchy artifacts resulting from the ray immediately finding an intersection with the surface it just left. Usually, 0.01 is the default scene value.
+			""",
+
+			"layout:section", "Raytracing",
+
+		],
+
+	}
 
 )
 
 GafferUI.PlugValueWidget.registerCreator(
 	GafferRenderMan.RenderManAttributes,
 	"attributes.cameraHitMode.value",
-	GafferUI.EnumPlugValueWidget,
-	labelsAndValues = (
-		( "Shader", "shader" ),
-		( "Primitive", "primitive" ),
-	),
+	GafferUI.PresetsPlugValueWidget
 )
 
 GafferUI.PlugValueWidget.registerCreator(
 	GafferRenderMan.RenderManAttributes,
 	"attributes.transmissionHitMode.value",
-	GafferUI.EnumPlugValueWidget,
-	labelsAndValues = (
-		( "Shader", "shader" ),
-		( "Primitive", "primitive" ),
-	),
+	GafferUI.PresetsPlugValueWidget
+)
+
+GafferUI.PlugValueWidget.registerCreator(
+	GafferRenderMan.RenderManAttributes,
+	"attributes.transmissionHitMode.value",
+	GafferUI.PresetsPlugValueWidget
 )
 
 GafferUI.PlugValueWidget.registerCreator(
 	GafferRenderMan.RenderManAttributes,
 	"attributes.diffuseHitMode.value",
-	GafferUI.EnumPlugValueWidget,
-	labelsAndValues = (
-		( "Shader", "shader" ),
-		( "Primitive", "primitive" ),
-	),
+	GafferUI.PresetsPlugValueWidget
 )
 
 GafferUI.PlugValueWidget.registerCreator(
 	GafferRenderMan.RenderManAttributes,
 	"attributes.specularHitMode.value",
-	GafferUI.EnumPlugValueWidget,
-	labelsAndValues = (
-		( "Shader", "shader" ),
-		( "Primitive", "primitive" ),
-	),
+	GafferUI.PresetsPlugValueWidget
 )
 
 GafferUI.PlugValueWidget.registerCreator(
 	GafferRenderMan.RenderManAttributes,
 	"attributes.photonHitMode.value",
-	GafferUI.EnumPlugValueWidget,
-	labelsAndValues = (
-		( "Shader", "shader" ),
-		( "Primitive", "primitive" ),
-	),
-)
-
-Gaffer.Metadata.registerNodeDescription(
-
-	GafferRenderMan.RenderManAttributes,
-
-	"""Apply render attributes to your scene.""",
-
-	"attributes.traceBias",
-	{
-		"description" : """This bias value affects rays. It is an offset applied to the ray origin, moving it slightly away from the surface launch point in the ray direction. This offset can prevent blotchy artifacts resulting from the ray immediately finding an intersection with the surface it just left. Usually, 0.01 is the default scene value.""",
-	}
-
+	GafferUI.PresetsPlugValueWidget
 )

--- a/python/GafferRenderManUI/RenderManOptionsUI.py
+++ b/python/GafferRenderManUI/RenderManOptionsUI.py
@@ -95,92 +95,179 @@ def __searchPathsSummary( plug ) :
 
 	return ", ".join( info )
 
-GafferUI.PlugValueWidget.registerCreator(
+Gaffer.Metadata.registerNode(
 
 	GafferRenderMan.RenderManOptions,
-	"options",
-	GafferUI.SectionedCompoundDataPlugValueWidget,
-	sections = (
 
-		{
-			"label" : "Quality",
-			"summary" : __qualitySummary,
-			"namesAndLabels" : (
-				( "ri:pixelSamples", "Pixel Samples" ),
-			),
-		},
+	plugs = {
 
-		{
-			"label" : "Hider",
-			"summary" : __hiderSummary,
-			"namesAndLabels" : (
-				( "ri:hider", "Hider" ),
-				( "ri:hider:depthfilter", "Depth Filter" ),
-				( "ri:hider:jitter", "Jitter" ),
-				( "ri:hider:samplemotion", "Sample Motion" ),
-				( "ri:hider:extrememotiondof", "Extreme Motion DOF" ),
-				( "ri:hider:progressive", "Progressive" ),
-			),
-		},
+		# Summaries
 
-		{
-			"label" : "Statistics",
-			"summary" : __statisticsSummary,
-			"namesAndLabels" : (
-				( "ri:statistics:endofframe", "Level" ),
-				( "ri:statistics:filename", "File Name" ),
-				( "ri:statistics:progress", "Progress" ),
-			),
-		},
+		"options" : [
 
-		{
-			"label" : "Search Paths",
-			"summary" : __searchPathsSummary,
-			"namesAndLabels" : (
-				( "ri:searchpath:shader", "Shaders" ),
-				( "ri:searchpath:texture", "Textures" ),
-				( "ri:searchpath:display", "Displays" ),
-				( "ri:searchpath:archive", "Archives" ),
-				( "ri:searchpath:procedural", "Procedurals" ),
-			),
-		},
+			"layout:section:Quality:summary", __qualitySummary,
+			"layout:section:Hider:summary", __hiderSummary,
+			"layout:section:Statistics:summary", __statisticsSummary,
+			"layout:section:Search Paths:summary", __searchPathsSummary,
 
-	),
+		],
+
+		# Quality
+
+		"options.pixelSamples" : [
+
+			"layout:section", "Quality",
+
+		],
+
+		# Hider
+
+		"options.hider" : [
+
+			"layout:section", "Hider",
+
+		],
+
+		"options.hider.value" : [
+
+			"preset:Hidden", "hidden",
+			"preset:Raytrace", "raytrace",
+
+		],
+
+		"options.hiderDepthFilter" : [
+
+			"layout:section", "Hider",
+			"label", "Depth Filter",
+
+		],
+
+		"options.hiderDepthFilter.value" : [
+
+			"preset:Min", "min",
+			"preset:Max", "max",
+			"preset:Average", "average",
+			"preset:Midpoint", "midpoint",
+
+		],
+
+		"options.hiderJitter" : [
+
+			"layout:section", "Hider",
+			"label", "Jitter",
+
+		],
+
+		"options.hiderSampleMotion" : [
+
+			"layout:section", "Hider",
+			"label", "Sample Motion",
+
+		],
+
+		"options.hiderExtremeMotionDOF" : [
+
+			"layout:section", "Hider",
+			"label", "Extreme Motion DOF",
+
+		],
+
+		"options.hiderProgressive" : [
+
+			"layout:section", "Hider",
+			"label", "Progressive",
+
+		],
+
+		# Statistics
+
+		"options.statisticsLevel" : [
+
+			"layout:section", "Statistics",
+			"label", "Level",
+
+		],
+
+		"options.statisticsLevel.value" : [
+
+			"preset:0 (Off)", 0,
+			"preset:1", 1,
+			"preset:2", 2,
+			"preset:3 (Most Verbose)", 3,
+
+		],
+
+		"options.statisticsFileName" : [
+
+			"layout:section", "Statistics",
+			"label", "File Name",
+
+		],
+
+		"options.statisticsProgress" : [
+
+			"layout:section", "Statistics",
+			"label", "Progress",
+
+		],
+
+		# Search Paths
+
+		"options.shaderSearchPath" : [
+
+			"layout:section", "Search Paths",
+			"label", "Shaders",
+
+		],
+
+		"options.textureSearchPath" : [
+
+			"layout:section", "Search Paths",
+			"label", "Textures",
+
+		],
+
+		"options.displaySearchPath" : [
+
+			"layout:section", "Search Paths",
+			"label", "Displays",
+
+		],
+
+		"options.archiveSearchPath" : [
+
+			"layout:section", "Search Paths",
+			"label", "Archives",
+
+		],
+
+		"options.proceduralSearchPath" : [
+
+			"layout:section", "Search Paths",
+			"label", "Procedurals",
+
+		],
+
+	}
 
 )
 
 GafferUI.PlugValueWidget.registerCreator(
 	GafferRenderMan.RenderManOptions,
 	"options.hider.value",
-	GafferUI.EnumPlugValueWidget,
-	labelsAndValues = (
-		( "Hidden", "hidden" ),
-		( "Raytrace", "raytrace" ),
-	),
+	GafferUI.PresetsPlugValueWidget,
 )
 
 GafferUI.PlugValueWidget.registerCreator(
 	GafferRenderMan.RenderManOptions,
 	"options.hiderDepthFilter.value",
-	GafferUI.EnumPlugValueWidget,
-	labelsAndValues = (
-		( "Min", "min" ),
-		( "Max", "max" ),
-		( "Average", "average" ),
-		( "Midpoint", "midpoint" ),
-	),
+	GafferUI.PresetsPlugValueWidget,
 )
 
 GafferUI.PlugValueWidget.registerCreator(
 	GafferRenderMan.RenderManOptions,
 	"options.statisticsLevel.value",
-	GafferUI.EnumPlugValueWidget,
-	labelsAndValues = (
-		( "0 (Off)", 0 ),
-		( "1", 1 ),
-		( "2", 2 ),
-		( "3 (Most Verbose)", 3 ),
-	),
+	GafferUI.PresetsPlugValueWidget,
 )
 
 GafferUI.PlugValueWidget.registerCreator(

--- a/python/GafferSceneUI/AttributesUI.py
+++ b/python/GafferSceneUI/AttributesUI.py
@@ -40,26 +40,42 @@ import GafferUI
 import GafferScene
 
 
-Gaffer.Metadata.registerNodeDescription(
+Gaffer.Metadata.registerNode(
 
-GafferScene.Attributes,
+	GafferScene.Attributes,
 
-"""The base type for nodes that apply attributes to the scene.
-""",
+	"description",
+	"""
+	The base type for nodes that apply attributes to the scene.
+	""",
 
-"attributes",
-"""The attributes to be applied - arbitrary numbers of user defined attributes may be added
-as children of this plug via the user interface, or using the CompoundDataPlug API via
-python.""",
+	plugs = {
 
-"global",
-{
-	"description" : "Causes the attributes to be applied to the scene globals "
-	                "instead of the individual locations defined by the filter.",
-	"nodeUI:section" : "Filter",
-}
+		"attributes" : [
+
+			"description",
+			"""
+			The attributes to be applied - arbitrary numbers of user defined
+			attributes may be added as children of this plug via the user
+			interface, or using the CompoundDataPlug API via python.
+			""",
+
+		],
+
+		"global" : [
+
+			"description",
+			"""
+			Causes the attributes to be applied to the scene globals
+			instead of the individual locations defined by the filter.
+			""",
+
+			"nodeUI:section", "Filter",
+
+		]
+
+	}
 
 )
 
-
-GafferUI.PlugValueWidget.registerCreator( GafferScene.Attributes, "attributes", GafferUI.CompoundDataPlugValueWidget, collapsed=None )
+GafferUI.PlugValueWidget.registerCreator( GafferScene.Attributes, "attributes", GafferUI.LayoutPlugValueWidget )

--- a/python/GafferSceneUI/OpenGLAttributesUI.py
+++ b/python/GafferSceneUI/OpenGLAttributesUI.py
@@ -42,223 +42,6 @@ import GafferScene
 # Metadata
 ##########################################################################
 
-Gaffer.Metadata.registerNode(
-
-	GafferScene.OpenGLAttributes,
-
-	"description",
-	"""
-	Applies attributes to modify the appearance of objects in
-	the viewport and in renders done by the OpenGLRender node.
-	""",
-
-	plugs = {
-
-		# General drawing plugs
-
-		"attributes.primitiveSolid" : [
-
-			"description",
-			"""
-			Whether or not the object is rendered solid, in which
-			case the assigned GLSL shader will be used to perform
-			the shading.
-			""",
-
-		],
-
-		"attributes.primitiveWireframe" : [
-
-			"description",
-			"""
-			Whether or not the object is rendered as a wireframe.
-			Use the primitiveWireframeColor and primitiveWireframeWidth
-			plugs for finer control of the wireframe appearance.
-			""",
-
-		],
-
-		"attributes.primitiveWireframeColor" : [
-
-			"description",
-			"""
-			The colour to use for the wireframe rendering. Only
-			meaningful if wireframe rendering is turned on.
-			""",
-
-		],
-
-		"attributes.primitiveWireframeWidth" : [
-
-			"description",
-			"""
-			The width in pixels of the wireframe rendering. Only
-			meaningful if wireframe rendering is turned on.
-			""",
-
-		],
-
-		"attributes.primitiveOutline" : [
-
-			"description",
-			"""
-			Whether or not an outline is drawn around the object.
-			Use the primitiveOutlineColor and primitiveOutlineWidth
-			plugs for finer control of the outline.
-			""",
-
-		],
-
-		"attributes.primitiveOutlineColor" : [
-
-			"description",
-			"""
-			The colour to use for the outline. Only
-			meaningful if outline rendering is turned on.
-			""",
-
-		],
-
-		"attributes.primitiveOutlineWidth" : [
-
-			"description",
-			"""
-			The width in pixels of the outline. Only
-			meaningful if outline rendering is turned on.
-			""",
-
-		],
-
-		"attributes.primitivePoint" : [
-
-			"description",
-			"""
-			Whether or not the individual points (vertices) of the
-			object are drawn. Use the primitivePointColor and primitivePointWidth
-			plugs for finer control of the point rendering.
-			""",
-
-		],
-
-		"attributes.primitivePointColor" : [
-
-			"description",
-			"""
-			The colour to use for the point rendering. Only
-			meaningful if point rendering is turned on.
-			""",
-
-		],
-
-		"attributes.primitivePointWidth" : [
-
-			"description",
-			"""
-			The width in pixels of the points. Only
-			meaningful if point rendering is turned on.
-			""",
-
-		],
-
-		"attributes.primitiveBound" : [
-
-			"description",
-			"""
-			Whether or not the bounding box of the object is drawn.
-			This is in addition to any drawing of unexpanded bounding
-			boxes that the viewer performs. Use the primitiveBoundColor
-			plug to change the colour of the bounding box.
-			""",
-
-		],
-
-		"attributes.primitiveBoundColor" : [
-
-			"description",
-			"""
-			The colour to use for the bounding box rendering. Only
-			meaningful if bounding box rendering is turned on.
-			""",
-
-		],
-
-		# Points primitive drawing plugs
-
-		"attributes.pointsPrimitiveUseGLPoints" : [
-
-			"description",
-			"""
-			Points primitives have a render type (set by the PointsType
-			node) which allows them to be rendered as particles, disks,
-			spheres etc. This attribute overrides that type for OpenGL
-			only, allowing a much faster rendering as raw OpenGL points.
-			""",
-
-		],
-
-		"attributes.pointsPrimitiveUseGLPoints.value" : [
-
-			"preset:For GL Points", "forGLPoints",
-			"preset:For Particles And Disks", "forParticlesAndDisks",
-			"preset:For All", "forAll",
-
-		],
-
-		"attributes.pointsPrimitiveGLPointWidth" : [
-
-			"description",
-			"""
-			The width in pixels of the GL points rendered when
-			the pointsPrimitiveUseGLPoints plug has overridden
-			the point type.
-			""",
-
-		],
-
-		# Curves primitive drawing plugs
-
-		"attributes.curvesPrimitiveUseGLLines" : [
-
-			"description",
-			"""
-			Curves primitives are typically rendered as ribbons
-			and as such have an associated width in object space.
-			This attribute overrides that for OpenGL only, allowing
-			a much faster rendering as raw OpenGL lines.
-			""",
-
-		],
-
-		"attributes.curvesPrimitiveGLLineWidth" : [
-
-			"description",
-			"""
-			The width in pixels of the GL lines rendered when
-			the curvesPrimitiveUseGLLines plug has overridden
-			the drawing to use lines.
-			""",
-
-		],
-
-		"attributes.curvesPrimitiveIgnoreBasis" : [
-
-			"description",
-			"""
-			Turns off interpolation for cubic curves, just
-			rendering straight lines between the vertices
-			instead.
-			""",
-
-		],
-
-	}
-
-)
-
-##########################################################################
-# PlugValueWidgets
-##########################################################################
-
 def __drawingSummary( plug ) :
 
 	info = []
@@ -307,59 +90,283 @@ def __curvesPrimitivesSummary( plug ) :
 
 	return ", ".join( info )
 
-GafferUI.PlugValueWidget.registerCreator(
+Gaffer.Metadata.registerNode(
 
 	GafferScene.OpenGLAttributes,
-	"attributes",
-	GafferUI.SectionedCompoundDataPlugValueWidget,
-	sections = (
 
-		{
-			"label" : "Drawing",
-			"summary" : __drawingSummary,
-			"namesAndLabels" : (
-				( "gl:primitive:solid", "Shaded" ),
+	"description",
+	"""
+	Applies attributes to modify the appearance of objects in
+	the viewport and in renders done by the OpenGLRender node.
+	""",
 
-				( "gl:primitive:wireframe", "Wireframe" ),
-				( "gl:primitive:wireframeColor", "Wireframe Color" ),
-				( "gl:primitive:wireframeWidth", "Wireframe Width" ),
+	plugs = {
 
-				( "gl:primitive:outline", "Outline" ),
-				( "gl:primitive:outlineColor", "Outline Color" ),
-				( "gl:primitive:outlineWidth", "Outline Width" ),
+		# Section summaries
 
-				( "gl:primitive:points", "Points" ),
-				( "gl:primitive:pointColor", "Point Color" ),
-				( "gl:primitive:pointWidth", "Point Width" ),
+		"attributes" : [
 
-				( "gl:primitive:bound", "Bound" ),
-				( "gl:primitive:boundColor", "Bound Color" ),
+			"layout:section:Drawing:summary", __drawingSummary,
+			"layout:section:Points Primitives:summary", __pointsPrimitivesSummary,
+			"layout:section:Curves Primitives:summary", __curvesPrimitivesSummary,
 
-			),
-		},
+		],
 
-		{
-			"label" : "Points Primitives",
-			"summary" : __pointsPrimitivesSummary,
-			"namesAndLabels" : (
-				( "gl:pointsPrimitive:useGLPoints", "Use GL Points" ),
-				( "gl:pointsPrimitive:glPointWidth", "GL Point Width" ),
-			),
-		},
+		# General drawing plugs
 
-		{
-			"label" : "Curves Primitives",
-			"summary" : __curvesPrimitivesSummary,
-			"namesAndLabels" : (
-				( "gl:curvesPrimitive:useGLLines", "Use GL Lines" ),
-				( "gl:curvesPrimitive:glLineWidth", "GL Line Width" ),
-				( "gl:curvesPrimitive:ignoreBasis", "Ignore Basis" ),
-			),
-		},
+		"attributes.primitiveSolid" : [
 
-	),
+			"description",
+			"""
+			Whether or not the object is rendered solid, in which
+			case the assigned GLSL shader will be used to perform
+			the shading.
+			""",
+
+			"layout:section", "Drawing",
+			"label", "Shaded",
+
+		],
+
+		"attributes.primitiveWireframe" : [
+
+			"description",
+			"""
+			Whether or not the object is rendered as a wireframe.
+			Use the primitiveWireframeColor and primitiveWireframeWidth
+			plugs for finer control of the wireframe appearance.
+			""",
+
+			"layout:section", "Drawing",
+			"label", "Wireframe",
+
+		],
+
+		"attributes.primitiveWireframeColor" : [
+
+			"description",
+			"""
+			The colour to use for the wireframe rendering. Only
+			meaningful if wireframe rendering is turned on.
+			""",
+
+			"layout:section", "Drawing",
+			"label", "Wireframe Color",
+
+		],
+
+		"attributes.primitiveWireframeWidth" : [
+
+			"description",
+			"""
+			The width in pixels of the wireframe rendering. Only
+			meaningful if wireframe rendering is turned on.
+			""",
+
+			"layout:section", "Drawing",
+			"label", "Wireframe Width",
+
+		],
+
+		"attributes.primitiveOutline" : [
+
+			"description",
+			"""
+			Whether or not an outline is drawn around the object.
+			Use the primitiveOutlineColor and primitiveOutlineWidth
+			plugs for finer control of the outline.
+			""",
+
+			"layout:section", "Drawing",
+			"label", "Outline",
+
+		],
+
+		"attributes.primitiveOutlineColor" : [
+
+			"description",
+			"""
+			The colour to use for the outline. Only
+			meaningful if outline rendering is turned on.
+			""",
+
+			"layout:section", "Drawing",
+			"label", "Outline Color",
+
+		],
+
+		"attributes.primitiveOutlineWidth" : [
+
+			"description",
+			"""
+			The width in pixels of the outline. Only
+			meaningful if outline rendering is turned on.
+			""",
+
+			"layout:section", "Drawing",
+			"label", "Outline Width",
+
+		],
+
+		"attributes.primitivePoint" : [
+
+			"description",
+			"""
+			Whether or not the individual points (vertices) of the
+			object are drawn. Use the primitivePointColor and primitivePointWidth
+			plugs for finer control of the point rendering.
+			""",
+
+			"layout:section", "Drawing",
+			"label", "Points",
+
+		],
+
+		"attributes.primitivePointColor" : [
+
+			"description",
+			"""
+			The colour to use for the point rendering. Only
+			meaningful if point rendering is turned on.
+			""",
+
+			"layout:section", "Drawing",
+			"label", "Point Color",
+
+		],
+
+		"attributes.primitivePointWidth" : [
+
+			"description",
+			"""
+			The width in pixels of the points. Only
+			meaningful if point rendering is turned on.
+			""",
+
+			"layout:section", "Drawing",
+			"label", "Point Width",
+
+		],
+
+		"attributes.primitiveBound" : [
+
+			"description",
+			"""
+			Whether or not the bounding box of the object is drawn.
+			This is in addition to any drawing of unexpanded bounding
+			boxes that the viewer performs. Use the primitiveBoundColor
+			plug to change the colour of the bounding box.
+			""",
+
+			"layout:section", "Drawing",
+			"label", "Bound",
+
+		],
+
+		"attributes.primitiveBoundColor" : [
+
+			"description",
+			"""
+			The colour to use for the bounding box rendering. Only
+			meaningful if bounding box rendering is turned on.
+			""",
+
+			"layout:section", "Drawing",
+			"label", "Bound Color",
+
+		],
+
+		# Points primitive drawing plugs
+
+		"attributes.pointsPrimitiveUseGLPoints" : [
+
+			"description",
+			"""
+			Points primitives have a render type (set by the PointsType
+			node) which allows them to be rendered as particles, disks,
+			spheres etc. This attribute overrides that type for OpenGL
+			only, allowing a much faster rendering as raw OpenGL points.
+			""",
+
+			"layout:section", "Points Primitives",
+			"label", "Use GL Points",
+
+		],
+
+		"attributes.pointsPrimitiveUseGLPoints.value" : [
+
+			"preset:For GL Points", "forGLPoints",
+			"preset:For Particles And Disks", "forParticlesAndDisks",
+			"preset:For All", "forAll",
+
+		],
+
+		"attributes.pointsPrimitiveGLPointWidth" : [
+
+			"description",
+			"""
+			The width in pixels of the GL points rendered when
+			the pointsPrimitiveUseGLPoints plug has overridden
+			the point type.
+			""",
+
+			"layout:section", "Points Primitives",
+			"label", "GL Point Width",
+
+		],
+
+		# Curves primitive drawing plugs
+
+		"attributes.curvesPrimitiveUseGLLines" : [
+
+			"description",
+			"""
+			Curves primitives are typically rendered as ribbons
+			and as such have an associated width in object space.
+			This attribute overrides that for OpenGL only, allowing
+			a much faster rendering as raw OpenGL lines.
+			""",
+
+			"layout:section", "Curves Primitives",
+			"label", "Use GL Lines",
+
+		],
+
+		"attributes.curvesPrimitiveGLLineWidth" : [
+
+			"description",
+			"""
+			The width in pixels of the GL lines rendered when
+			the curvesPrimitiveUseGLLines plug has overridden
+			the drawing to use lines.
+			""",
+
+			"layout:section", "Curves Primitives",
+			"label", "GL Line Width",
+
+		],
+
+		"attributes.curvesPrimitiveIgnoreBasis" : [
+
+			"description",
+			"""
+			Turns off interpolation for cubic curves, just
+			rendering straight lines between the vertices
+			instead.
+			""",
+
+			"layout:section", "Curves Primitives",
+			"label", "Ignore Basis",
+
+		],
+
+	}
 
 )
+
+##########################################################################
+# PlugValueWidgets
+##########################################################################
 
 GafferUI.PlugValueWidget.registerCreator(
 	GafferScene.OpenGLAttributes,

--- a/python/GafferSceneUI/OptionsUI.py
+++ b/python/GafferSceneUI/OptionsUI.py
@@ -38,21 +38,30 @@ import Gaffer
 import GafferUI
 import GafferScene
 
+Gaffer.Metadata.registerNode(
 
-Gaffer.Metadata.registerNodeDescription(
+	GafferScene.Options,
 
-GafferScene.Options,
+	"description",
+	"""
+	The base type for nodes that apply options to the scene.
+	""",
 
-"""The base type for nodes that apply options to the scene.
-""",
+	plugs = {
 
-"options",
-"""The options to be applied - arbitrary numbers of user defined options may be added
-as children of this plug via the user interface, or using the CompoundDataPlug API via
-python.""",
+		"options" : [
+
+			"description",
+			"""
+			The options to be applied - arbitrary numbers of user defined options may be added
+			as children of this plug via the user interface, or using the CompoundDataPlug API via
+			python.
+			""",
+
+		],
+
+	}
 
 )
 
-
-
-GafferUI.PlugValueWidget.registerCreator( GafferScene.Options, "options", GafferUI.CompoundDataPlugValueWidget, collapsed=None )
+GafferUI.PlugValueWidget.registerCreator( GafferScene.Options, "options", GafferUI.LayoutPlugValueWidget )

--- a/python/GafferSceneUI/StandardAttributesUI.py
+++ b/python/GafferSceneUI/StandardAttributesUI.py
@@ -38,104 +38,6 @@ import Gaffer
 import GafferUI
 import GafferScene
 
-##########################################################################
-# Metadata
-##########################################################################
-
-Gaffer.Metadata.registerNode(
-
-	GafferScene.StandardAttributes,
-
-	"description",
-	"""
-	Modifies the standard attributes on objects - these should
-	be respected by all renderers.
-	""",
-
-	plugs = {
-
-		# visibility plugs
-
-		"attributes.visibility" : [
-
-			"description",
-			"""
-			Whether or not the object can be seen - invisible objects are
-			not sent to the renderer at all. Typically more fine
-			grained (camera, reflection etc) visibility can be
-			specified using a renderer specific attributes node.
-			Note that making a parent location invisible will
-			always make all the children invisible too, regardless
-			of their visibility settings.
-			""",
-
-		],
-
-		"attributes.doubleSided" : [
-
-			"description",
-			"""
-			Whether or not the object can be seen from both sides.
-			Single sided objects appear invisible when seen from
-			the back.
-			""",
-
-		],
-
-		# motion blur plugs
-
-		"attributes.transformBlur" : [
-
-			"description",
-			"""
-			Whether or not transformation animation on the
-			object is taken into account in the rendered image.
-			Use the transformBlurSegments plug to specify the number
-			of segments used to represent the motion.
-			""",
-
-		],
-
-		"attributes.transformBlurSegments" : [
-
-			"description",
-			"""
-			The number of segments of transform animation to
-			pass to the renderer when transformBlur is on.
-			""",
-
-		],
-
-		"attributes.deformationBlur" : [
-
-			"description",
-			"""
-			Whether or not deformation animation on the
-			object is taken into account in the rendered image.
-			Use the deformationBlurSegments plug to specify the
-			number of segments used to represent the motion.
-			""",
-
-		],
-
-		"attributes.deformationBlurSegments" : [
-
-			"description",
-			"""
-			The number of segments of transform animation to
-			pass to the renderer when transformBlur is on.
-			""",
-
-		],
-
-	}
-
-)
-
-##########################################################################
-# PlugValueWidgets
-##########################################################################
-
 def __attributesSummary( plug ) :
 
 	info = []
@@ -162,33 +64,117 @@ def __motionBlurSummary( plug ) :
 
 	return ", ".join( info )
 
-GafferUI.PlugValueWidget.registerCreator(
+Gaffer.Metadata.registerNode(
 
 	GafferScene.StandardAttributes,
-	"attributes",
-	GafferUI.SectionedCompoundDataPlugValueWidget,
-	sections = (
 
-		{
-			"label" : "Attributes",
-			"summary" : __attributesSummary,
-			"namesAndLabels" : (
-				( "scene:visible", "Visibility" ),
-				( "doubleSided", "Double Sided" ),
-			),
-		},
+	"description",
+	"""
+	Modifies the standard attributes on objects - these should
+	be respected by all renderers.
+	""",
 
-		{
-			"label" : "Motion Blur",
-			"summary" : __motionBlurSummary,
-			"namesAndLabels" : (
-				( "gaffer:transformBlur", "Transform" ),
-				( "gaffer:transformBlurSegments", "Transform Segments" ),
-				( "gaffer:deformationBlur", "Deformation" ),
-				( "gaffer:deformationBlurSegments", "Deformation Segments" ),
-			),
-		},
+	plugs = {
 
-	),
+		# sections
+
+		"attributes" : [
+
+			"layout:section:Attributes:summary", __attributesSummary,
+			"layout:section:Motion Blur:summary", __motionBlurSummary,
+
+		],
+
+		# visibility plugs
+
+		"attributes.visibility" : [
+
+			"description",
+			"""
+			Whether or not the object can be seen - invisible objects are
+			not sent to the renderer at all. Typically more fine
+			grained (camera, reflection etc) visibility can be
+			specified using a renderer specific attributes node.
+			Note that making a parent location invisible will
+			always make all the children invisible too, regardless
+			of their visibility settings.
+			""",
+
+			"layout:section", "Attributes",
+
+		],
+
+		"attributes.doubleSided" : [
+
+			"description",
+			"""
+			Whether or not the object can be seen from both sides.
+			Single sided objects appear invisible when seen from
+			the back.
+			""",
+
+			"layout:section", "Attributes",
+
+		],
+
+		# motion blur plugs
+
+		"attributes.transformBlur" : [
+
+			"description",
+			"""
+			Whether or not transformation animation on the
+			object is taken into account in the rendered image.
+			Use the transformBlurSegments plug to specify the number
+			of segments used to represent the motion.
+			""",
+
+			"layout:section", "Motion Blur",
+			"label", "Transform",
+
+		],
+
+		"attributes.transformBlurSegments" : [
+
+			"description",
+			"""
+			The number of segments of transform animation to
+			pass to the renderer when transformBlur is on.
+			""",
+
+			"layout:section", "Motion Blur",
+			"label", "Transform Segments",
+
+		],
+
+		"attributes.deformationBlur" : [
+
+			"description",
+			"""
+			Whether or not deformation animation on the
+			object is taken into account in the rendered image.
+			Use the deformationBlurSegments plug to specify the
+			number of segments used to represent the motion.
+			""",
+
+			"layout:section", "Motion Blur",
+			"label", "Deformation",
+
+		],
+
+		"attributes.deformationBlurSegments" : [
+
+			"description",
+			"""
+			The number of segments of transform animation to
+			pass to the renderer when transformBlur is on.
+			""",
+
+			"layout:section", "Motion Blur",
+			"label", "Deformation Segments",
+
+		],
+
+	}
 
 )

--- a/python/GafferSceneUI/StandardOptionsUI.py
+++ b/python/GafferSceneUI/StandardOptionsUI.py
@@ -45,187 +45,6 @@ import GafferSceneUI
 # Metadata
 ##########################################################################
 
-Gaffer.Metadata.registerNode(
-
-	GafferScene.StandardOptions,
-
-	"description",
-	"""
-	Specifies the standard options (global settings) for the
-	scene. These should be respected by all renderers.
-	""",
-
-	plugs = {
-
-		# camera plugs
-
-		"options.renderCamera" : [
-
-			"description",
-			"""
-			The primary camera to be used for rendering. If this
-			is not specified, then a default orthographic camera
-			positioned at the origin is used.
-			""",
-
-		],
-
-		"options.renderResolution" : [
-
-			"description",
-			"""
-			The resolution of the image to be rendered. Use the
-			resolution multiplier as a convenient way to temporarily
-			render at multiples of this resolution.
-			""",
-
-		],
-
-		"options.pixelAspectRatio" : [
-
-			"description",
-			"""
-			The aspect ratio (x/y) of the pixels in the rendered image.
-			""",
-
-		],
-
-		"options.resolutionMultiplier" : [
-
-			"description",
-			"""
-			Multiplier applied to the render resolution.
-			""",
-
-		],
-
-		"options.renderCropWindow" : [
-
-			"description",
-			"""
-			Limits the render to a region of the image. The rendered
-			image will have the same resolution as usual, but areas
-			outside the crop will be rendered black. Coordinates
-			range from 0,0 at the top left of the image to 1,1 at the
-			bottom right. The crop window tool in the viewer may be
-			used to set this interactively.
-			""",
-
-		],
-
-		"options.overscan" : [
-
-			"description",
-			"""
-			Adds extra pixels to the sides of the rendered image.
-			This can be useful when camera shake or blur will be
-			added as a post process. This plug just enables overscan
-			as a whole - use the overscanTop, overscanBottom, overscanLeft
-			and overscanRight plugs to specify the amount of overscan
-			on each side of the image.
-			""",
-
-		],
-
-		"options.overscanTop" : [
-
-			"description",
-			"""
-			The amount of overscan at the top of the image. Specified
-			as a 0-1 proportion of the original image height.
-			""",
-
-		],
-
-		"options.overscanBottom" : [
-
-			"description",
-			"""
-			The amount of overscan at the bottom of the image. Specified
-			as a 0-1 proportion of the original image height.
-			""",
-
-		],
-
-		"options.overscanLeft" : [
-
-			"description",
-			"""
-			The amount of overscan at the left of the image. Specified
-			as a 0-1 proportion of the original image width.
-			""",
-
-		],
-
-		"options.overscanRight" : [
-
-			"description",
-			"""
-			The amount of overscan at the right of the image. Specified
-			as a 0-1 proportion of the original image width.
-			""",
-
-		],
-
-		# motion blur plugs
-
-		"options.cameraBlur" : [
-
-			"description",
-			"""
-			Whether or not camera motion is taken into
-			account in the renderered image. To specify the
-			number of segments to use for camera motion, use
-			a StandardAttributes node filtered for the camera.
-			""",
-
-		],
-
-		"options.transformBlur" : [
-
-			"description",
-			"""
-			Whether or not transform motion is taken into
-			account in the renderered image. To specify the
-			number of transform segments to use for each
-			object in the scene, use a StandardAttributes node
-			with appropriate filters.
-			""",
-
-		],
-
-		"options.deformationBlur" : [
-
-			"description",
-			"""
-			Whether or not deformation motion is taken into
-			account in the renderered image. To specify the
-			number of deformation segments to use for each
-			object in the scene, use a StandardAttributes node
-			with appropriate filters.
-			""",
-
-		],
-
-		"options.shutter" : [
-
-			"description",
-			"""
-			The interval over which the camera shutter is open.
-			Measured in frames, and specified relative to the
-			frame being rendered.
-			""",
-
-		],
-
-	}
-
-)
-
-##########################################################################
-# PlugValueWidgets
-##########################################################################
-
 ## \todo This is getting used in a few places now - maybe put it in one
 # place? Maybe a static method on NumericWidget?
 def __floatToString( f ) :
@@ -268,44 +87,229 @@ def __motionBlurSummary( plug ) :
 
 	return ", ".join( info )
 
-GafferUI.PlugValueWidget.registerCreator(
+Gaffer.Metadata.registerNode(
 
 	GafferScene.StandardOptions,
-	"options",
-	GafferUI.SectionedCompoundDataPlugValueWidget,
-	sections = (
 
-		{
-			"label" : "Camera",
-			"summary" : __cameraSummary,
-			"namesAndLabels" : (
-				( "render:camera", "Camera" ),
-				( "render:resolution", "Resolution" ),
-				( "render:pixelAspectRatio", "Pixel Aspect Ratio" ),
-				( "render:resolutionMultiplier", "Resolution Multiplier" ),
-				( "render:cropWindow", "Crop Window" ),
-				( "render:overscan", "Overscan" ),
-				( "render:overscanTop", "Overscan Top" ),
-				( "render:overscanBottom", "Overscan Bottom" ),
-				( "render:overscanLeft", "Overscan Left" ),
-				( "render:overscanRight", "Overscan Right" ),
-			),
-		},
+	"description",
+	"""
+	Specifies the standard options (global settings) for the
+	scene. These should be respected by all renderers.
+	""",
 
-		{
-			"label" : "Motion Blur",
-			"summary" : __motionBlurSummary,
-			"namesAndLabels" : (
-				( "render:cameraBlur", "Camera" ),
-				( "render:transformBlur", "Transform" ),
-				( "render:deformationBlur", "Deformation" ),
-				( "render:shutter", "Shutter" ),
-			),
-		},
+	plugs = {
 
-	),
+		# section summaries
+
+		"options" : [
+
+			"layout:section:Camera:summary", __cameraSummary,
+			"layout:section:Motion Blur:summary", __motionBlurSummary,
+
+		],
+
+		# camera plugs
+
+		"options.renderCamera" : [
+
+			"description",
+			"""
+			The primary camera to be used for rendering. If this
+			is not specified, then a default orthographic camera
+			positioned at the origin is used.
+			""",
+
+			"layout:section", "Camera",
+			"label", "Camera",
+
+		],
+
+		"options.renderResolution" : [
+
+			"description",
+			"""
+			The resolution of the image to be rendered. Use the
+			resolution multiplier as a convenient way to temporarily
+			render at multiples of this resolution.
+			""",
+
+			"layout:section", "Camera",
+			"label", "Resolution",
+
+		],
+
+		"options.pixelAspectRatio" : [
+
+			"description",
+			"""
+			The aspect ratio (x/y) of the pixels in the rendered image.
+			""",
+
+			"layout:section", "Camera",
+
+		],
+
+		"options.resolutionMultiplier" : [
+
+			"description",
+			"""
+			Multiplier applied to the render resolution.
+			""",
+
+			"layout:section", "Camera",
+
+		],
+
+		"options.renderCropWindow" : [
+
+			"description",
+			"""
+			Limits the render to a region of the image. The rendered
+			image will have the same resolution as usual, but areas
+			outside the crop will be rendered black. Coordinates
+			range from 0,0 at the top left of the image to 1,1 at the
+			bottom right. The crop window tool in the viewer may be
+			used to set this interactively.
+			""",
+
+			"layout:section", "Camera",
+			"label", "Crop Window",
+
+		],
+
+		"options.overscan" : [
+
+			"description",
+			"""
+			Adds extra pixels to the sides of the rendered image.
+			This can be useful when camera shake or blur will be
+			added as a post process. This plug just enables overscan
+			as a whole - use the overscanTop, overscanBottom, overscanLeft
+			and overscanRight plugs to specify the amount of overscan
+			on each side of the image.
+			""",
+
+			"layout:section", "Camera",
+
+		],
+
+		"options.overscanTop" : [
+
+			"description",
+			"""
+			The amount of overscan at the top of the image. Specified
+			as a 0-1 proportion of the original image height.
+			""",
+
+			"layout:section", "Camera",
+
+		],
+
+		"options.overscanBottom" : [
+
+			"description",
+			"""
+			The amount of overscan at the bottom of the image. Specified
+			as a 0-1 proportion of the original image height.
+			""",
+
+			"layout:section", "Camera",
+
+		],
+
+		"options.overscanLeft" : [
+
+			"description",
+			"""
+			The amount of overscan at the left of the image. Specified
+			as a 0-1 proportion of the original image width.
+			""",
+
+			"layout:section", "Camera",
+
+		],
+
+		"options.overscanRight" : [
+
+			"description",
+			"""
+			The amount of overscan at the right of the image. Specified
+			as a 0-1 proportion of the original image width.
+			""",
+
+			"layout:section", "Camera",
+
+		],
+
+		# motion blur plugs
+
+		"options.cameraBlur" : [
+
+			"description",
+			"""
+			Whether or not camera motion is taken into
+			account in the renderered image. To specify the
+			number of segments to use for camera motion, use
+			a StandardAttributes node filtered for the camera.
+			""",
+
+			"layout:section", "Motion Blur",
+			"label", "Camera",
+
+		],
+
+		"options.transformBlur" : [
+
+			"description",
+			"""
+			Whether or not transform motion is taken into
+			account in the renderered image. To specify the
+			number of transform segments to use for each
+			object in the scene, use a StandardAttributes node
+			with appropriate filters.
+			""",
+
+			"layout:section", "Motion Blur",
+			"label", "Transform",
+
+		],
+
+		"options.deformationBlur" : [
+
+			"description",
+			"""
+			Whether or not deformation motion is taken into
+			account in the renderered image. To specify the
+			number of deformation segments to use for each
+			object in the scene, use a StandardAttributes node
+			with appropriate filters.
+			""",
+
+			"layout:section", "Motion Blur",
+			"label", "Deformation",
+
+		],
+
+		"options.shutter" : [
+
+			"description",
+			"""
+			The interval over which the camera shutter is open.
+			Measured in frames, and specified relative to the
+			frame being rendered.
+			""",
+
+			"layout:section", "Motion Blur",
+
+		],
+
+	}
 
 )
+
+##########################################################################
+# PlugValueWidgets
+##########################################################################
 
 GafferUI.PlugValueWidget.registerCreator(
 	GafferScene.StandardOptions,

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -689,6 +689,39 @@ class MetadataTest( GafferTest.TestCase ) :
 		self.assertEqual( len( ncs ), 3 )
 		self.assertEqual( len( pcs ), 3 )
 
+	def testExactPreferredToWildcards( self ) :
+
+		class MetadataTestNodeD( Gaffer.Node ) :
+
+			def __init__( self, name = "MetadataTestNodeD" ) :
+
+				Gaffer.Node.__init__( self, name )
+
+				self["a"] = Gaffer.IntPlug()
+				self["b"] = Gaffer.IntPlug()
+
+		IECore.registerRunTimeTyped( MetadataTestNodeD )
+
+		Gaffer.Metadata.registerNode(
+
+			MetadataTestNodeD,
+
+			plugs = {
+				"*" : [
+					"test", "wildcard",
+				],
+				"a" :[
+					"test", "exact",
+				],
+			}
+
+		)
+
+		n = MetadataTestNodeD()
+
+		self.assertEqual( Gaffer.Metadata.plugValue( n["a"], "test" ), "exact" )
+		self.assertEqual( Gaffer.Metadata.plugValue( n["b"], "test" ), "wildcard" )
+
 if __name__ == "__main__":
 	unittest.main()
 

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -35,6 +35,7 @@
 #
 ##########################################################################
 
+import sys
 import collections
 
 import Gaffer
@@ -150,6 +151,7 @@ class PlugLayout( GafferUI.Widget ) :
 		for plugAndIndex in plugsAndIndices :
 			index = Gaffer.Metadata.plugValue( plugAndIndex[1], "layout:index" )
 			if index is not None :
+				index = index if index >= 0 else sys.maxint + index
 				plugAndIndex[0] = index
 
 		plugsAndIndices.sort( key = lambda x : x[0] )

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -35,6 +35,8 @@
 #
 ##########################################################################
 
+import collections
+
 import Gaffer
 import GafferUI
 
@@ -43,6 +45,7 @@ import GafferUI
 # Supported metadata :
 #
 #	- "layout:index" controls ordering of plugs within the layout
+#	- "layout:section" places the plug in a named section of the layout
 #	- "divider" specifies whether or not a plug should be followed by a divider
 #	- "layout:widgetType" the class name for the widget type of a particular plug
 #
@@ -50,11 +53,11 @@ class PlugLayout( GafferUI.Widget ) :
 
 	def __init__( self, parent, orientation = GafferUI.ListContainer.Orientation.Vertical, **kw ) :
 
-		assert( isinstance( parent, ( Gaffer.Node, Gaffer.CompoundPlug ) ) )
+		assert( isinstance( parent, ( Gaffer.Node, Gaffer.Plug ) ) )
 
-		self.__mainContainer = GafferUI.ListContainer( orientation, spacing = 4 )
+		self.__layout = _TabLayout( orientation ) if isinstance( parent, Gaffer.Node ) else _CollapsibleLayout( orientation )
 
-		GafferUI.Widget.__init__( self, self.__mainContainer, **kw )
+		GafferUI.Widget.__init__( self, self.__layout, **kw )
 
 		self.__parent = parent
 		self.__readOnly = False
@@ -141,24 +144,34 @@ class PlugLayout( GafferUI.Widget ) :
 			( plug, widget ) for plug, widget in self.__plugsToWidgets.items() if plug in plugsSet
 		)
 
-		# make (or reuse existing) uis for each plug
-		orderedWidgets = []
+		# make (or reuse existing) widgets for each plug, and sort them into
+		# sections.
+		rootSection = _Section()
 		for plug in plugs :
+
 			if plug not in self.__plugsToWidgets :
 				widget = self.__createPlugWidget( plug )
 				self.__plugsToWidgets[plug] = widget
 			else :
 				widget = self.__plugsToWidgets[plug]
 
-			if widget is not None :
-				orderedWidgets.append( widget )
-				if Gaffer.Metadata.plugValue( plug, "divider" ) :
-					orderedWidgets.append( GafferUI.Divider(
-						GafferUI.Divider.Orientation.Horizontal if self.__mainContainer.orientation() == GafferUI.ListContainer.Orientation.Vertical else GafferUI.Divider.Orientation.Vertical
-					) )
+			if widget is None :
+				continue
 
-		# and update the column to display them in the right order
-		self.__mainContainer[:] = orderedWidgets
+			section = rootSection
+			for sectionName in self.__sectionPath( plug ) :
+				section = section.subsections.setdefault( sectionName, _Section() )
+
+			section.widgets.append( widget )
+
+			if Gaffer.Metadata.plugValue( plug, "divider" ) :
+				section.widgets.append( GafferUI.Divider(
+					GafferUI.Divider.Orientation.Horizontal if self.__layout.orientation() == GafferUI.ListContainer.Orientation.Vertical else GafferUI.Divider.Orientation.Vertical
+				) )
+
+		# delegate to our layout class to create a concrete
+		# layout from the section definitions.
+		self.__layout.update( rootSection )
 
  	def __createPlugWidget( self, plug ) :
 
@@ -182,7 +195,7 @@ class PlugLayout( GafferUI.Widget ) :
 
  		if not result.hasLabel() and Gaffer.Metadata.plugValue( plug, "label" ) != "" :
  			result = GafferUI.PlugWidget( result )
-			if self.__mainContainer.orientation() == GafferUI.ListContainer.Orientation.Horizontal :
+			if self.__layout.orientation() == GafferUI.ListContainer.Orientation.Horizontal :
 				# undo the annoying fixed size the PlugWidget has applied
 				# to the label.
 				## \todo Shift all the label size fixing out of PlugWidget and just fix the
@@ -193,6 +206,21 @@ class PlugLayout( GafferUI.Widget ) :
 		self.__applyReadOnly( result )
 
  		return result
+
+	def __sectionPath( self, plug ) :
+
+		m = None
+		if isinstance( self.__parent, Gaffer.Node ) :
+			# Backwards compatibility with old metadata entry
+			## \todo Remove
+			m = Gaffer.Metadata.plugValue( plug, "nodeUI:section" )
+			if m == "header" :
+				m = ""
+
+		if m is None :
+			m = Gaffer.Metadata.plugValue( plug, "layout:section" )
+
+		return m.split( "." ) if m else []
 
 	def __visibilityChanged( self, widget ) :
 
@@ -249,7 +277,101 @@ class PlugLayout( GafferUI.Widget ) :
 		if not node.isInstanceOf( node.typeId() ) :
 			return
 
-		if key in ( "divider", "layout:index" ) :
+		if key in ( "divider", "layout:index", "layout:section" ) :
 			# we often see sequences of several metadata changes - so
 			# we schedule an update on idle to batch them into one ui update.
 			self.__scheduleUpdate()
+
+# The _Section class provides a simple abstract representation of a hierarchical
+# layout. Each section contains a list of widgets, and an OrderedDict of named
+# subsections.
+class _Section( object ) :
+
+	def __init__( self ) :
+
+		self.widgets = []
+		self.subsections = collections.OrderedDict()
+
+# The PlugLayout class deals with all the details of plugs, metadata and
+# signals to define an abstract layout in terms of _Sections. It then
+# delegates to the _Layout classes to create an actual layout.
+class _Layout( GafferUI.Widget ) :
+
+	def __init__( self, topLevelWidget, orientation, **kw ) :
+
+		GafferUI.Widget.__init__( self, topLevelWidget, **kw )
+
+		self.__orientation = orientation
+
+	def orientation( self ) :
+
+		return self.__orientation
+
+	def update( self, section ) :
+
+		raise NotImplementedError
+
+class _TabLayout( _Layout ) :
+
+	def __init__( self, orientation, **kw ) :
+
+		self.__mainColumn = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Vertical )
+
+		_Layout.__init__( self, self.__mainColumn, orientation, **kw )
+
+		with self.__mainColumn :
+			self.__widgetsColumn = GafferUI.ListContainer( self.orientation(), spacing = 4, borderWidth = 4 )
+			self.__tabbedContainer = GafferUI.TabbedContainer()
+
+	def update( self, section ) :
+
+		self.__widgetsColumn[:] = section.widgets
+
+		existingTabs = collections.OrderedDict()
+		for tab in self.__tabbedContainer[:] :
+			existingTabs[self.__tabbedContainer.getLabel( tab )] = tab
+
+		updatedTabs = collections.OrderedDict()
+		for name, subsection in section.subsections.items() :
+			tab = existingTabs.get( name )
+			if tab is None :
+				tab = GafferUI.ScrolledContainer( borderWidth = 8 )
+				if self.orientation() == GafferUI.ListContainer.Orientation.Vertical :
+					tab.setHorizontalMode( GafferUI.ScrolledContainer.ScrollMode.Never )
+				else :
+					tab.setVerticalMode( GafferUI.ScrolledContainer.ScrollMode.Never )
+				tab.setChild( _CollapsibleLayout( self.orientation() ) )
+			tab.getChild().update( subsection )
+			updatedTabs[name] = tab
+
+		if existingTabs.keys() != updatedTabs.keys() :
+			del self.__tabbedContainer[:]
+			for name, tab in updatedTabs.items() :
+				self.__tabbedContainer.append( tab, label = name )
+
+		self.__widgetsColumn.setVisible( len( section.widgets ) )
+		self.__tabbedContainer.setVisible( len( self.__tabbedContainer ) )
+
+class _CollapsibleLayout( _Layout ) :
+
+	def __init__( self, orientation, **kw ) :
+
+		self.__column = GafferUI.ListContainer( orientation, spacing = 4 )
+
+		_Layout.__init__( self, self.__column, orientation, **kw )
+
+		self.__collapsibles = {} # Indexed by section name
+
+	def update( self, section ) :
+
+		widgets = list( section.widgets )
+
+		for name, subsection in section.subsections.items() :
+			collapsible = self.__collapsibles.get( name )
+			if collapsible is None :
+				collapsible = GafferUI.Collapsible( name, _CollapsibleLayout( self.orientation() ), borderWidth = 2, collapsed = True )
+				self.__collapsibles[name] = collapsible
+			collapsible.getChild().update( subsection )
+			widgets.append( collapsible )
+
+		self.__column[:] = widgets

--- a/python/GafferUI/SectionedCompoundDataPlugValueWidget.py
+++ b/python/GafferUI/SectionedCompoundDataPlugValueWidget.py
@@ -35,6 +35,8 @@
 #
 ##########################################################################
 
+import warnings
+
 import GafferUI
 
 class _Section( GafferUI.CompoundDataPlugValueWidget ) :
@@ -54,8 +56,7 @@ class _Section( GafferUI.CompoundDataPlugValueWidget ) :
 
 		return self.__namesToLabels[childPlug["name"].getValue()]
 
-## \todo Remove this class. Add native metadata-driven sectioning support to
-# PlugLayout instead.
+## \todo Remove this class.
 class SectionedCompoundDataPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __init__( self, plug, sections, **kw ) :
@@ -76,6 +77,8 @@ class SectionedCompoundDataPlugValueWidget( GafferUI.PlugValueWidget ) :
 						labels = [ e[1] for e in section["namesAndLabels"] ],
 					)
 				)
+
+		warnings.warn( "SectionedCompoundDataPlugValueWidget is deprecated, use LayoutPlugValueWidget instead.", DeprecationWarning, 2 )
 
 	def setPlug( self, plug ) :
 

--- a/python/GafferUI/SectionedCompoundPlugValueWidget.py
+++ b/python/GafferUI/SectionedCompoundPlugValueWidget.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import warnings
+
 import GafferUI
 
 class _Section( GafferUI.CompoundPlugValueWidget ) :
@@ -48,6 +50,7 @@ class _Section( GafferUI.CompoundPlugValueWidget ) :
 
 		return [ self.getPlug()[name] for name in self.__names ]
 
+## \todo Remove
 class SectionedCompoundPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __init__( self, plug, sections, **kw ) :
@@ -65,6 +68,8 @@ class SectionedCompoundPlugValueWidget( GafferUI.PlugValueWidget ) :
 					summary = section.get( "summary", None ),
 					names = section["names"],
 				)
+
+		warnings.warn( "SectionedCompoundPlugValueWidget is deprecated, use LayoutPlugValueWidget instead.", DeprecationWarning, 2 )
 
 	def hasLabel( self ) :
 

--- a/src/Gaffer/Metadata.cpp
+++ b/src/Gaffer/Metadata.cpp
@@ -438,8 +438,20 @@ IECore::ConstDataPtr Metadata::plugValueInternal( const Plug *plug, IECore::Inte
 		NodeMetadataMap::const_iterator nIt = nodeMetadataMap().find( typeId );
 		if( nIt != nodeMetadataMap().end() )
 		{
-			NodeMetadata::PlugPathsToValues::const_iterator it, eIt;
-			for( it = nIt->second.plugPathsToValues.begin(), eIt = nIt->second.plugPathsToValues.end(); it != eIt; ++it )
+			// First do a direct lookup using the plug path.
+			NodeMetadata::PlugPathsToValues::const_iterator it = nIt->second.plugPathsToValues.find( plugPath );
+			const NodeMetadata::PlugPathsToValues::const_iterator eIt = nIt->second.plugPathsToValues.end();
+			if( it != eIt )
+			{
+				NodeMetadata::PlugValues::const_iterator vIt = it->second.find( key );
+				if( vIt != it->second.end() )
+				{
+					return vIt->second( plug );
+				}
+			}
+			// And only if the direct lookups fails, do a full search using
+			// wildcard matches.
+			for( it = nIt->second.plugPathsToValues.begin(); it != eIt; ++it )
 			{
 				if( match( plugPath, it->first ) )
 				{

--- a/src/GafferBindings/FileSystemPathBinding.cpp
+++ b/src/GafferBindings/FileSystemPathBinding.cpp
@@ -50,7 +50,7 @@ using namespace GafferBindings;
 namespace
 {
 
-PathFilterPtr createStandardFilter( list pythonExtensions, const std::string &extensionsLabel )
+PathFilterPtr createStandardFilter( object pythonExtensions, const std::string &extensionsLabel )
 {
 	std::vector<std::string> extensions;
 	boost::python::container_utils::extend_container( extensions, pythonExtensions );

--- a/src/GafferSceneBindings/ScenePathBinding.cpp
+++ b/src/GafferSceneBindings/ScenePathBinding.cpp
@@ -55,7 +55,7 @@ using namespace GafferScene;
 namespace
 {
 
-PathFilterPtr createStandardFilter( list pythonSetNames, const std::string &setsLabel )
+PathFilterPtr createStandardFilter( object pythonSetNames, const std::string &setsLabel )
 {
 	std::vector<std::string> setNames;
 	boost::python::container_utils::extend_container( setNames, pythonSetNames );


### PR DESCRIPTION
This reimplements the activator expressions from RenderManShaderUI, the section summaries from SectionedCompoundDataPlugValueWidget and the tabs from StandardNodeUI, bringing them all into the PlugLayout class. This brings us extremely close to being able to use PlugLayout for everything, everywhere. The reason for the "Part 1" though is that a couple of places in Gaffer, and a bunch of IE internal tools are relying on implementation details of the StandardNodeUI, so I haven't thrown the switch on the StandardNodeUI switchover yet. But Part 1 does make all features available for Box UIs, and removes all use of the now deprecated Sectioned* widgets from Gaffer.
 
I'd like to get this Part 1 merged first, and I'll follow up with some emails about coordinating the necessary changes for Part 2.