### PR TITLE
AppleseedOptions : Fixed typo in plug names.

### DIFF
--- a/python/GafferAppleseedUI/AppleseedOptionsUI.py
+++ b/python/GafferAppleseedUI/AppleseedOptionsUI.py
@@ -78,8 +78,8 @@ def __drtSummary( plug ) :
 		info.append( "Max Bounces %d" % plug["drtMaxBounces"]["value"].getValue() )
 	if plug["drtRRStartBounce"]["enabled"].getValue() :
 		info.append( "Min Bounces %d" % plug["drtRRStartBounce"]["value"].getValue() )
-	if plug["drtLighingSamples"]["enabled"].getValue() :
-		info.append( "Lighting samples %d" % plug["drtLighingSamples"]["value"].getValue() )
+	if plug["drtLightingSamples"]["enabled"].getValue() :
+		info.append( "Lighting samples %d" % plug["drtLightingSamples"]["value"].getValue() )
 	if plug["drtIBLSamples"]["enabled"].getValue() :
 		info.append( "IBL samples %d" % plug["drtIBLSamples"]["value"].getValue() )
 
@@ -100,8 +100,8 @@ def __ptSummary( plug ) :
 		info.append( "Min Bounces %d" % plug["ptRRStartBounce"]["value"].getValue() )
 	if plug["ptNextEvent"]["enabled"].getValue() and plug["ptNextEvent"]["value"].getValue() :
 		info.append( "Next Event Estimation" )
-	if plug["ptLighingSamples"]["enabled"].getValue() :
-		info.append( "Lighting Samples %d" % plug["ptLighingSamples"]["value"].getValue() )
+	if plug["ptLightingSamples"]["enabled"].getValue() :
+		info.append( "Lighting Samples %d" % plug["ptLightingSamples"]["value"].getValue() )
 	if plug["ptIBLSamples"]["enabled"].getValue() :
 		info.append( "IBL Samples %d" % plug["ptIBLSamples"]["value"].getValue() )
 	if plug["ptMaxRayIntensity"]["enabled"].getValue() :
@@ -114,8 +114,8 @@ def __sppmSummary( plug ) :
 	info = []
 	if plug["photonType"]["enabled"].getValue() :
 		info.append( "Photon Type %s" % plug["photonType"]["value"].getValue() )
-	if plug["sppmDirectLighing"]["enabled"].getValue() and plug["sppmDirectLighing"]["value"].getValue() != 'off' :
-		info.append( "Direct Lighting %s" % plug["sppmDirectLighing"]["value"].getValue() )
+	if plug["sppmDirectLighting"]["enabled"].getValue() and plug["sppmDirectLighting"]["value"].getValue() != 'off' :
+		info.append( "Direct Lighting %s" % plug["sppmDirectLighting"]["value"].getValue() )
 	if plug["sppmIBL"]["enabled"].getValue() and plug["sppmIBL"]["value"].getValue() :
 		info.append( "IBL" )
 	if plug["sppmCaustics"]["enabled"].getValue() and plug["sppmCaustics"]["value"].getValue() :
@@ -284,7 +284,7 @@ Gaffer.Metadata.registerNode(
 
 		],
 
-		"options.drtLighingSamples" : [
+		"options.drtLightingSamples" : [
 
 			"layout:section", "Distribution Ray Tracer",
 			"label", "Direct Lighting Samples",
@@ -342,7 +342,7 @@ Gaffer.Metadata.registerNode(
 
 		],
 
-		"options.ptLighingSamples" : [
+		"options.ptLightingSamples" : [
 
 			"layout:section", "Unidirectional Path Tracer",
 			"label", "Direct Lighting Samples",
@@ -379,14 +379,14 @@ Gaffer.Metadata.registerNode(
 
 		],
 
-		"options.sppmDirectLighing" : [
+		"options.sppmDirectLighting" : [
 
 			"layout:section", "SPPM",
 			"label", "Direct Lighting",
 
 		],
 
-		"options.sppmDirectLighing.value" : [
+		"options.sppmDirectLighting.value" : [
 
 			"preset:Ray Tracing", "rt",
 			"preset:SPPM", "sppm",
@@ -547,7 +547,7 @@ GafferUI.PlugValueWidget.registerCreator(
 
 GafferUI.PlugValueWidget.registerCreator(
 	GafferAppleseed.AppleseedOptions,
-	"options.sppmDirectLighing.value",
+	"options.sppmDirectLighting.value",
 	GafferUI.PresetsPlugValueWidget,
 )
 

--- a/src/GafferAppleseed/AppleseedOptions.cpp
+++ b/src/GafferAppleseed/AppleseedOptions.cpp
@@ -63,7 +63,7 @@ AppleseedOptions::AppleseedOptions( const std::string &name )
 	options->addOptionalMember( "as:cfg:drt:enable_ibl", new IECore::BoolData( true ), "drtIBL", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "as:cfg:drt:max_path_lenght", new IECore::IntData( 16 ), "drtMaxBounces", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "as:cfg:drt:rr_min_path_length", new IECore::IntData( 3 ), "drtRRStartBounce", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "as:cfg:drt:dl_light_samples", new IECore::IntData( 1.0f ), "drtLighingSamples", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "as:cfg:drt:dl_light_samples", new IECore::IntData( 1.0f ), "drtLightingSamples", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "as:cfg:drt:ibl_env_samples", new IECore::FloatData( 1.0f ), "drtIBLSamples", Gaffer::Plug::Default, false );
 
 	// path tracing
@@ -73,13 +73,13 @@ AppleseedOptions::AppleseedOptions( const std::string &name )
 	options->addOptionalMember( "as:cfg:pt:max_path_lenght", new IECore::IntData( 16 ), "ptMaxBounces", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "as:cfg:pt:rr_min_path_length", new IECore::IntData( 3 ), "ptRRStartBounce", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "as:cfg:pt:next_event_estimation", new IECore::BoolData( true ), "ptNextEvent", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "as:cfg:pt:dl_light_samples", new IECore::IntData( 1.0f ), "ptLighingSamples", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "as:cfg:pt:dl_light_samples", new IECore::IntData( 1.0f ), "ptLightingSamples", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "as:cfg:pt:ibl_env_samples", new IECore::FloatData( 1.0f ), "ptIBLSamples", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "as:cfg:pt:max_ray_intensity", new IECore::FloatData( 1.0f ), "ptMaxRayIntensity", Gaffer::Plug::Default, false );
 
 	// sppm
 	options->addOptionalMember( "as:cfg:sppm:photon_type", new IECore::StringData( "mono" ), "photonType", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "as:cfg:sppm:dl_type", new IECore::StringData( "rt" ), "sppmDirectLighing", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "as:cfg:sppm:dl_type", new IECore::StringData( "rt" ), "sppmDirectLighting", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "as:cfg:sppm:enable_ibl", new IECore::BoolData( true ), "sppmIBL", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "as:cfg:sppm:enable_caustics", new IECore::BoolData( true ), "sppmCaustics", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "as:cfg:sppm:photon_tracing_max_path_length", new IECore::IntData( 16 ), "sppmPhotonMaxBounces", Gaffer::Plug::Default, false );


### PR DESCRIPTION
This is backwards-incompatible, but since it's early days for Gaffleseed I think this is probably OK. Does that sound right @est77?