### PR TITLE
Attribute Visualisation

### DIFF
--- a/include/GafferScene/AttributeVisualiser.h
+++ b/include/GafferScene/AttributeVisualiser.h
@@ -1,0 +1,115 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENE_ATTRIBUTEVISUALISER_H
+#define GAFFERSCENE_ATTRIBUTEVISUALISER_H
+
+#include "Gaffer/SplinePlug.h"
+#include "Gaffer/NumericPlug.h"
+
+#include "GafferScene/SceneElementProcessor.h"
+
+namespace Gaffer
+{
+
+IE_CORE_FORWARDDECLARE( StringPlug )
+
+} // namespace Gaffer
+
+namespace GafferScene
+{
+
+class AttributeVisualiser : public SceneElementProcessor
+{
+
+	public :
+
+		AttributeVisualiser( const std::string &name=defaultName<AttributeVisualiser>() );
+		virtual ~AttributeVisualiser();
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::AttributeVisualiser, AttributeVisualiserTypeId, SceneElementProcessor );
+
+		enum Mode
+		{
+			Color,
+			FalseColor,
+			Random,
+			ShaderNodeColor
+		};
+
+		Gaffer::StringPlug *attributeNamePlug();
+		const Gaffer::StringPlug *attributeNamePlug() const;
+
+		Gaffer::IntPlug *modePlug();
+		const Gaffer::IntPlug *modePlug() const;
+
+		Gaffer::FloatPlug *minPlug();
+		const Gaffer::FloatPlug *minPlug() const;
+
+		Gaffer::FloatPlug *maxPlug();
+		const Gaffer::FloatPlug *maxPlug() const;
+
+		Gaffer::SplinefColor3fPlug *rampPlug();
+		const Gaffer::SplinefColor3fPlug *rampPlug() const;
+
+		Gaffer::StringPlug *shaderTypePlug();
+		const Gaffer::StringPlug *shaderTypePlug() const;
+
+		Gaffer::StringPlug *shaderNamePlug();
+		const Gaffer::StringPlug *shaderNamePlug() const;
+
+		Gaffer::StringPlug *shaderParameterPlug();
+		const Gaffer::StringPlug *shaderParameterPlug() const;
+
+		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+
+	protected :
+
+		virtual bool processesAttributes() const;
+		virtual void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		virtual IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputAttributes ) const;
+
+	private :
+
+		static size_t g_firstPlugIndex;
+
+};
+
+IE_CORE_DECLAREPTR( AttributeVisualiser )
+
+} // namespace GafferScene
+
+#endif // GAFFERSCENE_ATTRIBUTEVISUALISER_H

--- a/include/GafferScene/Shader.h
+++ b/include/GafferScene/Shader.h
@@ -43,6 +43,7 @@
 
 #include "Gaffer/DependencyNode.h"
 #include "Gaffer/TypedPlug.h"
+#include "Gaffer/CompoundNumericPlug.h"
 
 #include "GafferScene/TypeIds.h"
 
@@ -162,6 +163,7 @@ class Shader : public Gaffer::DependencyNode
 	private :
 
 		void nameChanged();
+		void nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key );
 
 		// We want to use the node name when computing the shader, so that we
 		// can generate more useful shader handles. It's illegal to use anything
@@ -171,6 +173,11 @@ class Shader : public Gaffer::DependencyNode
 		// when computing.
 		Gaffer::StringPlug *nodeNamePlug();
 		const Gaffer::StringPlug *nodeNamePlug() const;
+		// As above, we want to put the node colour in the shader for diagnostic
+		// use in the scene UI, so we must transfer it on to this plug to use
+		// during compute.
+		Gaffer::Color3fPlug *nodeColorPlug();
+		const Gaffer::Color3fPlug *nodeColorPlug() const;
 
 		static size_t g_firstPlugIndex;
 

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -125,6 +125,7 @@ enum TypeId
 	ParametersTypeId = 110580,
 	SceneFilterPathFilterTypeId = 110581,
 	PathMatcherDataPlugTypeId = 110582,
+	AttributeVisualiserTypeId = 110583,
 
 	LastTypeId = 110650
 };

--- a/include/GafferSceneUI/SceneView.h
+++ b/include/GafferSceneUI/SceneView.h
@@ -47,6 +47,13 @@
 #include "GafferSceneUI/TypeIds.h"
 #include "GafferSceneUI/SceneGadget.h"
 
