### PR TITLE
Node UI Refactoring : Part 2

### DIFF
--- a/python/GafferImageUI/ImageNodeUI.py
+++ b/python/GafferImageUI/ImageNodeUI.py
@@ -73,5 +73,3 @@ def __noduleCreator( plug ) :
 
 GafferUI.Nodule.registerNodule( GafferImage.ImageNode, fnmatch.translate( "*" ), __noduleCreator )
 GafferUI.PlugValueWidget.registerType( GafferImage.ImagePlug, None )
-
-Gaffer.Metadata.registerPlugValue( GafferImage.ImageNode, "enabled", "nodeUI:section", "Node" )

--- a/python/GafferSceneUI/AttributesUI.py
+++ b/python/GafferSceneUI/AttributesUI.py
@@ -70,7 +70,7 @@ Gaffer.Metadata.registerNode(
 			instead of the individual locations defined by the filter.
 			""",
 
-			"nodeUI:section", "Filter",
+			"layout:section", "Filter",
 
 		]
 

--- a/python/GafferSceneUI/FilterPlugValueWidget.py
+++ b/python/GafferSceneUI/FilterPlugValueWidget.py
@@ -46,7 +46,7 @@ class FilterPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __init__( self, plug, **kw ) :
 
-		self.__column = GafferUI.ListContainer()
+		self.__column = GafferUI.ListContainer( spacing = 8 )
 		GafferUI.PlugValueWidget.__init__( self, self.__column, plug, **kw )
 
 		row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 )
@@ -99,7 +99,7 @@ class FilterPlugValueWidget( GafferUI.PlugValueWidget ) :
 			if len( self.__column ) > 1 :
 				filterNodeUI = self.__column[1]
 			if filterNodeUI is None or not filterNodeUI.node().isSame( filterNode ) :
-				filterNodeUI = GafferUI.StandardNodeUI( filterNode, displayMode = GafferUI.StandardNodeUI.DisplayMode.Bare )
+				filterNodeUI = GafferUI.NodeUI.create( filterNode )
 			if len( self.__column ) > 1 :
 				self.__column[1] = filterNodeUI
 			else :

--- a/python/GafferSceneUI/FilterUI.py
+++ b/python/GafferSceneUI/FilterUI.py
@@ -58,8 +58,6 @@ Gaffer.Metadata.registerNode(
 			filter does not match any locations.
 			""",
 
-			"nodeUI:section", "Node",
-
 		],
 
 		"out" : [

--- a/python/GafferSceneUI/FilteredSceneProcessorUI.py
+++ b/python/GafferSceneUI/FilteredSceneProcessorUI.py
@@ -46,18 +46,33 @@ import GafferSceneUI
 # Metadata
 ##########################################################################
 
-Gaffer.Metadata.registerNodeDescription(
+Gaffer.Metadata.registerNode(
 
-GafferScene.FilteredSceneProcessor,
+	GafferScene.FilteredSceneProcessor,
 
-"""The base type for scene processors which use a Filter node to control which part of the scene is affected.""",
+	"description",
+	"""
+	The base type for scene processors which use a Filter node to control
+	which part of the scene is affected.
+	""",
 
-"filter",
-{
-	"description" : """The filter used to control which parts of the scene are processed. A Filter node should be connected here.""",
-	"nodeUI:section" : "Filter",
-	"nodeGadget:nodulePosition" : "right",
-}
+	plugs = {
+
+		"filter" : [
+
+			"description",
+			"""
+			The filter used to control which parts of the scene are
+			processed. A Filter node should be connected here.
+			""",
+
+			"layout:section", "Filter",
+			"nodeGadget:nodulePosition", "right",
+			"layout:index", -3, # Just before the enabled plug
+
+		],
+
+	},
 
 )
 

--- a/python/GafferSceneUI/GridUI.py
+++ b/python/GafferSceneUI/GridUI.py
@@ -68,7 +68,7 @@ Gaffer.Metadata.registerNode(
 			The transform applied to the grid.
 			""",
 
-			"nodeUI:section", "Transform",
+			"layout:section", "Transform",
 
 		],
 

--- a/python/GafferSceneUI/ObjectSourceUI.py
+++ b/python/GafferSceneUI/ObjectSourceUI.py
@@ -65,7 +65,7 @@ Gaffer.Metadata.registerNode(
 			The transform applied to the object.
 			""",
 
-			"nodeUI:section", "Transform",
+			"layout:section", "Transform",
 
 		],
 

--- a/python/GafferSceneUI/ParentConstraintUI.py
+++ b/python/GafferSceneUI/ParentConstraintUI.py
@@ -43,17 +43,30 @@ import GafferScene
 # Metadata
 ##########################################################################
 
-Gaffer.Metadata.registerNodeDescription(
+Gaffer.Metadata.registerNode(
 
-GafferScene.ParentConstraint,
+	GafferScene.ParentConstraint,
 
-"""Constrains objects from one part of the scene hierarchy as if they were children of another part of the hierarchy.""",
+	"description",
+	"""
+	Constrains objects from one part of the scene hierarchy as if they were
+	children of another part of the hierarchy.
+	""",
 
-"relativeTransform",
-{
-	"description" : "Transforms the constrained object relative to the target location.",
-	"nodeUI:section" : "Transform",
-}
+	plugs = {
+
+		"relativeTransform" : [
+
+			"description",
+			"""
+			Transforms the constrained object relative to the target location.
+			""",
+
+			"layout:section", "Transform",
+
+		],
+
+	}
 
 )
 

--- a/python/GafferSceneUI/SceneNodeUI.py
+++ b/python/GafferSceneUI/SceneNodeUI.py
@@ -72,8 +72,6 @@ Gaffer.Metadata.registerNode(
 			an empty scene.
 			""",
 
-			"nodeUI:section", "Node",
-
 		],
 
 	}

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -70,7 +70,7 @@ Gaffer.Metadata.registerNode(
 			method to load a shader.
 			""",
 
-			"nodeUI:section", "header",
+			"layout:section", "",
 
 		],
 
@@ -83,7 +83,7 @@ Gaffer.Metadata.registerNode(
 			method to load a shader.
 			""",
 
-			"nodeUI:section", "header",
+			"layout:section", "",
 
 		],
 
@@ -163,8 +163,6 @@ GafferUI.PlugValueWidget.registerCreator( GafferScene.Shader, "name", __ShaderNa
 GafferUI.PlugValueWidget.registerCreator( GafferScene.Shader, "parameters", GafferUI.LayoutPlugValueWidget )
 GafferUI.PlugValueWidget.registerCreator( GafferScene.Shader, "out", None )
 GafferUI.PlugValueWidget.registerCreator( GafferScene.Shader, "type", None )
-
-GafferUI.Metadata.registerPlugValue( GafferScene.Shader, "enabled", "nodeUI:section", "Node" )
 
 ##########################################################################
 # NodeGadgets and Nodules

--- a/python/GafferSceneUI/SphereUI.py
+++ b/python/GafferSceneUI/SphereUI.py
@@ -51,6 +51,8 @@ Gaffer.Metadata.registerNode(
 	Produces scenes containing a sphere.
 	""",
 
+	"layout:activator:typeIsMesh", lambda node : node["type"].getValue() == GafferScene.Sphere.Type.Mesh,
+
 	plugs = {
 
 		"type" : [
@@ -113,6 +115,8 @@ Gaffer.Metadata.registerNode(
 			Controls tesselation of the sphere when type is Mesh.
 			""",
 
+			"layout:activator", "typeIsMesh",
+
 		],
 
 	}
@@ -124,6 +128,3 @@ Gaffer.Metadata.registerNode(
 ##########################################################################
 
 GafferUI.PlugValueWidget.registerCreator( GafferScene.Sphere, "type", GafferUI.PresetsPlugValueWidget )
-
-## \todo: Disable divisions when type is Primitive. There is a similar mechanism in RenderManShaderUI, which
-## could be generalized on StandardNodeUI and used here.

--- a/python/GafferUI/ApplicationMenu.py
+++ b/python/GafferUI/ApplicationMenu.py
@@ -118,8 +118,11 @@ def preferences( menu ) :
 		saveButton = window._addButton( "Save" )
 		window.__saveButtonConnection = saveButton.clickedSignal().connect( __savePreferences )
 
-		nodeUI = GafferUI.NodeUI.create( application["preferences"] )
-		window._setWidget( nodeUI )
+		with GafferUI.ListContainer() as column :
+			GafferUI.NodeUI.create( application["preferences"] )
+			GafferUI.Spacer( IECore.V2i( 0 ), parenting = { "expand" : True } )
+
+		window._setWidget( column )
 
 		__preferencesWindows[application] = weakref.ref( window )
 

--- a/python/GafferUI/DispatcherUI.py
+++ b/python/GafferUI/DispatcherUI.py
@@ -78,7 +78,9 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			The frame range to be used when framedMode is "CustomRange".
-			"""
+			""",
+
+			"layout:activator", "customRange",
 
 		),
 
@@ -238,6 +240,7 @@ class DispatcherWindow( GafferUI.Window ) :
 			return window()
 		
 		window = DispatcherWindow()
+
 		applicationRoot._dispatcherWindow = weakref.ref( window )
 		
 		return window
@@ -363,16 +366,16 @@ class __FramesModePlugValueWidget( GafferUI.PlugValueWidget ) :
 		
 		label = selectionMenu.getSelection()[0]
 		value = self.__labelsAndValues[ selectionMenu.index( label ) ][1]
-		
+
+		Gaffer.Metadata.registerNodeValue(
+			self.getPlug().node(),
+			"layout:activator:customRange",
+			label == "CustomRange",
+		)
+
 		with Gaffer.BlockedConnection( self._plugConnections() ) :
 			self.getPlug().setValue( value )
-		
-		frameRangeWidget = self.__frameRangeWidget()
-		if frameRangeWidget :
-			## \todo: This should be managed by activator metadata once we've ported
-			# that functionality out of RenderManShaderUI and into PlugLayout.
-			frameRangeWidget.setReadOnly( label in [ "CurrentFrame", "FullRange", "PlaybackRange" ] )
-		
+
 		self.__updateFrameRangeConnection = None
 		
 		window = self.ancestor( GafferUI.ScriptWindow )

--- a/python/GafferUI/DispatcherUI.py
+++ b/python/GafferUI/DispatcherUI.py
@@ -452,7 +452,7 @@ class __FrameRangePlugValueWidget( GafferUI.StringPlugValueWidget ) :
 # Metadata, PlugValueWidgets and Nodules
 ##########################################################################
 
-Gaffer.Metadata.registerPlugValue( Gaffer.ExecutableNode, "requirement", "nodeUI:section", "header" )
+Gaffer.Metadata.registerPlugValue( Gaffer.ExecutableNode, "requirement", "layout:section", "" )
 Gaffer.Metadata.registerPlugDescription( Gaffer.ExecutableNode, "dispatcher.batchSize", "Maximum number of frames to batch together when dispatching execution tasks." )
 
 GafferUI.PlugValueWidget.registerCreator(

--- a/python/GafferUI/DispatcherUI.py
+++ b/python/GafferUI/DispatcherUI.py
@@ -169,7 +169,7 @@ class DispatcherWindow( GafferUI.Window ) :
 				self.__dispatchButton = GafferUI.Button( "Dispatch" )
 				self.__dispatchClickedConnection = self.__dispatchButton.clickedSignal().connect( Gaffer.WeakMethod( self.__dispatchClicked ) )
 
-		self.__update()
+		self.__update( resizeToFit = True )
 
 	def setVisible( self, visible ) :
 
@@ -245,11 +245,16 @@ class DispatcherWindow( GafferUI.Window ) :
 		
 		return window
 	
-	def __update( self ) :
+	def __update( self, resizeToFit = False ) :
 		
 		nodeUI = GafferUI.NodeUI.create( self.__currentDispatcher )
 		self.__frame.setChild( nodeUI )
 		self.__updateTitle()
+
+		if resizeToFit :
+			# Force the node UI to build so we fit to the right contents
+			nodeUI.plugValueWidget( self.__currentDispatcher["framesMode"], lazy = False )
+			self.resizeToFitChild()
 
 	def __updateTitle( self ) :
 

--- a/python/GafferUI/ExecutableNodeUI.py
+++ b/python/GafferUI/ExecutableNodeUI.py
@@ -80,7 +80,8 @@ Gaffer.Metadata.registerNode(
 			control their behaviour.
 			""",
 
-			"nodeUI:section", "Dispatcher"
+			"layout:section", "Dispatcher",
+			"layout:index", -3, # Just before the node section
 
 		),
 

--- a/python/GafferUI/ExpressionUI.py
+++ b/python/GafferUI/ExpressionUI.py
@@ -58,7 +58,9 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			The expression language to use.
-			"""
+			""",
+
+			"layout:section", "",
 
 		),
 
@@ -69,18 +71,15 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			The expression to evaluate."
-			"""
+			""",
+
+			"layout:section", "",
 
 		),
 
 	}
 
 )
-
-# NodeUI registration
-##########################################################################
-
-GafferUI.NodeUI.registerNodeUI( Gaffer.Expression, lambda node : GafferUI.StandardNodeUI( node, displayMode = GafferUI.StandardNodeUI.DisplayMode.Simplified ) )
 
 # PlugValueWidget popup menu for creating expressions
 ##########################################################################
@@ -190,6 +189,12 @@ GafferUI.PlugValueWidget.registerCreator(
 GafferUI.PlugValueWidget.registerCreator(
 	Gaffer.Expression,
 	"out",
+	None
+)
+
+GafferUI.PlugValueWidget.registerCreator(
+	Gaffer.Expression,
+	"user",
 	None
 )
 

--- a/python/GafferUI/NodeUI.py
+++ b/python/GafferUI/NodeUI.py
@@ -58,8 +58,18 @@ Gaffer.Metadata.registerNode(
 			Container for user-defined plugs. Nodes
 			should never make their own plugs here,
 			so users are free to do as they wish.
-			"""
-		)
+			""",
+
+			"layout:index", -1, # Last
+			"layout:section", "User",
+
+		),
+
+		"*" : (
+
+			"layout:section", lambda plug : "Settings" if isinstance( plug.parent(), Gaffer.Node ) else ""
+
+		),
 
 	}
 
@@ -132,5 +142,3 @@ class NodeUI( GafferUI.Widget ) :
 		cls.__nodeUIs[nodeTypeId] = nodeUICreator
 
 GafferUI.Nodule.registerNodule( Gaffer.Node, "user", lambda plug : None )
-
-Gaffer.Metadata.registerPlugValue( Gaffer.Node, "user", "nodeUI:section", "User" )

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -144,11 +144,13 @@ class PlugLayout( GafferUI.Widget ) :
 		else :
 			return w.plugValueWidget()
 
-	## Takes a list of plugs and returns a new list, sorted into
-	# the order in which they'll be laid out, based on "layout:index"
-	# Metadata entries.
+	## Returns the child plugs of the parent in the order in which they
+	# will be laid out, based on "layout:index" Metadata entries.
 	@staticmethod
-	def layoutOrder( plugs ) :
+	def layoutOrder( parent ) :
+
+		plugs = parent.children( Gaffer.Plug )
+		plugs = [ plug for plug in plugs if not plug.getName().startswith( "__" ) ]
 
 		plugsAndIndices = [ list( x ) for x in enumerate( plugs ) ]
 		for plugAndIndex in plugsAndIndices :
@@ -182,12 +184,8 @@ class PlugLayout( GafferUI.Widget ) :
 
 	def __updateLayout( self ) :
 
-		# get the plugs we want to represent
-		plugs = self.__parent.children( Gaffer.Plug )
-		plugs = [ plug for plug in plugs if not plug.getName().startswith( "__" ) ]
-
-		# reorder them based on metadata
-		plugs = self.layoutOrder( plugs )
+		# get the plugs to lay out
+		plugs = self.layoutOrder( self.__parent )
 
 		# ditch widgets we don't need any more
 		plugsSet = set( plugs )

--- a/python/GafferUI/PreferencesUI.py
+++ b/python/GafferUI/PreferencesUI.py
@@ -46,7 +46,20 @@ Gaffer.Metadata.registerNode(
 	A container for application preferences.
 	""",
 
-)
+	plugs = {
 
-# we don't want the user plug to be visible on the preferences node
-GafferUI.NodeUI.registerNodeUI( Gaffer.Preferences, lambda node : GafferUI.StandardNodeUI( node, displayMode = GafferUI.StandardNodeUI.DisplayMode.Simplified ) )
+		"*" : [
+
+			"layout:section", "",
+
+		],
+
+		"user" : [
+
+			"layout:widgetType", "None",
+
+		],
+
+	}
+
+)

--- a/python/GafferUI/ReferenceUI.py
+++ b/python/GafferUI/ReferenceUI.py
@@ -65,6 +65,16 @@ Gaffer.Metadata.registerNode(
 			The external script referenced by this node.
 			""",
 
+			"layout:section", "",
+
+		),
+
+		"user" : (
+
+			# Stopgap until we start parenting promoted plugs directly
+			# under the node as we want to (rather than as user plugs).
+			"layout:section", "Settings"
+
 		),
 
 	}
@@ -153,7 +163,6 @@ class __FileNamePlugValueWidget( GafferUI.PlugValueWidget ) :
 			self.getPlug().node().load( self.getPlug().getValue() )
 
 GafferUI.PlugValueWidget.registerCreator( Gaffer.Reference, "fileName", __FileNamePlugValueWidget )
-Gaffer.Metadata.registerPlugValue( Gaffer.Reference, "fileName", "nodeUI:section", "header" )
 
 GafferUI.PlugValueWidget.registerCreator( Gaffer.Reference, re.compile( "in[0-9]*" ), None )
 GafferUI.PlugValueWidget.registerCreator( Gaffer.Reference, re.compile( "out[0-9]*" ), None )
@@ -189,9 +198,3 @@ def _waitForFileName( initialFileName="", parentWindow=None ) :
 ##########################################################################
 
 GafferUI.Nodule.registerNodule( Gaffer.Reference, "fileName", lambda plug : None )
-
-##########################################################################
-# Metadata
-##########################################################################
-
-Gaffer.Metadata.registerPlugValue( Gaffer.Reference, "user", "nodeUI:section", "Settings" )

--- a/python/GafferUI/ScriptNodeUI.py
+++ b/python/GafferUI/ScriptNodeUI.py
@@ -112,7 +112,9 @@ Gaffer.Metadata.registerNode(
 			"""
 			Container for user-defined variables which can
 			be used in expressions anywhere in the script.
-			"""
+			""",
+
+			"layout:section", "Variables",
 
 		),
 
@@ -136,11 +138,4 @@ GafferUI.PlugValueWidget.registerCreator(
 	Gaffer.ScriptNode,
 	"variables",
 	lambda plug : GafferUI.CompoundDataPlugValueWidget( plug, collapsed=None ),
-)
-
-Gaffer.Metadata.registerPlugValue(
-	Gaffer.ScriptNode,
-	"variables",
-	"nodeUI:section",
-	"Variables",
 )

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -194,6 +194,17 @@ class UIEditor( GafferUI.NodeSetEditor ) :
 		menuDefinition.append( "/UIEditorDivider", { "divider" : True } )
 		menuDefinition.append( "/Set Color...", { "command" : functools.partial( cls.__setColor, node = node ) } )
 
+	@classmethod
+	def appendNodeEditorToolMenuDefinitions( cls, nodeEditor, node, menuDefinition ) :
+
+		menuDefinition.append(
+			"/Edit UI...",
+			{
+				"command" : functools.partial( GafferUI.UIEditor.acquire, node ),
+				"active" : nodeEditor.nodeUI().plugValueWidget( node["user"] ) is not None
+			}
+		)
+
 	def _updateFromSet( self ) :
 
 		GafferUI.NodeSetEditor._updateFromSet( self )

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -418,8 +418,7 @@ class _PlugListing( GafferUI.PathListingWidget ) :
 
 		# build an EntryPath to represent our child plugs.
 
-		plugs = self.__parent.children( Gaffer.Plug )
-		plugs = GafferUI.PlugLayout.layoutOrder( plugs )
+		plugs = GafferUI.PlugLayout.layoutOrder( self.__parent )
 
 		entries = [ self.Entry( plug, index ) for index, plug in enumerate( plugs ) ]
 		self.setPath( self.EntryPath( entries, "/" ) )

--- a/python/GafferUI/ViewUI.py
+++ b/python/GafferUI/ViewUI.py
@@ -39,28 +39,16 @@ import GafferUI
 
 Gaffer.Metadata.registerNode(
 
-	Gaffer.DependencyNode,
-
-	"description",
-	"""
-	Base class for nodes where input plugs have an
-	effect on output plugs.
-	""",
+	GafferUI.View,
 
 	plugs = {
 
-		"enabled" : (
+		"*" : [
 
-			"description",
-			"""
-			Turns the node on and off.
-			""",
+			"layout:section", "",
 
-			"layout:index", -2, # Last but one
-			"layout:section", "Node",
+		]
 
-		),
-
-	},
+	}
 
 )

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -246,6 +246,7 @@ from RampPlugValueWidget import RampPlugValueWidget
 from NodeFinderDialogue import NodeFinderDialogue
 from ConnectionPlugValueWidget import ConnectionPlugValueWidget
 import View3DToolbar
+import ViewUI
 from Playback import Playback
 from UIEditor import UIEditor
 import GraphBookmarksUI

--- a/python/GafferUITest/PlugLayoutTest.py
+++ b/python/GafferUITest/PlugLayoutTest.py
@@ -58,5 +58,26 @@ class PlugLayoutTest( GafferUITest.TestCase ) :
 		self.assertTrue( w2 is w )
 		self.assertTrue( w2.getPlug().isSame( n["b"] ) )
 
+	def testLayoutOrder( self ) :
+
+		n = Gaffer.Node()
+		n["user"]["a"] = Gaffer.IntPlug()
+		n["user"]["b"] = Gaffer.IntPlug()
+		n["user"]["c"] = Gaffer.IntPlug()
+
+		self.assertEqual(
+			GafferUI.PlugLayout.layoutOrder( n["user"] ),
+			[ n["user"]["a"], n["user"]["b"], n["user"]["c"] ],
+		)
+
+		Gaffer.Metadata.registerPlugValue( n["user"]["a"], "layout:index", 3 )
+		Gaffer.Metadata.registerPlugValue( n["user"]["b"], "layout:index", 2 )
+		Gaffer.Metadata.registerPlugValue( n["user"]["c"], "layout:index", 1 )
+
+		self.assertEqual(
+			GafferUI.PlugLayout.layoutOrder( n["user"] ),
+			[ n["user"]["c"], n["user"]["b"], n["user"]["a"] ],
+		)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/PlugLayoutTest.py
+++ b/python/GafferUITest/PlugLayoutTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import Gaffer
+import GafferTest
 import GafferUI
 import GafferUITest
 
@@ -78,6 +79,24 @@ class PlugLayoutTest( GafferUITest.TestCase ) :
 			GafferUI.PlugLayout.layoutOrder( n["user"] ),
 			[ n["user"]["c"], n["user"]["b"], n["user"]["a"] ],
 		)
+
+	class CustomWidget( GafferUI.Widget ) :
+
+		def __init__( self, node ) :
+
+			GafferUI.Widget.__init__( self, GafferUI.Label( "Custom Widget" ) )
+
+			self.node = node
+
+	def testCustomWidgets( self ) :
+
+		n = Gaffer.Node()
+		Gaffer.Metadata.registerNodeValue( n, "layout:customWidget:test:widgetType", "GafferUITest.PlugLayoutTest.CustomWidget" )
+
+		p = GafferUI.PlugLayout( n )
+
+		self.assertTrue( isinstance( p.customWidget( "test", lazy = False ), self.CustomWidget ) )
+		self.assertTrue( p.customWidget( "test" ).node.isSame( n ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/SectionedCompoundDataPlugValueWidgetTest.py
+++ b/python/GafferUITest/SectionedCompoundDataPlugValueWidgetTest.py
@@ -86,7 +86,7 @@ class SectionedCompoundDataPlugValueWidgetTest( GafferUITest.TestCase ) :
 		node = SectionedTestNode()
 		nodeUI = GafferUI.StandardNodeUI( node )
 
-		self.assertTrue( isinstance( nodeUI.plugValueWidget( node["p"] ), GafferUI.SectionedCompoundDataPlugValueWidget ) )
+		self.assertTrue( isinstance( nodeUI.plugValueWidget( node["p"], lazy = False ), GafferUI.SectionedCompoundDataPlugValueWidget ) )
 
 		for plugName in [
 			"p",

--- a/python/GafferUITest/StandardNodeUITest.py
+++ b/python/GafferUITest/StandardNodeUITest.py
@@ -49,7 +49,7 @@ class StandardNodeUITest( GafferUITest.TestCase ) :
 
 		u = GafferUI.StandardNodeUI( n )
 
-		self.assertTrue( isinstance( u.plugValueWidget( n["c"] ), GafferUI.PlugValueWidget ) )
+		self.assertTrue( isinstance( u.plugValueWidget( n["c"], lazy=False ), GafferUI.PlugValueWidget ) )
 		self.assertTrue( u.plugValueWidget( n["c"] ).getPlug().isSame( n["c"] ) )
 
 		self.assertEqual( u.plugValueWidget( n["c"]["i"] ), None )

--- a/startup/gui/nodeEditor.py
+++ b/startup/gui/nodeEditor.py
@@ -37,5 +37,6 @@
 def __toolMenu( nodeEditor, node, menuDefinition ) :
 
 	GafferUI.UIEditor.appendNodeEditorToolMenuDefinitions( nodeEditor, node, menuDefinition )
+	GafferUI.BoxUI.appendNodeEditorToolMenuDefinitions( nodeEditor, node, menuDefinition )
 
 __nodeEditorToolMenuConnection = GafferUI.NodeEditor.toolMenuSignal().connect( __toolMenu )

--- a/startup/gui/nodeEditor.py
+++ b/startup/gui/nodeEditor.py
@@ -1,0 +1,41 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+def __toolMenu( nodeEditor, node, menuDefinition ) :
+
+	GafferUI.UIEditor.appendNodeEditorToolMenuDefinitions( nodeEditor, node, menuDefinition )
+
+__nodeEditorToolMenuConnection = GafferUI.NodeEditor.toolMenuSignal().connect( __toolMenu )


### PR DESCRIPTION
This completes the NodeUI refactoring, so that StandardNodeUI uses PlugLayout to do all the layout work, making features such as activators etc available everywhere. It also adds the ability to insert custom widgets into PlugLayouts, which will be necessary for updating the internal IE UIs to deal with this refactoring. This is a backwards incompatible change - see 0cec503 for the most important changes.