### PR TITLE
Wrapper : Added support for bundled Appleseed.

### DIFF
--- a/bin/gaffer
+++ b/bin/gaffer
@@ -124,6 +124,31 @@ fi
 
 export PATH=$GAFFER_ROOT/bin:$PATH
 
+# If appleseed isn't configured in the environment, and we've been
+# shipped with it, then get that set up.
+##########################################################################
+
+if [[ -z $APPLESEED && -d $GAFFER_ROOT/appleseed ]] ; then
+
+	export APPLESEED=$GAFFER_ROOT/appleseed
+
+	if [[ `uname` = "Linux" ]] ; then
+		export LD_LIBRARY_PATH=$APPLESEED/lib:$LD_LIBRARY_PATH
+	else
+		export DYLD_LIBRARY_PATH=$APPLESEED/lib:$DYLD_LIBRARY_PATH
+	fi
+
+	# Using a glob to keep the wrapper agnostic of python version.
+	for appleseedPython in $APPLESEED/lib/python* ; do
+		export PYTHONPATH=$appleseedPython:$PYTHONPATH
+	done
+
+	export APPLESEED_SEARCHPATH=$APPLESEED/shaders:$GAFFER_ROOT/appleseedDisplays
+
+	export PATH=$APPLESEED/bin:$PATH
+
+fi
+
 # Run gaffer itself
 ##########################################################################
 


### PR DESCRIPTION
If the APPLESEED environment variable is already set, we don't do anything, on the assumption that a separate appleseed build has been set up manually. But if it isn't set, and there's an appleseed inside the Gaffer distribution, then we use it.

I've got corresponding changes that I'll merge to my gafferDependencies project soon, that'll do the appleseed build and ensure that it's bundled in the location now expected by the wrapper.