+namespace GafferScene
+{
+
+IE_CORE_FORWARDDECLARE( SceneProcessor )
+
+} // namespace GafferScene
+
 namespace GafferSceneUI
 {
 
@@ -92,6 +99,11 @@ class SceneView : public GafferUI::View3D
 		/// empty bound.
 		const Imath::Box2f &resolutionGate() const;
 
+		typedef boost::function<GafferScene::SceneProcessorPtr ()> ShadingModeCreator;
+
+		static void registerShadingMode( const std::string &name, ShadingModeCreator );
+		static void registeredShadingModes( std::vector<std::string> &names );
+
 	protected :
 
 		virtual void contextChanged( const IECore::InternedString &name );
@@ -123,6 +135,8 @@ class SceneView : public GafferUI::View3D
 		boost::shared_ptr<Grid> m_grid;
 		class Gnomon;
 		boost::shared_ptr<Gnomon> m_gnomon;
+		class ShadingMode;
+		boost::shared_ptr<ShadingMode> m_shadingMode;
 
 		static size_t g_firstPlugIndex;
 		static ViewDescription<SceneView> g_viewDescription;

--- a/include/GafferSceneUIBindings/SceneViewBinding.h
+++ b/include/GafferSceneUIBindings/SceneViewBinding.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENEUIBINDINGS_SCENEVIEWBINDING_H
+#define GAFFERSCENEUIBINDINGS_SCENEVIEWBINDING_H
+
+namespace GafferSceneUIBindings
+{
+
+void bindSceneView();
+
+} // namespace GafferSceneUIBindings
+
+#endif // GAFFERSCENEUIBINDINGS_SCENEVIEWBINDING_H

--- a/include/GafferUI/ObjectView.h
+++ b/include/GafferUI/ObjectView.h
@@ -46,6 +46,7 @@
 namespace GafferUI
 {
 
+/// \todo Remove this class, and use SceneView for everything.
 class ObjectView : public View3D
 {
 

--- a/include/GafferUI/View.h
+++ b/include/GafferUI/View.h
@@ -124,6 +124,10 @@ class View : public Gaffer::Node
 		/// internally to the view. A preprocessor must have an "in" plug
 		/// which will get it's input from inPlug(), and an "out" plug
 		/// which will be returned by preprocessedInPlug().
+		/// \todo Having just one preprocessor is pretty limiting. If we
+		/// allowed chains of preprocessors, and made the API public, then
+		/// we could make Views in a more modular manner, adding components
+		/// (each with their own preprocessors) to build up the view.
 		void setPreprocessor( Gaffer::NodePtr preprocessor );
 		/// Returns the node used for preprocessing, or 0 if no such
 		/// node has been specified (or if it is not of type T).

--- a/include/GafferUI/View3D.h
+++ b/include/GafferUI/View3D.h
@@ -42,6 +42,7 @@
 namespace GafferUI
 {
 
+/// \todo Remove this class, moving everything to SceneView.
 class View3D : public View
 {
 

--- a/python/GafferSceneTest/AttributeVisualiserTest.py
+++ b/python/GafferSceneTest/AttributeVisualiserTest.py
@@ -1,0 +1,161 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import IECore
+
+import Gaffer
+import GafferScene
+import GafferSceneTest
+
+class AttributeVisualiserTest( GafferSceneTest.SceneTestCase ) :
+
+	def testColorMode( self ) :
+
+		sphere = GafferScene.Sphere()
+		group = GafferScene.Group()
+		group["in"].setInput( sphere["out"] )
+		group["in1"].setInput( sphere["out"] )
+		group["in2"].setInput( sphere["out"] )
+
+		filter1 = GafferScene.PathFilter()
+		filter1["paths"].setValue( IECore.StringVectorData( [ "/group/sphere1" ] ) )
+
+		attributes1 = GafferScene.StandardAttributes()
+		attributes1["in"].setInput( group["out"] )
+		attributes1["attributes"]["transformBlurSegments"]["enabled"].setValue( 1 )
+		attributes1["attributes"]["transformBlurSegments"]["value"].setValue( 4 )
+		attributes1["filter"].setInput( filter1["out"] )
+
+		filter2 = GafferScene.PathFilter()
+		filter2["paths"].setValue( IECore.StringVectorData( [ "/group/sphere2" ] ) )
+
+		attributes2 = GafferScene.StandardAttributes()
+		attributes2["in"].setInput( attributes1["out"] )
+		attributes2["attributes"]["transformBlurSegments"]["enabled"].setValue( 1 )
+		attributes2["attributes"]["transformBlurSegments"]["value"].setValue( 2 )
+		attributes2["filter"].setInput( filter2["out"] )
+
+		self.assertTrue( "gl:surface" not in attributes2["out"].attributes( "/group/sphere" ) )
+		self.assertTrue( "gl:surface" not in attributes2["out"].attributes( "/group/sphere1" ) )
+		self.assertTrue( "gl:surface" not in attributes2["out"].attributes( "/group/sphere2" ) )
+
+		visualiser = GafferScene.AttributeVisualiser()
+		visualiser["in"].setInput( attributes2["out"] )
+		self.assertSceneValid( visualiser["out"] )
+
+		self.assertTrue( "gl:surface" not in visualiser["out"].attributes( "/group/sphere" ) )
+		self.assertTrue( "gl:surface" not in visualiser["out"].attributes( "/group/sphere1" ) )
+		self.assertTrue( "gl:surface" not in visualiser["out"].attributes( "/group/sphere2" ) )
+
+		visualiser["attributeName"].setValue( "gaffer:transformBlurSegments" )
+		visualiser["mode"].setValue( visualiser.Mode.Color )
+		visualiser["max"].setValue( 4 )
+
+		self.assertTrue( "gl:surface" not in visualiser["out"].attributes( "/group/sphere" ) )
+		self.assertTrue( "gl:surface" in visualiser["out"].attributes( "/group/sphere1" ) )
+		self.assertTrue( "gl:surface" in visualiser["out"].attributes( "/group/sphere2" ) )
+		self.assertEqual(
+			visualiser["out"].attributes( "/group/sphere1" )["gl:surface"].parameters["Cs"].value,
+			IECore.Color3f( 1 ),
+		)
+		self.assertEqual(
+			visualiser["out"].attributes( "/group/sphere2" )["gl:surface"].parameters["Cs"].value,
+			IECore.Color3f( .5 ),
+		)
+
+	def testShaderNodeColorMode( self ) :
+
+		sphere = GafferScene.Sphere()
+		group = GafferScene.Group()
+		group["in"].setInput( sphere["out"] )
+		group["in1"].setInput( sphere["out"] )
+		group["in2"].setInput( sphere["out"] )
+
+		shader1 = GafferSceneTest.TestShader()
+		shader1["name"].setValue( "test" )
+		shader1["type"].setValue( "gfr:surface" )
+
+		filter1 = GafferScene.PathFilter()
+		filter1["paths"].setValue( IECore.StringVectorData( [ "/group/sphere1" ] ) )
+
+		assignment1 = GafferScene.ShaderAssignment()
+		assignment1["in"].setInput( group["out"] )
+		assignment1["filter"].setInput( filter1["out"] )
+		assignment1["shader"].setInput( shader1["out"] )
+
+		shader2 = GafferSceneTest.TestShader()
+		shader2["name"].setValue( "test" )
+		shader2["type"].setValue( "gfr:surface" )
+		Gaffer.Metadata.registerNodeValue( shader2, "nodeGadget:color", IECore.Color3f( 1, 0, 0 ) )
+
+		filter2 = GafferScene.PathFilter()
+		filter2["paths"].setValue( IECore.StringVectorData( [ "/group/sphere2" ] ) )
+
+		assignment2 = GafferScene.ShaderAssignment()
+		assignment2["in"].setInput( assignment1["out"] )
+		assignment2["filter"].setInput( filter2["out"] )
+		assignment2["shader"].setInput( shader2["out"] )
+
+		self.assertTrue( "gl:surface" not in assignment2["out"].attributes( "/group/sphere" ) )
+		self.assertTrue( "gl:surface" not in assignment2["out"].attributes( "/group/sphere1" ) )
+		self.assertTrue( "gl:surface" not in assignment2["out"].attributes( "/group/sphere2" ) )
+
+		visualiser = GafferScene.AttributeVisualiser()
+		visualiser["in"].setInput( assignment2["out"] )
+		self.assertSceneValid( visualiser["out"] )
+
+		self.assertTrue( "gl:surface" not in visualiser["out"].attributes( "/group/sphere" ) )
+		self.assertTrue( "gl:surface" not in visualiser["out"].attributes( "/group/sphere1" ) )
+		self.assertTrue( "gl:surface" not in visualiser["out"].attributes( "/group/sphere2" ) )
+
+		visualiser["attributeName"].setValue( "gfr:surface" )
+		visualiser["mode"].setValue( visualiser.Mode.ShaderNodeColor )
+		self.assertSceneValid( visualiser["out"] )
+
+		self.assertTrue( "gl:surface" not in visualiser["out"].attributes( "/group/sphere" ) )
+		self.assertTrue( "gl:surface" in visualiser["out"].attributes( "/group/sphere1" ) )
+		self.assertTrue( "gl:surface" in visualiser["out"].attributes( "/group/sphere2" ) )
+		self.assertEqual(
+			visualiser["out"].attributes( "/group/sphere1" )["gl:surface"].parameters["Cs"].value,
+			IECore.Color3f( 0 ),
+		)
+		self.assertEqual(
+			visualiser["out"].attributes( "/group/sphere2" )["gl:surface"].parameters["Cs"].value,
+			IECore.Color3f( 1, 0, 0 ),
+		)
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneTest/ShaderTest.py
+++ b/python/GafferSceneTest/ShaderTest.py
@@ -96,6 +96,27 @@ class ShaderTest( unittest.TestCase ) :
 		self.assertEqual( s1[0].blindData()["gaffer:nodeName"], IECore.StringData( "node1" ) )
 		self.assertEqual( s2[0].blindData()["gaffer:nodeName"], IECore.StringData( "node2" ) )
 
+	def testNodeColorBlindData( self ) :
+
+		s = GafferSceneTest.TestShader()
+
+		h1 = s.stateHash()
+		s1 = s.state()
+
+		cs = GafferTest.CapturingSlot( s.plugDirtiedSignal() )
+
+		Gaffer.Metadata.registerNodeValue( s, "nodeGadget:color", IECore.Color3f( 1, 0, 0 ) )
+
+		self.assertTrue( s["out"] in [ x[0] for x in cs ] )
+
+		self.assertNotEqual( s.stateHash(), h1 )
+
+		s2 = s.state()
+		self.assertNotEqual( s2, s1 )
+
+		self.assertEqual( s1[0].blindData()["gaffer:nodeColor"], IECore.Color3fData( IECore.Color3f( 0 ) ) )
+		self.assertEqual( s2[0].blindData()["gaffer:nodeColor"], IECore.Color3fData( IECore.Color3f( 1, 0, 0 ) ) )
+
 	def testShaderTypesInState( self ) :
 
 		surface = GafferSceneTest.TestShader( "surface" )

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -107,6 +107,7 @@ from FilterSwitchTest import FilterSwitchTest
 from PointsTypeTest import PointsTypeTest
 from ParametersTest import ParametersTest
 from SceneFilterPathFilterTest import SceneFilterPathFilterTest
+from AttributeVisualiserTest  import AttributeVisualiserTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferSceneUI/AttributeVisualiserUI.py
+++ b/python/GafferSceneUI/AttributeVisualiserUI.py
@@ -1,0 +1,174 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferUI
+
+import GafferScene
+import GafferSceneUI
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.AttributeVisualiser,
+
+	"description",
+	"""
+	Visualises attribute values by applying a constant
+	shader to display them as a colour.
+	""",
+
+	"layout:activator:modeIsColorOrFalseColor", lambda node : node["mode"].getValue() in ( node.Mode.Color, node.Mode.FalseColor ),
+	"layout:activator:modeIsFalseColor", lambda node : node["mode"].getValue() == node.Mode.FalseColor,
+
+	plugs = {
+
+		"attributeName" : [
+
+			"description",
+			"""
+			The name of the attribute to be visualised. The value of the
+			attribute will be converted to a colour using the chosen mode
+			and then assigned using a constant shader.
+			""",
+
+		],
+
+		"mode" : [
+
+			"description",
+			"""
+			The method used to turn the attribute value into a colour for
+			visualisation.
+
+			- Color : This only works for attributes which already contain a colour
+			  or numeric value. The value is converted directly to a colour, using the
+			  min and max values to perform a remapping.
+			- FalseColor : This only works for numeric attributes. Values between min
+			  and max are used to look up a colour in the ramp below.
+			- Random : This works for any attribute type - a random colour is chosen
+			  for each unique attribute value.
+			- Shader Node Color : This only works when visualising a shader attribute. It
+			  uses the node colour for the shader node which is assigned.
+			""",
+
+			"preset:Color", GafferScene.AttributeVisualiser.Mode.Color,
+			"preset:FalseColor", GafferScene.AttributeVisualiser.Mode.FalseColor,
+			"preset:Random", GafferScene.AttributeVisualiser.Mode.Random,
+			"preset:Shader Node Color", GafferScene.AttributeVisualiser.Mode.ShaderNodeColor,
+
+		],
+
+		"min" : [
+
+			"description",
+			"""
+			Used in the Color and False Color modes to define the value which is mapped
+			to black or the left end of the spline respectively.
+			""",
+
+			"layout:activator", "modeIsColorOrFalseColor",
+
+		],
+
+		"max" : [
+
+			"description",
+			"""
+			Used in the Color and False Color modes to define the value which is mapped
+			to white or the right end of the spline respectively.
+			""",
+
+			"layout:activator", "modeIsColorOrFalseColor",
+
+		],
+
+		"ramp" : [
+
+			"description",
+			"""
+			Provides the colour mapping for the False Color mode. Values between min and
+			max are remapped using the colours from the ramp (left to right).
+			""",
+
+			"layout:activator", "modeIsFalseColor",
+
+		],
+
+		"shaderType" : [
+
+			"description",
+			"""
+			The type of shader used to perform the visualisation. The default value
+			is for an OpenGL shader which will be used in the viewport. It's possible
+			to perform a visualisation for other renderers by entering a different
+			shader type here.
+			""",
+
+			"layout:section", "Advanced",
+
+		],
+
+		"shaderName" : [
+
+			"description",
+			"""
+			The name of the shader used to perform the visualisation. The default value
+			is for an OpenGL shader which will be used in the viewport. It's possible
+			to perform a visualisation for other renderers by entering a different
+			shader name here.
+			""",
+
+			"layout:section", "Advanced",
+
+		],
+
+		"shaderParameter" : [
+
+			"description",
+			"""
+			The name of the shader parameter used to perform the visualisation. The default
+			value is for an OpenGL shader which will be used in the viewport.
+			""",
+
+			"layout:section", "Advanced",
+
+		],
+
+	}
+
+)
+
+GafferUI.PlugValueWidget.registerCreator( GafferScene.AttributeVisualiser, "mode", GafferUI.PresetsPlugValueWidget )

--- a/python/GafferSceneUI/CustomAttributesUI.py
+++ b/python/GafferSceneUI/CustomAttributesUI.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import functools
+
 import Gaffer
 import GafferUI
 
@@ -52,6 +54,86 @@ Gaffer.Metadata.registerNode(
 	needing to set a custom attribute not supported by the specialised nodes.
 	""",
 
+	plugs = {
+
+		"attributes.*.name" : [
+
+			"ui:scene:acceptsAttributeName", True,
+
+		],
+
+	}
+
 )
 
 GafferUI.PlugValueWidget.registerCreator( GafferScene.CustomAttributes, "attributes", GafferUI.CompoundDataPlugValueWidget, collapsed=None )
+
+##########################################################################
+# Right click menu for adding attribute names to plugs
+# This is driven by metadata so it can be used for plugs on other
+# nodes too.
+##########################################################################
+
+def __setValue( plug, value, *unused ) :
+
+	with Gaffer.UndoContext( plug.ancestor( Gaffer.ScriptNode ) ) :
+		plug.setValue( value )
+
+def __attributePopupMenu( menuDefinition, plugValueWidget ) :
+
+	plug = plugValueWidget.getPlug()
+	if plug is None :
+		return
+
+	acceptsAttributeName = Gaffer.Metadata.plugValue( plug, "ui:scene:acceptsAttributeName" )
+	acceptsAttributeNames = Gaffer.Metadata.plugValue( plug, "ui:scene:acceptsAttributeNames" )
+	if not acceptsAttributeName and not acceptsAttributeNames :
+		return
+
+	selectedPaths = plugValueWidget.getContext().get( "ui:scene:selectedPaths" )
+	if not selectedPaths :
+		return
+
+	node = plug.node()
+	if isinstance( node, GafferScene.Filter ) :
+		nodes = [ o.node() for o in node["out"].outputs() ]
+	else :
+		nodes = [ node ]
+
+	attributeNames = set()
+	with plugValueWidget.getContext() :
+
+		if acceptsAttributeNames :
+			currentNames = set( plug.getValue().split() )
+		else :
+			currentNames = set( [ plug.getValue() ] )
+
+		for node in nodes :
+			for path in selectedPaths :
+				attributes = node["in"].attributes( path, _copy=False )
+				attributeNames.update( attributes.keys() )
+
+	if not attributeNames :
+		return
+
+	menuDefinition.prepend( "/AttributesDivider", { "divider" : True } )
+
+	for attributeName in reversed( sorted( list( attributeNames ) ) ) :
+
+		newNames = set( currentNames ) if acceptsAttributeNames else set()
+
+		if attributeName not in currentNames :
+			newNames.add( attributeName )
+		else :
+			newNames.discard( attributeName )
+
+		menuDefinition.prepend(
+			"/Attributes/%s" % attributeName,
+			{
+				"command" : functools.partial( __setValue, plug, " ".join( sorted( newNames ) ) ),
+				"checkBox" : attributeName in currentNames,
+				"active" : plug.settable() and not plugValueWidget.getReadOnly(),
+			}
+		)
+
+__attributesPopupMenuConnection = GafferUI.PlugValueWidget.popupMenuSignal().connect( __attributePopupMenu )

--- a/python/GafferSceneUI/CustomAttributesUI.py
+++ b/python/GafferSceneUI/CustomAttributesUI.py
@@ -39,21 +39,18 @@ import GafferUI
 
 import GafferScene
 
-Gaffer.Metadata.registerNodeDescription(
+Gaffer.Metadata.registerNode(
 
-GafferScene.CustomAttributes,
+	GafferScene.CustomAttributes,
 
-"""Applies arbitrary user-defined attributes to locations in the scene. Note
-that for most common cases the StandardAttributes, OpenGLAttributes, RenderManAttributes,
-and ArnoldAttributes nodes should be used in preference - they provide predefined
-sets of attributes with customised user interfaces. The CustomAttributes node is of most use when
-needing to set a custom attribute not supported by the specialised nodes.
-""",
-
-"attributes",
-"""The attributes to be applied - arbitrary numbers of user defined attributes may be added
-as children of this plug via the user interface, or using the CompoundDataPlug API via
-python.""",
+	"description",
+	"""
+	Applies arbitrary user-defined attributes to locations in the scene. Note
+	that for most common cases the StandardAttributes, OpenGLAttributes, RenderManAttributes,
+	and ArnoldAttributes nodes should be used in preference - they provide predefined
+	sets of attributes with customised user interfaces. The CustomAttributes node is of most use when
+	needing to set a custom attribute not supported by the specialised nodes.
+	""",
 
 )
 

--- a/python/GafferSceneUI/DeleteAttributesUI.py
+++ b/python/GafferSceneUI/DeleteAttributesUI.py
@@ -63,6 +63,8 @@ Gaffer.Metadata.registerNode(
 			separated by spaces and can use Gaffer's standard wildcards.
 			""",
 
+			"ui:scene:acceptsAttributeNames", True,
+
 		],
 
 		"invertNames" : [

--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -466,7 +466,7 @@ class TextDiff( SideBySideDiff ) :
 			return self.__formatMatrices( values )
 		elif isinstance( values[0], ( IECore.Box3f, IECore.Box3d, IECore.Box3i, IECore.Box2f, IECore.Box2d, IECore.Box2i ) ) :
 			return self.__formatBoxes( values )
-		elif isinstance( values[0], IECore.ObjectVector ) :
+		elif isinstance( values[0], ( IECore.Shader, IECore.ObjectVector ) ) :
 			return self.__formatShaders( values )
 		elif isinstance( values[0], ( float, int ) ) :
 			return self.__formatNumbers( values )
@@ -546,14 +546,28 @@ class TextDiff( SideBySideDiff ) :
 
 		formattedValues = []
 		for value in values :
-			shaderName = value[-1].name
-			nodeName = value[-1].blindData().get( "gaffer:nodeName", None )
-			if nodeName is not None and nodeName.value != shaderName :
-				formattedValues.append( "%s (%s)" % ( nodeName.value, shaderName ) )
-			else :
-				formattedValues.append( shaderName )
 
-		return self.__formatStrings( formattedValues )
+			shader = value[-1] if isinstance( value, IECore.ObjectVector ) else value
+			shaderName = shader.name
+			nodeName = shader.blindData().get( "gaffer:nodeName", None )
+
+			formattedValue = "<table cellspacing=2><tr>"
+			if nodeName is not None :
+				nodeColor = shader.blindData().get( "gaffer:nodeColor", None )
+				if nodeColor is not None :
+					nodeColor = GafferUI.Widget._qtColor( nodeColor.value ).name()
+				else :
+					nodeColor = "#000000"
+				formattedValue += "<td bgcolor=%s>%s</td>" % ( nodeColor, cgi.escape( nodeName.value ) )
+				formattedValue += "<td>(" + cgi.escape( shaderName ) + ")</td>"
+			else :
+				formattedValue += "<td>" + cgi.escape( shaderName ) + "</td>"
+
+			formattedValue += "</tr></table>"
+
+			formattedValues.append( formattedValue )
+
+		return formattedValues
 
 	def __formatStrings( self, strings ) :
 

--- a/python/GafferSceneUI/SceneViewToolbar.py
+++ b/python/GafferSceneUI/SceneViewToolbar.py
@@ -35,12 +35,65 @@
 #
 ##########################################################################
 
+import functools
+
 import IECore
 
 import Gaffer
 import GafferUI
 import GafferScene
 import GafferSceneUI
+
+##########################################################################
+# Shading Mode
+##########################################################################
+
+class _ShadingModePlugValueWidget( GafferUI.PlugValueWidget ) :
+
+		def __init__( self, plug, **kw ) :
+
+			menuButton = GafferUI.MenuButton(
+				image = "shading.png",
+				menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) ),
+				hasFrame = False,
+			)
+
+			GafferUI.PlugValueWidget.__init__( self, menuButton, plug, **kw )
+
+		def hasLabel( self ) :
+
+			return True
+
+		def _updateFromPlug( self ) :
+
+			pass
+
+		def __menuDefinition( self ) :
+
+			m = IECore.MenuDefinition()
+
+			currentName = self.getPlug().getValue()
+			for name in [ "" ] + GafferSceneUI.SceneView.registeredShadingModes() :
+				m.append(
+					"/" + name if name else "Default",
+					{
+						"checkBox" : name == currentName,
+						"command" : functools.partial( Gaffer.WeakMethod( self.__setValue ), name if name != currentName else "" ),
+					}
+				)
+
+				if not name :
+					m.append( "/DefaultDivider", { "divider" : True } )
+
+			return m
+
+		def __setValue( self, value, *unused ) :
+
+			self.getPlug().setValue( value )
+
+Gaffer.Metadata.registerPlugValue( GafferSceneUI.SceneView, "shadingMode", "layout:index", 2 )
+Gaffer.Metadata.registerPlugValue( GafferSceneUI.SceneView, "shadingMode", "divider", True )
+GafferUI.PlugValueWidget.registerCreator( GafferSceneUI.SceneView, "shadingMode", _ShadingModePlugValueWidget )
 
 ##########################################################################
 # Expansion

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -117,6 +117,7 @@ import BranchCreatorUI
 import ConstraintUI
 import PlaneUI
 import CubeUI
+import AttributeVisualiserUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -14,10 +14,17 @@
    height="1000"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.1 r9760"
+   inkscape:version="0.47 r22583"
    sodipodi:docname="graphics.svg">
   <defs
      id="defs4">
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 500 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1000 : 500 : 1"
+       inkscape:persp3d-origin="500 : 333.33333 : 1"
+       id="perspective353" />
     <linearGradient
        id="linearGradient5496"
        osb:paint="solid">
@@ -51,16 +58,16 @@
      borderopacity="1"
      inkscape:pageopacity="1"
      inkscape:pageshadow="2"
-     inkscape:zoom="8"
-     inkscape:cx="187.48633"
-     inkscape:cy="769.29143"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="25.553042"
+     inkscape:cy="879.67896"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:window-width="1374"
-     inkscape:window-height="814"
-     inkscape:window-x="66"
-     inkscape:window-y="0"
+     showgrid="false"
+     inkscape:window-width="1281"
+     inkscape:window-height="1002"
+     inkscape:window-x="635"
+     inkscape:window-y="25"
      inkscape:window-maximized="0"
      inkscape:snap-global="true"
      inkscape:snap-nodes="false"
@@ -2277,103 +2284,103 @@
        transform="matrix(1.3868993,0,0,1.3868993,-57.129221,-44.589805)"
        style="fill:#779bbc;fill-opacity:1">
       <path
-	 style="fill:#557490;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.72103286;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-	 d="m 128.38062,163.8549 -5.53956,1.63762 0.465,6.7526 4.93304,3.01239 5.17566,-2.93152 0.46499,-6.81326 -5.49913,-1.65783 z"
-	 id="path3284-0"
-	 inkscape:connector-curvature="0" />
+         style="fill:#557490;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.72103286;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 128.38062,163.8549 -5.53956,1.63762 0.465,6.7526 4.93304,3.01239 5.17566,-2.93152 0.46499,-6.81326 -5.49913,-1.65783 z"
+         id="path3284-0"
+         inkscape:connector-curvature="0" />
       <path
-	 sodipodi:nodetypes="ccccc"
-	 id="path3286-5"
-	 d="m 123.30064,172.252 -0.45949,-6.76096 5.5138,2.19895 -0.11487,7.56506 -4.93944,-3.00305 z"
-	 style="fill:#779bbc;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.72103286;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-	 inkscape:connector-curvature="0" />
+         sodipodi:nodetypes="ccccc"
+         id="path3286-5"
+         d="m 123.30064,172.252 -0.45949,-6.76096 5.5138,2.19895 -0.11487,7.56506 -4.93944,-3.00305 z"
+         style="fill:#779bbc;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.72103286;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
       <path
-	 sodipodi:nodetypes="ccccc"
-	 id="path3288-6"
-	 d="m 122.84115,165.49104 5.5138,2.19895 5.53021,-2.18254 -5.5138,-1.65742 -5.53021,1.64101 z"
-	 style="fill:#89accd;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.72103286;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-	 inkscape:connector-curvature="0" />
+         sodipodi:nodetypes="ccccc"
+         id="path3288-6"
+         d="m 122.84115,165.49104 5.5138,2.19895 5.53021,-2.18254 -5.5138,-1.65742 -5.53021,1.64101 z"
+         style="fill:#89accd;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.72103286;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
     </g>
     <g
        id="forExport:gafferSceneUISelectionTool"
        inkscape:label="#g4092">
       <rect
-	 transform="translate(0,52.362183)"
-	 y="170"
-	 x="140"
-	 height="25"
-	 width="25"
-	 id="rect4090"
-	 style="opacity:0.35344830999999999;fill:none;fill-opacity:0.99607842999999996;fill-rule:evenodd;stroke:none" />
+         transform="translate(0,52.362183)"
+         y="170"
+         x="140"
+         height="25"
+         width="25"
+         id="rect4090"
+         style="opacity:0.35344830999999999;fill:none;fill-opacity:0.99607842999999996;fill-rule:evenodd;stroke:none" />
       <g
-	 inkscape:label="#g4601"
-	 id="f">
-	<path
-	   inkscape:connector-curvature="0"
-	   id="path4542"
-	   d="m 150.21875,223.51843 -8.5625,2.53125 0.71875,10.4375 7.625,4.65625 8,-4.53125 0.71875,-10.53125 -8.5,-2.5625 z"
-	   style="fill:#595959;fill-opacity:1;stroke:#779bbc;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-	<path
-	   inkscape:connector-curvature="0"
-	   style="fill:#787878;fill-opacity:1;stroke:#779bbc;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-	   d="m 142.36661,236.49782 -0.71022,-10.45042 8.52267,3.39892 -0.17756,11.69331 -7.63489,-4.64181 z"
-	   id="path4544"
-	   sodipodi:nodetypes="ccccc" />
-	<path
-	   inkscape:connector-curvature="0"
-	   style="fill:#787878;fill-opacity:1;stroke:#779bbc;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-	   d="m 141.65639,226.0474 8.52267,3.39892 8.54804,-3.37356 -8.52267,-2.56187 -8.54804,2.53651 z"
-	   id="path4546"
-	   sodipodi:nodetypes="ccccc" />
-	<path
-	   sodipodi:nodetypes="ccccccccc"
-	   inkscape:connector-curvature="0"
-	   id="path3692"
-	   d="m 154.55204,244.8176 0,-11.87736 8.12095,9.01041 -3.24836,0 1.62418,2.86695 0,2.04782 -2.03024,0 -2.03022,-4.09564 z"
-	   style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         inkscape:label="#g4601"
+         id="f">
+        <path
+           inkscape:connector-curvature="0"
+           id="path4542"
+           d="m 150.21875,223.51843 -8.5625,2.53125 0.71875,10.4375 7.625,4.65625 8,-4.53125 0.71875,-10.53125 -8.5,-2.5625 z"
+           style="fill:#595959;fill-opacity:1;stroke:#779bbc;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:#787878;fill-opacity:1;stroke:#779bbc;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           d="m 142.36661,236.49782 -0.71022,-10.45042 8.52267,3.39892 -0.17756,11.69331 -7.63489,-4.64181 z"
+           id="path4544"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:#787878;fill-opacity:1;stroke:#779bbc;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           d="m 141.65639,226.0474 8.52267,3.39892 8.54804,-3.37356 -8.52267,-2.56187 -8.54804,2.53651 z"
+           id="path4546"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           sodipodi:nodetypes="ccccccccc"
+           inkscape:connector-curvature="0"
+           id="path3692"
+           d="m 154.55204,244.8176 0,-11.87736 8.12095,9.01041 -3.24836,0 1.62418,2.86695 0,2.04782 -2.03024,0 -2.03022,-4.09564 z"
+           style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
       </g>
     </g>
     <g
        id="forExport:gafferSceneUICropWindowTool"
        inkscape:label="#g4102">
       <g
-	 transform="translate(6,1.0000156)"
-	 inkscape:label="#g4134"
-	 id="fs">
-	<path
-	   sodipodi:open="true"
-	   sodipodi:end="6.2821966"
-	   sodipodi:start="0"
-	   transform="matrix(2.0000002,0,0,1.9999998,-592.50008,154.86219)"
-	   d="m 390,40 c 0,2.761424 -2.23858,5 -5,5 -2.76142,0 -5,-2.238576 -5,-5 0,-2.761424 2.23858,-5 5,-5 2.75949,0 4.99727,2.235564 5,4.995056"
-	   sodipodi:ry="5"
-	   sodipodi:rx="5"
-	   sodipodi:cy="40"
-	   sodipodi:cx="385"
-	   id="path4107"
-	   style="opacity:0.35344831;fill:none;stroke:#3c3c3c;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-	   sodipodi:type="arc" />
-	<path
-	   style="fill:#a7a7a7;fill-opacity:0.99607843;stroke:#3c3c3c;stroke-width:0.99999994000000003;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-	   d="m 177.5,224.86218 c -5.52285,0 -10,4.47715 -10,10 0,0.69036 0.0855,1.34902 0.21875,2 l 11.78125,0 0,-11.8125 c -0.65057,-0.13304 -1.31013,-0.1875 -2,-0.1875 z"
-	   id="rect4109"
-	   inkscape:connector-curvature="0" />
-	<rect
-	   style="fill:none;stroke:#bb2b2b;stroke-width:0.99999994000000003;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-	   id="rect3319"
-	   width="14"
-	   height="14"
-	   x="165.5"
-	   y="222.86217" />
+         transform="translate(6,1.0000156)"
+         inkscape:label="#g4134"
+         id="fs">
+        <path
+           sodipodi:open="true"
+           sodipodi:end="6.2821966"
+           sodipodi:start="0"
+           transform="matrix(2.0000002,0,0,1.9999998,-592.50008,154.86219)"
+           d="m 390,40 c 0,2.761424 -2.23858,5 -5,5 -2.76142,0 -5,-2.238576 -5,-5 0,-2.761424 2.23858,-5 5,-5 2.75949,0 4.99727,2.235564 5,4.995056"
+           sodipodi:ry="5"
+           sodipodi:rx="5"
+           sodipodi:cy="40"
+           sodipodi:cx="385"
+           id="path4107"
+           style="opacity:0.35344831;fill:none;stroke:#3c3c3c;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           sodipodi:type="arc" />
+        <path
+           style="fill:#a7a7a7;fill-opacity:0.99607843;stroke:#3c3c3c;stroke-width:0.99999994000000003;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+           d="m 177.5,224.86218 c -5.52285,0 -10,4.47715 -10,10 0,0.69036 0.0855,1.34902 0.21875,2 l 11.78125,0 0,-11.8125 c -0.65057,-0.13304 -1.31013,-0.1875 -2,-0.1875 z"
+           id="rect4109"
+           inkscape:connector-curvature="0" />
+        <rect
+           style="fill:none;stroke:#bb2b2b;stroke-width:0.99999994000000003;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+           id="rect3319"
+           width="14"
+           height="14"
+           x="165.5"
+           y="222.86217" />
       </g>
       <rect
-	 transform="translate(0,52.362183)"
-	 y="170"
-	 x="170"
-	 height="25"
-	 width="25"
-	 id="rect4100"
-	 style="opacity:0.35344831;fill:none;stroke:none" />
+         transform="translate(0,52.362183)"
+         y="170"
+         x="170"
+         height="25"
+         width="25"
+         id="rect4100"
+         style="opacity:0.35344831;fill:none;stroke:none" />
     </g>
     <g
        style="font-size:20.02241135px;font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none;font-family:Apple LiSung;-inkscape-font-specification:Apple LiSung Light"
@@ -2388,34 +2395,34 @@
        inkscape:label="#g4105"
        transform="translate(20,0)">
       <rect
-	 y="316.36218"
-	 x="9"
-	 height="117"
-	 width="132"
-	 id="rect3334"
-	 style="fill:none;stroke:none" />
+         y="316.36218"
+         x="9"
+         height="117"
+         width="132"
+         id="rect3334"
+         style="fill:none;stroke:none" />
       <g
-	 transform="matrix(1.0229949,0,0,1.0572693,-4.4222807,-17.752239)"
-	 id="g3329">
-	<path
-	   style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#bb2b2b;fill-opacity:1;fill-rule:nonzero;stroke:#313131;stroke-width:4.80773449;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
-	   d="m 76.999384,319.35707 c -2.590589,0.20118 -5.044144,1.72235 -6.376289,3.9533 l -53.05072,87.73773 c -2.965943,4.93049 1.260118,12.38371 7.013918,12.37 l 106.101437,0 c 5.75384,0.0122 9.9799,-7.43951 7.01392,-12.37 L 84.65093,323.31037 c -1.55002,-2.59663 -4.636837,-4.19146 -7.651546,-3.9533 z"
-	   id="fsdffsd"
-	   inkscape:connector-curvature="0"
-	   sodipodi:nodetypes="cccccccc"
-	   inkscape:label="#path3123" />
-	<path
-	   d="M 77.28782,388.36112 76.634158,380.0269 C 76.416242,377.79358 75.871538,373.57201 75,367.36218 c -0.817091,-6.26427 -1.225631,-9.91388 -1.225623,-10.94889 -8e-6,-4.30323 1.361792,-6.45489 4.0854,-6.45493 2.723583,4e-5 4.085378,2.09722 4.085399,6.29153 -2.1e-5,0.43579 -0.02734,0.92606 -0.0817,1.47073 -0.05448,0.49031 -0.08174,0.89884 -0.0817,1.22563 l -3.431733,29.41487 -1.062206,0 z m -3.513422,10.29519 c -8e-6,-2.77806 1.389027,-4.16709 4.167105,-4.16709 2.778054,0 4.167089,1.33455 4.167106,4.00365 -1.7e-5,2.66915 -1.389052,4.0037 -4.167106,4.0037 -2.778078,0 -4.167113,-1.28007 -4.167105,-3.84026"
-	   style="font-size:20.02241135px;font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#f9f9f9;fill-opacity:1;stroke:#313131;stroke-width:5.76928091;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;font-family:Apple LiSung;-inkscape-font-specification:Apple LiSung Light"
-	   id="path3336"
-	   inkscape:connector-curvature="0"
-	   sodipodi:nodetypes="cccsccccccccscsc" />
-	<path
-	   sodipodi:nodetypes="cccsccccccccscsc"
-	   inkscape:connector-curvature="0"
-	   id="path3338"
-	   style="font-size:20.02241135px;font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#f9f9f9;fill-opacity:1;stroke:none;font-family:Apple LiSung;-inkscape-font-specification:Apple LiSung Light"
-	   d="M 77.28782,388.36112 76.634158,380.0269 C 76.416242,377.79358 75.871538,373.57201 75,367.36218 c -0.817091,-6.26427 -1.225631,-9.91388 -1.225623,-10.94889 -8e-6,-4.30323 1.361792,-6.45489 4.0854,-6.45493 2.723583,4e-5 4.085378,2.09722 4.085399,6.29153 -2.1e-5,0.43579 -0.02734,0.92606 -0.0817,1.47073 -0.05448,0.49031 -0.08174,0.89884 -0.0817,1.22563 l -3.431733,29.41487 -1.062206,0 z m -3.513422,10.29519 c -8e-6,-2.77806 1.389027,-4.16709 4.167105,-4.16709 2.778054,0 4.167089,1.33455 4.167106,4.00365 -1.7e-5,2.66915 -1.389052,4.0037 -4.167106,4.0037 -2.778078,0 -4.167113,-1.28007 -4.167105,-3.84026" />
+         transform="matrix(1.0229949,0,0,1.0572693,-4.4222807,-17.752239)"
+         id="g3329">
+        <path
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#bb2b2b;fill-opacity:1;fill-rule:nonzero;stroke:#313131;stroke-width:4.80773449;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+           d="m 76.999384,319.35707 c -2.590589,0.20118 -5.044144,1.72235 -6.376289,3.9533 l -53.05072,87.73773 c -2.965943,4.93049 1.260118,12.38371 7.013918,12.37 l 106.101437,0 c 5.75384,0.0122 9.9799,-7.43951 7.01392,-12.37 L 84.65093,323.31037 c -1.55002,-2.59663 -4.636837,-4.19146 -7.651546,-3.9533 z"
+           id="fsdffsd"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccc"
+           inkscape:label="#path3123" />
+        <path
+           d="M 77.28782,388.36112 76.634158,380.0269 C 76.416242,377.79358 75.871538,373.57201 75,367.36218 c -0.817091,-6.26427 -1.225631,-9.91388 -1.225623,-10.94889 -8e-6,-4.30323 1.361792,-6.45489 4.0854,-6.45493 2.723583,4e-5 4.085378,2.09722 4.085399,6.29153 -2.1e-5,0.43579 -0.02734,0.92606 -0.0817,1.47073 -0.05448,0.49031 -0.08174,0.89884 -0.0817,1.22563 l -3.431733,29.41487 -1.062206,0 z m -3.513422,10.29519 c -8e-6,-2.77806 1.389027,-4.16709 4.167105,-4.16709 2.778054,0 4.167089,1.33455 4.167106,4.00365 -1.7e-5,2.66915 -1.389052,4.0037 -4.167106,4.0037 -2.778078,0 -4.167113,-1.28007 -4.167105,-3.84026"
+           style="font-size:20.02241135px;font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#f9f9f9;fill-opacity:1;stroke:#313131;stroke-width:5.76928091;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;font-family:Apple LiSung;-inkscape-font-specification:Apple LiSung Light"
+           id="path3336"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccsccccccccscsc" />
+        <path
+           sodipodi:nodetypes="cccsccccccccscsc"
+           inkscape:connector-curvature="0"
+           id="path3338"
+           style="font-size:20.02241135px;font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#f9f9f9;fill-opacity:1;stroke:none;font-family:Apple LiSung;-inkscape-font-specification:Apple LiSung Light"
+           d="M 77.28782,388.36112 76.634158,380.0269 C 76.416242,377.79358 75.871538,373.57201 75,367.36218 c -0.817091,-6.26427 -1.225631,-9.91388 -1.225623,-10.94889 -8e-6,-4.30323 1.361792,-6.45489 4.0854,-6.45493 2.723583,4e-5 4.085378,2.09722 4.085399,6.29153 -2.1e-5,0.43579 -0.02734,0.92606 -0.0817,1.47073 -0.05448,0.49031 -0.08174,0.89884 -0.0817,1.22563 l -3.431733,29.41487 -1.062206,0 z m -3.513422,10.29519 c -8e-6,-2.77806 1.389027,-4.16709 4.167105,-4.16709 2.778054,0 4.167089,1.33455 4.167106,4.00365 -1.7e-5,2.66915 -1.389052,4.0037 -4.167106,4.0037 -2.778078,0 -4.167113,-1.28007 -4.167105,-3.84026" />
       </g>
     </g>
     <path
@@ -2477,5 +2484,24 @@
        d="m 302.30138,18.423424 -3.26391,-3.457531 -2.55071,4.0569 1.36235,-4.555392 -4.78873,-0.180534 4.62626,-1.097861 -2.23802,-4.2374343 3.26391,3.4575313 2.55071,-4.0569002 -1.36235,4.5553922 4.78873,0.180534 -4.62626,1.097861 2.23802,4.237434 z"
        transform="matrix(1.1039167,-0.49853331,0.49895085,1.1048412,55.474744,203.81434)"
        inkscape:label="#path3064" />
+    <path
+       sodipodi:open="true"
+       sodipodi:end="6.2821966"
+       sodipodi:start="0"
+       transform="matrix(0.25466537,0,0,0.25466542,-27.652509,127.91257)"
+       d="m 220.61732,174.54121 a 33.499184,33.499184 0 1 1 -2e-5,-0.0331"
+       sodipodi:ry="33.499184"
+       sodipodi:rx="33.499184"
+       sodipodi:cy="174.54121"
+       sodipodi:cx="187.11813"
+       id="forExport:shading"
+       style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:3.92672118;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       sodipodi:type="arc"
+       inkscape:label="#path3352" />
+    <path
+       style="fill:#aaaaaa;fill-opacity:1;stroke:none"
+       d="m 17.444981,168.57203 c -2.092886,1.37871 -2.641656,4.33859 -3.535981,3.1401 -0.894324,-1.19849 0.405111,-3.97228 1.59811,-4.87074 1.192994,-0.89844 4.11797,-1.89376 5.012295,-0.69526 0.894325,1.19848 -1.122142,0.79291 -3.074424,2.4259 z"
+       id="path3163"
+       sodipodi:nodetypes="csssc" />
   </g>
 </svg>

--- a/src/GafferScene/AttributeVisualiser.cpp
+++ b/src/GafferScene/AttributeVisualiser.cpp
@@ -1,0 +1,312 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "OpenEXR/ImathRandom.h"
+
+#include "IECore/Shader.h"
+
+#include "Gaffer/StringPlug.h"
+
+#include "GafferScene/AttributeVisualiser.h"
+
+using namespace Imath;
+using namespace IECore;
+using namespace Gaffer;
+using namespace GafferScene;
+
+IE_CORE_DEFINERUNTIMETYPED( AttributeVisualiser );
+
+size_t AttributeVisualiser::g_firstPlugIndex = 0;
+
+AttributeVisualiser::AttributeVisualiser( const std::string &name )
+	:	SceneElementProcessor( name, Filter::EveryMatch )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+
+	addChild( new StringPlug( "attributeName" ) );
+
+	addChild( new IntPlug( "mode", Plug::In, Color, Color, ShaderNodeColor ) );
+	addChild( new FloatPlug( "min", Plug::In, 0.0f ) );
+	addChild( new FloatPlug( "max", Plug::In, 1.0f ) );
+
+	SplinefColor3f rampDefault;
+	rampDefault.points.insert( SplinefColor3f::Point( 1.0f, Color3f( 0.0f, 1.0f, 0.0f ) ) );
+	rampDefault.points.insert( SplinefColor3f::Point( 1.0f, Color3f( 0.0f, 1.0f, 0.0f ) ) );
+	rampDefault.points.insert( SplinefColor3f::Point( 0.0f, Color3f( 1.0f, 0.0f, 0.0f ) ) );
+	rampDefault.points.insert( SplinefColor3f::Point( 0.0f, Color3f( 1.0f, 0.0f, 0.0f ) ) );
+	addChild( new SplinefColor3fPlug( "ramp", Plug::In, rampDefault ) );
+
+	addChild( new StringPlug( "shaderType", Plug::In, "gl:surface" ) );
+	addChild( new StringPlug( "shaderName", Plug::In, "Constant" ) );
+	addChild( new StringPlug( "shaderParameter", Plug::In, "Cs" ) );
+
+	// Fast pass-throughs for the things we don't alter.
+	outPlug()->objectPlug()->setInput( inPlug()->objectPlug() );
+	outPlug()->transformPlug()->setInput( inPlug()->transformPlug() );
+	outPlug()->boundPlug()->setInput( inPlug()->boundPlug() );
+}
+
+AttributeVisualiser::~AttributeVisualiser()
+{
+}
+
+Gaffer::StringPlug *AttributeVisualiser::attributeNamePlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex );
+}
+
+const Gaffer::StringPlug *AttributeVisualiser::attributeNamePlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex );
+}
+
+Gaffer::IntPlug *AttributeVisualiser::modePlug()
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 1 );
+}
+
+const Gaffer::IntPlug *AttributeVisualiser::modePlug() const
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 1 );
+}
+
+Gaffer::FloatPlug *AttributeVisualiser::minPlug()
+{
+	return getChild<FloatPlug>( g_firstPlugIndex + 2 );
+}
+
+const Gaffer::FloatPlug *AttributeVisualiser::minPlug() const
+{
+	return getChild<FloatPlug>( g_firstPlugIndex + 2 );
+}
+
+Gaffer::FloatPlug *AttributeVisualiser::maxPlug()
+{
+	return getChild<FloatPlug>( g_firstPlugIndex + 3 );
+}
+
+const Gaffer::FloatPlug *AttributeVisualiser::maxPlug() const
+{
+	return getChild<FloatPlug>( g_firstPlugIndex + 3 );
+}
+
+Gaffer::SplinefColor3fPlug *AttributeVisualiser::rampPlug()
+{
+	return getChild<SplinefColor3fPlug>( g_firstPlugIndex + 4 );
+}
+
+const Gaffer::SplinefColor3fPlug *AttributeVisualiser::rampPlug() const
+{
+	return getChild<SplinefColor3fPlug>( g_firstPlugIndex + 4 );
+}
+
+Gaffer::StringPlug *AttributeVisualiser::shaderTypePlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 5 );
+}
+
+const Gaffer::StringPlug *AttributeVisualiser::shaderTypePlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 5 );
+}
+
+Gaffer::StringPlug *AttributeVisualiser::shaderNamePlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 6 );
+}
+
+const Gaffer::StringPlug *AttributeVisualiser::shaderNamePlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 6 );
+}
+
+Gaffer::StringPlug *AttributeVisualiser::shaderParameterPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 7 );
+}
+
+const Gaffer::StringPlug *AttributeVisualiser::shaderParameterPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 7 );
+}
+
+void AttributeVisualiser::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
+{
+	SceneElementProcessor::affects( input, outputs );
+
+	if(
+		input == attributeNamePlug() ||
+		input == modePlug() ||
+		input == minPlug() ||
+		input == maxPlug() ||
+		input == shaderTypePlug() ||
+		input == shaderNamePlug() ||
+		input == shaderParameterPlug() ||
+		rampPlug()->isAncestorOf( input )
+	)
+	{
+		outputs.push_back( outPlug()->attributesPlug() );
+	}
+}
+
+bool AttributeVisualiser::processesAttributes() const
+{
+	return true;
+}
+
+void AttributeVisualiser::hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	attributeNamePlug()->hash( h );
+	modePlug()->hash( h );
+	minPlug()->hash( h );
+	maxPlug()->hash( h );
+	rampPlug()->hash( h );
+	shaderTypePlug()->hash( h );
+	shaderNamePlug()->hash( h );
+	shaderParameterPlug()->hash( h );
+}
+
+IECore::ConstCompoundObjectPtr AttributeVisualiser::computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputAttributes ) const
+{
+	const std::string attributeName = attributeNamePlug()->getValue();
+	if( !attributeName.size() )
+	{
+		return inputAttributes;
+	}
+
+	const std::string shaderType = shaderTypePlug()->getValue();
+	if( !shaderType.size() )
+	{
+		return inputAttributes;
+	}
+
+	const Object *attribute = inputAttributes->member<Object>( attributeName );
+	if( !attribute )
+	{
+		if( !inputAttributes->member<Object>( shaderType ) )
+		{
+			return inputAttributes;
+		}
+	}
+
+	CompoundObjectPtr result = new CompoundObject;
+	// Since we're not going to modify any existing members (only add a new one),
+	// and our result becomes const on returning it, we can directly reference
+	// the input members in our result without copying. Be careful not to modify
+	// them though!
+	result->members() = inputAttributes->members();
+
+	if( !attribute )
+	{
+		result->members().erase( shaderType );
+		return result;
+	}
+
+	// Compute our colour.
+
+	Color3f color( 0.0f );
+	const Mode mode = (Mode)modePlug()->getValue();
+	if( mode == Random )
+	{
+		Rand32 r( tbb_hasher( attribute->hash() ) );
+		for( int i = 0; i < 3; ++i )
+		{
+			color[i] = r.nextf();
+		}
+	}
+	else if( mode == ShaderNodeColor )
+	{
+		const Shader *shader = runTimeCast<const Shader>( attribute );
+		if( !shader )
+		{
+			if( const ObjectVector *objectVector = runTimeCast<const ObjectVector>( attribute ) )
+			{
+				if( objectVector->members().size() )
+				{
+					shader = runTimeCast<const Shader>( objectVector->members()[0].get() );
+				}
+			}
+		}
+		if( shader )
+		{
+			const Color3fData *colorData = shader->blindData()->member<const Color3fData>( "gaffer:nodeColor" );
+			if( colorData )
+			{
+				color = colorData->readable();
+			}
+		}
+	}
+	else
+	{
+		// Color or FalseColor
+		switch( attribute->typeId() )
+		{
+			case FloatDataTypeId :
+				color = Color3f( static_cast<const FloatData *>( attribute )->readable() );
+				break;
+			case DoubleDataTypeId :
+				color = Color3f( static_cast<const DoubleData *>( attribute )->readable() );
+				break;
+			case IntDataTypeId :
+				color = Color3f( static_cast<const IntData *>( attribute )->readable() );
+				break;
+			case BoolDataTypeId :
+				color = Color3f( static_cast<const BoolData *>( attribute )->readable() );
+				break;
+			default :
+				throw IECore::Exception( boost::str(
+					boost::format( "Unsupported attribute data type \"%s\"" ) % attribute->typeName()
+				) );
+		}
+		const Color3f min( minPlug()->getValue() );
+		const Color3f max( maxPlug()->getValue() );
+		color = ( color - min ) / ( max - min );
+		if( mode == FalseColor )
+		{
+			const SplinefColor3f ramp = rampPlug()->getValue();
+			color = ramp( color[0] );
+		}
+	}
+
+	// Apply the colour using a shader.
+
+	ShaderPtr shader = new Shader( shaderNamePlug()->getValue(), shaderType );
+	shader->parameters()[shaderParameterPlug()->getValue()] = new Color3fData( color );
+
+	result->members()[shaderType] = shader;
+
+	return result;
+}

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -43,12 +43,15 @@
 #include "Gaffer/NumericPlug.h"
 #include "Gaffer/CompoundDataPlug.h"
 #include "Gaffer/StringPlug.h"
