### PR TITLE
made Parameters work with objects derived from Light/Camera etc

### DIFF
--- a/src/GafferScene/Parameters.cpp
+++ b/src/GafferScene/Parameters.cpp
@@ -103,29 +103,24 @@ IECore::ConstObjectPtr Parameters::computeProcessedObject( const ScenePath &path
 
 	ConstObjectPtr outputObject = inputObject;
 	CompoundData *outputParameters = NULL;
-	switch( inputObject->typeId() )
-	{
-		case IECore::CameraTypeId : {
-			CameraPtr camera = boost::static_pointer_cast<Camera>( inputObject->copy() );
-			outputObject = camera;
-			outputParameters = camera->parametersData();
-			break;
-		}
-		case IECore::LightTypeId : {
-			LightPtr light = boost::static_pointer_cast<Light>( inputObject->copy() );
-			outputObject = light;
-			outputParameters = light->parametersData().get();
-			break;
-		}
-		case IECore::ExternalProceduralTypeId : {
-			ExternalProceduralPtr procedural = boost::static_pointer_cast<ExternalProcedural>( inputObject->copy() );
-			outputObject = procedural;
-			outputParameters = procedural->parameters();
-			break;
-		}
 
-		default :
-			outputParameters = NULL;
+	if( const Camera *camera = runTimeCast<const Camera>( inputObject.get() ) )
+	{
+		CameraPtr cameraCopy = camera->copy();
+		outputParameters = cameraCopy->parametersData();
+		outputObject = cameraCopy;
+	}
+	else if( const Light *light = runTimeCast<const Light>( inputObject.get() ) )
+	{
+		LightPtr lightCopy = light->copy();
+		outputParameters = lightCopy->parametersData().get();
+		outputObject = lightCopy;
+	}
+	else if( const ExternalProcedural *procedural = runTimeCast<const ExternalProcedural>( inputObject.get() ) )
+	{
+		ExternalProceduralPtr proceduralCopy = procedural->copy();
+		outputParameters = proceduralCopy->parameters();
+		outputObject = proceduralCopy;
 	}
 
 	if( outputParameters )


### PR DESCRIPTION
Our lights aren't actually IECore.Lights when they get inserted into the scene hierarchy - they're IEShading.Lights, meaning the Parameters node ignores them.

Writing a unit test for this ate my whole morning, and I still didn't manage it so I gave up. I was trying things like deriving from IECore.Light in python and putting it into a CompoundObjectSource (looks like python derived lights just turn into IECore.Lights when you put them into a CompoundObject), deriving from IECore.Light in c++ and putting it into a CompoundObjectSource (this seemed to suffer from a type registration problem - whenever I set "in" on the CompoundObjectSource it complained that my new type ids weren't registered), and I played around deriving from ObjectSource and SceneNode in python too, but it didn't seem like either of those classes were set up to do so. Maybe I'll try and chase down these problems when my patience has returned.
