### PR TITLE
GafferArnold documentation

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1043,6 +1043,8 @@ libraries = {
 
 	"GafferArnoldUI" : {},
 
+	"GafferArnoldUITest" : {},
+
 	"GafferRenderMan" : {
 		"envAppends" : {
 			"LIBS" : [ "Gaffer", "GafferScene", "IECoreRI$CORTEX_LIB_SUFFIX" ],

--- a/python/GafferArnoldUI/ArnoldAttributesUI.py
+++ b/python/GafferArnoldUI/ArnoldAttributesUI.py
@@ -75,6 +75,12 @@ Gaffer.Metadata.registerNode(
 
 	GafferArnold.ArnoldAttributes,
 
+	"description",
+	"""
+	Applies Arnold attributes to objects
+	in the scene.
+	""",
+
 	plugs = {
 
 		# Sections
@@ -90,12 +96,26 @@ Gaffer.Metadata.registerNode(
 
 		"attributes.cameraVisibility" : [
 
+			"description",
+			"""
+			Whether or not the object is visible to camera
+			rays. To hide an object completely, use the
+			visibility settings on the StandardAttributes
+			node instead.
+			""",
+
 			"layout:section", "Visibility",
 			"label", "Camera",
 
 		],
 
 		"attributes.shadowVisibility" : [
+
+			"description",
+			"""
+			Whether or not the object is visible to shadow
+			rays (whether or not it casts shadows).
+			""",
 
 			"layout:section", "Visibility",
 			"label", "Shadow",
@@ -104,12 +124,24 @@ Gaffer.Metadata.registerNode(
 
 		"attributes.reflectedVisibility" : [
 
+			"description",
+			"""
+			Whether or not the object is visible in
+			tight mirror reflections.
+			""",
+
 			"layout:section", "Visibility",
 			"label", "Reflections",
 
 		],
 
 		"attributes.refractedVisibility" : [
+
+			"description",
+			"""
+			Whether or not the object is visible in
+			refractions.
+			""",
 
 			"layout:section", "Visibility",
 			"label", "Refractions",
@@ -118,12 +150,24 @@ Gaffer.Metadata.registerNode(
 
 		"attributes.diffuseVisibility" : [
 
+			"description",
+			"""
+			Whether or not the object is visible to diffuse
+			rays - whether it casts bounce light or not.
+			""",
+
 			"layout:section", "Visibility",
 			"label", "Diffuse",
 
 		],
 
 		"attributes.glossyVisibility" : [
+
+			"description",
+			"""
+			Whether or not the object is visible in
+			soft specular reflections.
+			""",
 
 			"layout:section", "Visibility",
 			"label", "Glossy",
@@ -134,6 +178,20 @@ Gaffer.Metadata.registerNode(
 
 		"attributes.subdivIterations" : [
 
+			"description",
+			"""
+			The maximum number of subdivision
+			steps to apply when rendering subdivision
+			surface. To set an exact number of
+			subdivisions, set the pixel error to
+			0 so that the maximum becomes the
+			controlling factor.
+
+			Use the MeshType node to ensure that a
+			mesh is treated as a subdivision surface
+			in the first place.
+			""",
+
 			"layout:section", "Subdivision",
 			"label", "Iterations",
 
@@ -141,12 +199,42 @@ Gaffer.Metadata.registerNode(
 
 		"attributes.subdivPixelError" : [
 
+			"description",
+			"""
+			The maximum allowable deviation from the true
+			surface and the subdivided approximation. How
+			the error is measured is determined by the
+			metric below. Note also that the iterations
+			value above provides a hard limit on the maximum
+			number of subdivision steps, so if changing the
+			pixel error setting appears to have no effect,
+			you may need to raise the maximum.
+			""",
+
 			"layout:section", "Subdivision",
 			"label", "Pixel Error",
 
 		],
 
 		"attributes.subdivAdaptiveMetric" : [
+
+			"description",
+			"""
+			The metric used when performing adaptive
+			subdivision as specified by the pixel error.
+			The flatness metric ensures that the subdivided
+			surface doesn't deviate from the true surface
+			by more than the pixel error, and will tend to
+			increase detail in areas of high curvature. The
+			edge length metric ensures that the edge length
+			of a polygon is never longer than the pixel metric,
+			so will tend to subdivide evenly regardless of
+			curvature - this can be useful when applying a
+			displacement shader. The auto metric automatically
+			uses the flatness metric when no displacement
+			shader is applied, and the edge length metric when
+			a displacement shader is applied.
+			""",
 
 			"layout:section", "Subdivision",
 			"label", "Adaptive Metric",

--- a/python/GafferArnoldUI/ArnoldOptionsUI.py
+++ b/python/GafferArnoldUI/ArnoldOptionsUI.py
@@ -95,6 +95,13 @@ Gaffer.Metadata.registerNode(
 
 	GafferArnold.ArnoldOptions,
 
+	"description",
+	"""
+	Sets global scene options applicable to the Arnold
+	renderer. Use the StandardOptions node to set
+	global options applicable to all renderers.
+	""",
+
 	plugs = {
 
 		# Sections
@@ -112,12 +119,32 @@ Gaffer.Metadata.registerNode(
 
 		"options.aaSamples" : [
 
+			"description",
+			"""
+			Controls the number of rays per pixel
+			traced from the camera. The more samples,
+			the better the quality of antialiasing,
+			motion blur and depth of field. The actual
+			number of rays per pixel is the square of
+			the AA samples value - so a value of 3
+			means 9 rays are traced, 4 means 16 rays are
+			traced and so on.
+			""",
+
 			"layout:section", "Sampling",
 			"label", "AA Samples",
 
 		],
 
 		"options.giDiffuseSamples" : [
+
+			"description",
+			"""
+			Controls the number of rays traced when
+			computing indirect illumination ("bounce light").
+			The number of actual diffuse rays traced is the
+			square of this number.
+			""",
 
 			"layout:section", "Sampling",
 			"label", "Diffuse Samples",
@@ -126,12 +153,27 @@ Gaffer.Metadata.registerNode(
 
 		"options.giGlossySamples" : [
 
+			"description",
+			"""
+			Controls the number of rays traced when
+			computing glossy specular reflections.
+			The number of actual specular rays traced
+			is the square of this number.
+			""",
+
 			"layout:section", "Sampling",
 			"label", "Glossy Samples",
 
 		],
 
 		"options.giRefractionSamples" : [
+
+			"description",
+			"""
+			Controls the number of rays traced when
+			computing refractions. The number of actual
+			specular rays traced is the square of this number.
+			""",
 
 			"layout:section", "Sampling",
 			"label", "Refraction Samples",
@@ -142,11 +184,23 @@ Gaffer.Metadata.registerNode(
 
 		"options.ignoreTextures" : [
 
+			"description",
+			"""
+			Ignores all file textures, rendering as
+			if they were all white.
+			""",
+
 			"layout:section", "Features",
 
 		],
 
 		"options.ignoreShaders" : [
+
+			"description",
+			"""
+			Ignores all shaders, rendering as a
+			simple facing ratio shader instead.
+			""",
 
 			"layout:section", "Features",
 
@@ -154,11 +208,21 @@ Gaffer.Metadata.registerNode(
 
 		"options.ignoreAtmosphere" : [
 
+			"description",
+			"""
+			Ignores all atmosphere shaders.
+			""",
+
 			"layout:section", "Features",
 
 		],
 
 		"options.ignoreLights" : [
+
+			"description",
+			"""
+			Ignores all lights.
+			""",
 
 			"layout:section", "Features",
 
@@ -166,11 +230,22 @@ Gaffer.Metadata.registerNode(
 
 		"options.ignoreShadows" : [
 
+			"description",
+			"""
+			Skips all shadow calculations.
+			""",
+
 			"layout:section", "Features",
 
 		],
 
 		"options.ignoreSubdivision" : [
+
+			"description",
+			"""
+			Treats all subdivision surfaces
+			as simple polygon meshes instead.
+			""",
 
 			"layout:section", "Features",
 
@@ -178,11 +253,21 @@ Gaffer.Metadata.registerNode(
 
 		"options.ignoreDisplacement" : [
 
+			"description",
+			"""
+			Ignores all displacement shaders.
+			""",
+
 			"layout:section", "Features",
 
 		],
 
 		"options.ignoreBump" : [
+
+			"description",
+			"""
+			Ignores all bump mapping.
+			""",
 
 			"layout:section", "Features",
 
@@ -190,11 +275,24 @@ Gaffer.Metadata.registerNode(
 
 		"options.ignoreMotionBlur" : [
 
+			"description",
+			"""
+			Ignores motion blur. Note that the turn
+			off motion blur completely, it is more
+			efficient to use the motion blur controls
+			in the StandardOptions node.
+			""",
+
 			"layout:section", "Features",
 
 		],
 
 		"options.ignoreSSS" : [
+
+			"description",
+			"""
+			Disables all subsurface scattering.
+			""",
 
 			"layout:section", "Features",
 
@@ -204,6 +302,12 @@ Gaffer.Metadata.registerNode(
 
 		"options.textureSearchPath" : [
 
+			"description",
+			"""
+			The locations used to search for texture
+			files.
+			""",
+
 			"layout:section", "Search Paths",
 			"label", "Textures",
 
@@ -211,12 +315,23 @@ Gaffer.Metadata.registerNode(
 
 		"options.proceduralSearchPath" : [
 
+			"description",
+			"""
+			The locations used to search for procedural
+			DSOs.
+			""",
+
 			"layout:section", "Search Paths",
 			"label", "Procedurals",
 
 		],
 
 		"options.shaderSearchPath" : [
+
+			"description",
+			"""
+			The locations used to search for shader plugins.
+			""",
 
 			"layout:section", "Search Paths",
 			"label", "Shaders",
@@ -227,12 +342,24 @@ Gaffer.Metadata.registerNode(
 
 		"options.errorColorBadTexture" : [
 
+			"description",
+			"""
+			The colour to display if an attempt is
+			made to use a bad or non-existent texture.
+			""",
+
 			"layout:section", "Error Colors",
 			"label", "Bad Texture",
 
 		],
 
 		"options.errorColorBadMesh" : [
+
+			"description",
+			"""
+			The colour to display if bad geometry
+			is encountered.
+			""",
 
 			"layout:section", "Error Colors",
 			"label", "Bad Mesh",
@@ -241,12 +368,24 @@ Gaffer.Metadata.registerNode(
 
 		"options.errorColorBadPixel" : [
 
+			"description",
+			"""
+			The colour to display for a pixel where
+			a NaN is encountered.
+			""",
+
 			"layout:section", "Error Colors",
 			"label", "Bad Pixel",
 
 		],
 
 		"options.errorColorBadShader" : [
+
+			"description",
+			"""
+			The colour to display if a problem occurs
+			in a shader.
+			""",
 
 			"layout:section", "Error Colors",
 			"label", "Bad Shader",

--- a/python/GafferArnoldUI/ArnoldRenderUI.py
+++ b/python/GafferArnoldUI/ArnoldRenderUI.py
@@ -38,15 +38,78 @@ import Gaffer
 import GafferUI
 import GafferArnold
 
+Gaffer.Metadata.registerNode(
+
+	GafferArnold.ArnoldRender,
+
+	"description",
+	"""
+	Performs offline batch rendering using the
+	Arnold renderer. This is done in two phases -
+	first a .ass file is generated and then Arnold
+	is invoked to render it. Note though that the .ass
+	file is lightweight, and contains little more than
+	a procedural which will use Gaffer to generate the
+	scene at render time.
+	""",
+
+	plugs = {
+
+		"mode" : [
+
+			"description",
+			"""
+			When in the standard "Render" mode, an .ass
+			file is generated and then renderered in Arnold.
+			Alternatively, just the .ass file can be generated
+			and then another method can be used to post-process
+			it or launch the render - a SystemCommand node may
+			be useful for this. Finally, an expanded .ass file
+			may be generated - this will contain the entire
+			expanded scene rather than just a procedural, and can
+			be useful for debugging.
+			""",
+
+			"preset:Render", "render",
+			"preset:Generate .ass only", "generate",
+			"preset:Generate expanded .ass", "expand",
+
+		],
+
+		"fileName" : [
+
+			"description",
+			"""
+			The name of the .ass file to be generated.
+			""",
+
+		],
+
+		"verbosity" : [
+
+			"description",
+			"""
+			Controls the verbosity of the Arnold renderer output.
+			""",
+
+			"preset:0", 0,
+			"preset:1", 1,
+			"preset:2", 2,
+			"preset:3", 3,
+			"preset:4", 4,
+			"preset:5", 5,
+			"preset:6", 6,
+
+		],
+
+}
+
+)
+
 GafferUI.PlugValueWidget.registerCreator(
 	GafferArnold.ArnoldRender,
 	"mode",
-	GafferUI.EnumPlugValueWidget,
-	labelsAndValues = (
-		( "Render", "render" ),
-		( "Generate .ass only", "generate" ),
-		( "Generate expanded .ass", "expand" ),
-	),
+	GafferUI.PresetsPlugValueWidget,
 )
 
 GafferUI.PlugValueWidget.registerCreator(
@@ -64,16 +127,7 @@ GafferUI.PlugValueWidget.registerCreator(
 GafferUI.PlugValueWidget.registerCreator(
 	GafferArnold.ArnoldRender,
 	"verbosity",
-	GafferUI.EnumPlugValueWidget,
-	labelsAndValues = (
-		( "0", 0 ),
-		( "1", 1 ),
-		( "2", 2 ),
-		( "3", 3 ),
-		( "4", 4 ),
-		( "5", 5 ),
-		( "6", 6 ),
-	),
+	GafferUI.PresetsPlugValueWidget,
 )
 
 GafferUI.Nodule.registerNodule( GafferArnold.ArnoldRender, "mode", lambda plug : None )

--- a/python/GafferArnoldUITest/DocumentationTest.py
+++ b/python/GafferArnoldUITest/DocumentationTest.py
@@ -1,0 +1,54 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import GafferUITest
+import GafferScene
+import GafferSceneUI
+import GafferArnold
+import GafferArnoldUI
+
+class DocumentationTest( GafferUITest.TestCase ) :
+
+	def test( self ) :
+
+		self.maxDiff = None
+		self.assertNodesAreDocumented(
+			GafferArnold,
+			additionalTerminalPlugTypes = ( GafferScene.ScenePlug, )
+		)
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferArnoldUITest/__init__.py
+++ b/python/GafferArnoldUITest/__init__.py
@@ -1,0 +1,40 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+from DocumentationTest import DocumentationTest
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
This adds documentation via metadata for all GafferArnold nodes. Perhaps more usefully, it also translates shader/light metadata from Arnold .mtd files, making it available as Gaffer metadata descriptions, and therefore as tooltips in the UI.