+#include "Gaffer/Metadata.h"
 
 #include "GafferScene/Shader.h"
 
 using namespace Imath;
 using namespace GafferScene;
 using namespace Gaffer;
+
+static IECore::InternedString g_nodeColorMetadataName( "nodeGadget:color" );
 
 IE_CORE_DEFINERUNTIMETYPED( Shader );
 
@@ -63,8 +66,11 @@ Shader::Shader( const std::string &name )
 	addChild( new CompoundPlug( "parameters", Plug::In, Plug::Default & ~Plug::AcceptsInputs ) );
 	addChild( new BoolPlug( "enabled", Gaffer::Plug::In, true ) );
 	addChild( new StringPlug( "__nodeName", Gaffer::Plug::In, name, Plug::Default & ~(Plug::Serialisable | Plug::AcceptsInputs), Context::NoSubstitutions ) );
+	addChild( new Color3fPlug( "__nodeColor", Gaffer::Plug::In, Color3f( 0.0f ) ) );
+	nodeColorPlug()->setFlags( Plug::Serialisable | Plug::AcceptsInputs, false );
 
 	nameChangedSignal().connect( boost::bind( &Shader::nameChanged, this ) );
+	Metadata::nodeValueChangedSignal().connect( boost::bind( &Shader::nodeMetadataChanged, this, ::_1, ::_2 ) );
 }
 
 Shader::~Shader()
@@ -133,6 +139,16 @@ const Gaffer::StringPlug *Shader::nodeNamePlug() const
 	return getChild<StringPlug>( g_firstPlugIndex + 4 );
 }
 
+Gaffer::Color3fPlug *Shader::nodeColorPlug()
+{
+	return getChild<Color3fPlug>( g_firstPlugIndex + 5 );
+}
+
+const Gaffer::Color3fPlug *Shader::nodeColorPlug() const
+{
+	return getChild<Color3fPlug>( g_firstPlugIndex + 5 );
+}
+
 IECore::MurmurHash Shader::stateHash() const
 {
 	NetworkBuilder networkBuilder( this );
@@ -159,7 +175,8 @@ void Shader::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs
 		input == enabledPlug() ||
 		input == nodeNamePlug() ||
 		input == namePlug() ||
-		input == typePlug()
+		input == typePlug() ||
+		input->parent<Plug>() == nodeColorPlug()
 	)
 	{
 		const Plug *out = outPlug();
@@ -250,6 +267,15 @@ void Shader::nameChanged()
 	nodeNamePlug()->setValue( getName() );
 }
 
+void Shader::nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key )
+{
+	if( key == g_nodeColorMetadataName && this->isInstanceOf( nodeTypeId ) )
+	{
+		IECore::ConstColor3fDataPtr d = Metadata::nodeValue<const IECore::Color3fData>( this, g_nodeColorMetadataName );
+		nodeColorPlug()->setValue( d ? d->readable() : Color3f( 0.0f ) );
+	}
+}
+
 //////////////////////////////////////////////////////////////////////////
 // NetworkBuilder implementation
 //////////////////////////////////////////////////////////////////////////
@@ -297,6 +323,7 @@ IECore::MurmurHash Shader::NetworkBuilder::shaderHash( const Shader *shaderNode 
 	parameterHashWalk( shaderNode, shaderNode->parametersPlug(), shaderAndHash.hash );
 
 	shaderNode->nodeNamePlug()->hash( shaderAndHash.hash );
+	shaderNode->nodeColorPlug()->hash( shaderAndHash.hash );
 
 	return shaderAndHash.hash;
 }
@@ -335,6 +362,7 @@ IECore::Shader *Shader::NetworkBuilder::shader( const Shader *shaderNode )
 	parameterValueWalk( shaderNode, shaderNode->parametersPlug(), IECore::InternedString(), shaderAndHash.shader->parameters() );
 
 	shaderAndHash.shader->blindData()->writable()["gaffer:nodeName"] = new IECore::StringData( shaderNode->nodeNamePlug()->getValue() );
+	shaderAndHash.shader->blindData()->writable()["gaffer:nodeColor"] = new IECore::Color3fData( shaderNode->nodeColorPlug()->getValue() );
 
 	m_state->members().push_back( shaderAndHash.shader );
 	return shaderAndHash.shader.get();

--- a/src/GafferSceneBindings/AttributesBinding.cpp
+++ b/src/GafferSceneBindings/AttributesBinding.cpp
@@ -45,9 +45,11 @@
 #include "GafferScene/CustomAttributes.h"
 #include "GafferScene/AttributeProcessor.h"
 #include "GafferScene/DeleteAttributes.h"
+#include "GafferScene/AttributeVisualiser.h"
 
 #include "GafferSceneBindings/AttributesBinding.h"
 
+using namespace boost::python;
 using namespace GafferScene;
 
 void GafferSceneBindings::bindAttributes()
@@ -60,5 +62,14 @@ void GafferSceneBindings::bindAttributes()
 	GafferBindings::DependencyNodeClass<CustomAttributes>();
 	GafferBindings::DependencyNodeClass<AttributeProcessor>();
 	GafferBindings::DependencyNodeClass<DeleteAttributes>();
+
+	scope s = GafferBindings::DependencyNodeClass<AttributeVisualiser>();
+
+	enum_<AttributeVisualiser::Mode>( "Mode" )
+		.value( "Color", AttributeVisualiser::Color )
+		.value( "FalseColor", AttributeVisualiser::FalseColor )
+		.value( "Random", AttributeVisualiser::Random )
+		.value( "ShaderNodeColor", AttributeVisualiser::ShaderNodeColor )
+	;
 
 }

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -237,6 +237,7 @@ nodeMenu.append( "/Scene/Attributes/Shader Switch", GafferScene.ShaderSwitch, se
 nodeMenu.append( "/Scene/Attributes/Standard Attributes", GafferScene.StandardAttributes, searchText = "StandardAttributes" )
 nodeMenu.append( "/Scene/Attributes/Custom Attributes", GafferScene.CustomAttributes, searchText = "CustomAttributes" )
 nodeMenu.append( "/Scene/Attributes/Delete Attributes", GafferScene.DeleteAttributes, searchText = "DeleteAttributes" )
+nodeMenu.append( "/Scene/Attributes/Attribute Visualiser", GafferScene.AttributeVisualiser, searchText = "AttributeVisualiser" )
 nodeMenu.append( "/Scene/Filters/Set Filter", GafferScene.SetFilter, searchText = "SetFilter" )
 nodeMenu.append( "/Scene/Filters/Path Filter", GafferScene.PathFilter, searchText = "PathFilter" )
 nodeMenu.append( "/Scene/Filters/Union Filter", GafferScene.UnionFilter, searchText = "UnionFilter" )

--- a/startup/gui/viewer.py
+++ b/startup/gui/viewer.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import functools
+
 import IECore
 
 import Gaffer
@@ -58,3 +60,49 @@ def __sceneView( plug ) :
 	return view
 
 GafferUI.View.registerView( GafferScene.ScenePlug.staticTypeId(), __sceneView )
+
+# register shading modes
+
+def __createNode( nodeType, plugValues ) :
+
+	node = nodeType()
+	for name, value in plugValues.items() :
+		node.descendant( name ).setValue( value )
+
+	return node
+
+for name, nodeType, plugValues in [
+
+		( "Diagnostic/RenderMan/Shader Assignment", GafferScene.AttributeVisualiser, { "attributeName" : "ri:surface", "mode" : GafferScene.AttributeVisualiser.Mode.ShaderNodeColor } ),
+		( "Diagnostic/RenderMan/Camera Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "ri:visibility:camera" } ),
+		( "Diagnostic/RenderMan/Transmission Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "ri:visibility:transmission" } ),
+		( "Diagnostic/RenderMan/Diffuse Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "ri:visibility:diffuse" } ),
+		( "Diagnostic/RenderMan/Specular Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "ri:visibility:specular" } ),
+		( "Diagnostic/RenderMan/Photon Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "ri:visibility:photon" } ),
+		( "Diagnostic/RenderMan/Matte", GafferScene.AttributeVisualiser, { "attributeName" : "ri:visibility:matte" } ),
+
+		( "Diagnostic/Arnold/Shader Assignment", GafferScene.AttributeVisualiser, { "attributeName" : "ai:surface", "mode" : GafferScene.AttributeVisualiser.Mode.ShaderNodeColor } ),
+		( "Diagnostic/Arnold/Camera Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "ai:visibility:camera" } ),
+		( "Diagnostic/Arnold/Shadow Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "ai:visibility:shadow" } ),
+		( "Diagnostic/Arnold/Reflection Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "ai:visibility:reflected" } ),
+		( "Diagnostic/Arnold/Refraction Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "ai:visibility:refracted" } ),
+		( "Diagnostic/Arnold/Diffuse Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "ai:visibility:diffuse" } ),
+		( "Diagnostic/Arnold/Glossy Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "ai:visibility:glossy" } ),
+
+		( "Diagnostic/Appleseed/Shader Assignment", GafferScene.AttributeVisualiser, { "attributeName" : "osl:surface", "mode" : GafferScene.AttributeVisualiser.Mode.ShaderNodeColor } ),
+		( "Diagnostic/Appleseed/Camera Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "ai:visibility:camera" } ),
+		( "Diagnostic/Appleseed/Shadow Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "ai:visibility:shadow" } ),
+		( "Diagnostic/Appleseed/Diffuse Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "ai:visibility:diffuse" } ),
+		( "Diagnostic/Appleseed/Specular Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "ai:visibility:specular" } ),
+		( "Diagnostic/Appleseed/Glossy Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "ai:visibility:glossy" } ),
+
+	] :
+
+	GafferSceneUI.SceneView.registerShadingMode(
+		name,
+		functools.partial(
+			__createNode,
+			nodeType,
+			plugValues,
+		)
+	)


### PR DESCRIPTION
This adds an AttributeVisualiser node, which applies OpenGL shaders to visualise the current state of a particular attribute. It then adds configurable inbuilt visualisers to the viewer, so that you can quickly see the current state of things like camera visibility or shader assignments. Shader assignment visualisation is made more useful by including the node colour of the assigned shader in the datastream, so shaders can be recognised by colour - the SceneInspector has also been updated to display these colours.

![shaderassignments](https://cloud.githubusercontent.com/assets/1133871/7709369/7eecf3a8-fe54-11e4-8df4-e678b789f575.png)

The AttributeVisualiser node UI itself has been set up using features from https://github.com/ImageEngine/gaffer/pull/1309, but since it's all just metadata, it's mergeable without that one (the UI will just improve when it is merged).