### PR TITLE
Improved SceneInspector performance

### DIFF
--- a/Changes
+++ b/Changes
@@ -31,7 +31,24 @@ UI
   - Opened in tree mode rather than list mode
   - Removed unnecessary columns
   - Added filtering to display only cameras where appropriate
-- Improved error handling in the Viewer
+- CustomAttributes/DeleteAttributes
+  - Added right click menu for quickly adding attributes from the
+    currently selected object.
+- Viewer
+  - Added shading mode menu. This allows the default shading to be overridden
+    with another shader. Currently configured menu entries allow visualisation
+    of shader assignments and visibility for RenderMan, Arnold and Appleseed
+    (#1037).
+  - Improved error handling.
+- SceneInspector
+  - Improved shader display in attributes section. The node colour of the
+    assigned shader is used as the background colour.
+  - Improved performance (#1050).
+- Node UIs
+  - Added tool menu to NodeEditor
+  - Added support for metadata-driven activators.
+  - Added support for metadata-driven section summaries.
+  - Added support for metadata-driven custom widgets.
 
 Scene
 -----------------------------------------------------------------------
@@ -52,6 +69,16 @@ Scene
   - Prevented wildcards from being used in the Set node (#1307).
 - Made Parameters node compatible with subclasses of Light/Camera/ExternalProcedural,
   such as those used internally at IE.
+- Shader node now adds "gaffer:nodeColor" entry into the blind data
+  for the shader in the scene - this allows UI components to display
+  the colour as appropriate.
+- Added AttributeVisualiser node. This applies an OpenGL shader to
+  visualise the values of attributes and shader assignments.
+
+Appleseed
+-----------------------------------------------------------------------
+
+- Fixed typo in AppleseedOptions plug names.
 
 Documentation
 -----------------------------------------------------------------------
@@ -80,6 +107,12 @@ API
   - Added support for section summaries driven by Metadata.
   - Deprecated SectionedCompoundDataPlugValueWidget.
   - Deprecated SectionedCompoundPlugValueWidget.
+  - Improved layoutOrder() API. It now returns the ordered plugs
+    for a specific parent, rather than accepting a possibly unrelated
+    list of plugs.
+  - Added support for arbitrary custom widgets to be inserted into
+    layouts.
+  - Reimplemented StandardNodeUI using PlugLayout.
 - Fixed ExecutableNode::requirements() binding.
 - Added support for fixing the height (measured in number of lines)
   of the MultiLineTextWidget.
@@ -108,6 +141,8 @@ API
 - Implemented PathMatcherData::hash().
 - Added GafferScene::PathMatcherDataPlug.
 - Reimplemented SceneNode sets API.
+- Added GafferUI.LazyMethod for deferring widget method calls until
+  visible/idle.
 
  Incompatibilities
 -----------------------------------------------------------------------
@@ -123,6 +158,15 @@ API
 - GafferScene
   - Reimplemented sets API.
   - Removed SceneReader "sets" plug.
+- GafferAppleseed
+  - Fixed typo in AppleseedOptions plug names.
+- PlugLayout
+  - Changed layoutOrder() signature.
+- StandardNodeUI
+  - Removed DisplayMode enum.
+  - Removed displayMode constructor argument.
+  - Removed _header() method.
+  - Removed _tabbedContainer() method.
 
 Build
 -----------------------------------------------------------------------

--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -875,6 +875,7 @@ class DiffColumn( GafferUI.Widget ) :
 
 			self.__rowContainer = GafferUI.ListContainer()
 
+	@GafferUI.LazyMethod()
 	def update( self, targets ) :
 
 		inspectors = {}

--- a/python/GafferUI/LazyMethod.py
+++ b/python/GafferUI/LazyMethod.py
@@ -1,0 +1,166 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import weakref
+import functools
+import collections
+
+import IECore
+
+import GafferUI
+
+class LazyMethod( object ) :
+
+	__PendingCall = collections.namedtuple( "__PendingCall", [ "args", "kw" ] )
+
+	def __init__( self, deferUntilVisible = True, deferUntilIdle = True, deferUntilPlaybackStops = False, replacePendingCalls = True ) :
+
+		self.__deferUntilVisible = deferUntilVisible
+		self.__deferUntilIdle = deferUntilIdle
+		self.__deferUntilPlaybackStops = deferUntilPlaybackStops
+		self.__replacePendingCalls = replacePendingCalls
+
+	# Called to return the decorated method.
+	def __call__( self, method ) :
+
+		@functools.wraps( method )
+		def wrapper( widget, *args, **kw ) :
+
+			assert( isinstance( widget, GafferUI.Widget ) )
+
+			# Update the list of pending method calls for this widget.
+
+			try :
+				pendingCalls = getattr( widget, method.__name__ + "__PendingCalls" )
+			except AttributeError :
+				pendingCalls = []
+				setattr( widget, method.__name__ + "__PendingCalls", pendingCalls )
+
+			hadPendingCalls = bool( pendingCalls )
+			if self.__replacePendingCalls :
+				del pendingCalls[:]
+
+			pendingCalls.append( self.__PendingCall( args, kw ) )
+
+			# Arrange to make the pending calls at an appropriate time.
+
+			if hadPendingCalls :
+
+				# The previous call will have set up the machinery to
+				# make the pending call, so we don't need to.
+				return
+
+			elif self.__deferUntilVisible and not widget.visible() :
+				
+				setattr(
+					widget,
+					method.__name__ + "__VisibilityChangedConnection",
+					widget.visibilityChangedSignal().connect(
+						functools.partial( self.__visibilityChanged, method = method )
+					)
+				)
+			
+			elif self.__deferUntilPlaybackStops and self.__playback( widget ).getState() != GafferUI.Playback.State.Stopped :
+
+				setattr(
+					widget,
+					method.__name__ + "__PlaybackStateChangedConnection",
+					self.__playback( widget ).stateChangedSignal().connect(
+						functools.partial( self.__playbackStateChanged, widgetWeakref = weakref.ref( widget ), method = method )
+					)
+				)
+
+			elif self.__deferUntilIdle :
+
+				GafferUI.EventLoop.addIdleCallback( functools.partial( self.__idle, weakref.ref( widget ), method ) )
+
+			else :
+
+				self.__doPendingCalls( widget, method )
+
+		return wrapper
+	
+	@classmethod
+	def __playback( cls, widget ) :
+
+		context = None
+		with IECore.IgnoredExceptions( AttributeError ) :
+			context = widget.getContext()
+		if context is None :
+			with IECore.IgnoredExceptions( AttributeError ) :
+				context = widget.context()
+
+		return GafferUI.Playback.acquire( context )
+
+	@classmethod
+	def __visibilityChanged( cls, widget, method ) :
+
+		if not widget.visible() :
+			return
+
+		cls.__doPendingCalls( widget, method )
+
+	@classmethod
+	def __playbackStateChanged( cls, playback, widgetWeakref, method ) :
+
+		if playback.getState() != playback.State.Stopped :
+			return
+
+		widget = widgetWeakref()
+		if widget is None :
+			return
+
+		cls.__doPendingCalls( widget, method )	
+
+	@classmethod
+	def __idle( cls, widgetWeakref, method ) :
+
+		widget = widgetWeakref()
+		if widget is None :
+			return
+
+		cls.__doPendingCalls( widget, method )
+
+		return False # Remove idle callback
+
+	@classmethod
+	def __doPendingCalls( cls, widget, method ) :
+
+		pendingCalls = getattr( widget, method.__name__ + "__PendingCalls" )
+		for pendingCall in pendingCalls :
+			method( widget, *pendingCall.args, **pendingCall.kw )
+
+		del pendingCalls[:]

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -170,6 +170,7 @@ from Divider import Divider
 import _Pointer
 from SplineWidget import SplineWidget
 from Bookmarks import Bookmarks
+from LazyMethod import LazyMethod
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferUITest/LazyMethodTest.py
+++ b/python/GafferUITest/LazyMethodTest.py
@@ -1,0 +1,165 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferTest
+import GafferUI
+import GafferUITest
+
+class LazyMethodTest( GafferUITest.TestCase ) :
+
+	class LazyWidget( GafferUI.TextWidget ) :
+
+		def __init__( self, **kw ) :
+
+			GafferUI.TextWidget.__init__( self, **kw )
+
+			self.__context = Gaffer.Context()
+
+		## To use deferUntilPlaybackStops, the widget must
+		# have a context() or getContext() method which
+		# provides the context in which it works.
+		def context( self ) :
+
+			return self.__context
+
+		@GafferUI.LazyMethod()
+		def setTextLazily( self, text ) :
+
+			self.setText( text )
+
+		@GafferUI.LazyMethod( replacePendingCalls = False )
+		def setTextLazilyNoReplace( self, text ) :
+
+			self.setText( text )
+
+		@GafferUI.LazyMethod( deferUntilPlaybackStops = True )
+		def setTextLazilyDeferredUntilStop( self, text ) :
+
+			self.setText( text )	
+
+	def test( self ) :
+
+		with GafferUI.Window() as window :
+			w = self.LazyWidget()
+		
+		cs = GafferTest.CapturingSlot( w.textChangedSignal() )
+
+		w.setTextLazily( "t" )
+		self.assertEqual( len( cs ), 0 )
+		self.assertEqual( w.getText(), "" )
+
+		window.setVisible( True )
+		
+		self.assertEqual( len( cs ), 1 )
+		self.assertEqual( w.getText(), "t" )
+
+		w.setTextLazily( "u" )
+
+		self.assertEqual( len( cs ), 1 )
+		self.assertEqual( w.getText(), "t" )
+
+		self.waitForIdle( 100 )
+
+		self.assertEqual( len( cs ), 2 )
+		self.assertEqual( w.getText(), "u" )
+
+		w.setTextLazily( "v" )
+		w.setTextLazily( "w" )
+
+		self.assertEqual( len( cs ), 2 )
+		self.assertEqual( w.getText(), "u" )
+
+		self.waitForIdle( 100 )
+
+		self.assertEqual( len( cs ), 3 )
+		self.assertEqual( w.getText(), "w" )
+
+	def testReplacePendingCalls( self ) :
+
+		with GafferUI.Window() as window :
+			w = self.LazyWidget()
+		
+		cs = GafferTest.CapturingSlot( w.textChangedSignal() )
+
+		w.setTextLazilyNoReplace( "s" )
+		w.setTextLazilyNoReplace( "t" )
+		self.assertEqual( len( cs ), 0 )
+		self.assertEqual( w.getText(), "" )
+
+		window.setVisible( True )
+		
+		self.assertEqual( len( cs ), 2 )
+		self.assertEqual( w.getText(), "t" )
+
+	def testDeferUntilPlaybackStops( self ) :
+
+		with GafferUI.Window() as window :
+			w = self.LazyWidget()
+		
+		cs = GafferTest.CapturingSlot( w.textChangedSignal() )
+
+		w.setTextLazilyDeferredUntilStop( "t" )
+		self.assertEqual( len( cs ), 0 )
+		self.assertEqual( w.getText(), "" )
+
+		window.setVisible( True )
+		
+		self.assertEqual( len( cs ), 1 )
+		self.assertEqual( w.getText(), "t" )
+
+		p = GafferUI.Playback.acquire( w.context() )
+
+		p.setState( p.State.PlayingForwards )
+
+		w.setTextLazilyDeferredUntilStop( "s" )
+
+		self.assertEqual( len( cs ), 1 )
+		self.assertEqual( w.getText(), "t" )
+
+		self.waitForIdle( 100 )
+
+		self.assertEqual( len( cs ), 1 )
+		self.assertEqual( w.getText(), "t" )
+
+		p.setState( p.State.Stopped )
+
+		self.assertEqual( len( cs ), 2 )
+		self.assertEqual( w.getText(), "s" )
+
+if __name__ == "__main__":
+	unittest.main()
+

--- a/python/GafferUITest/PlugLayoutTest.py
+++ b/python/GafferUITest/PlugLayoutTest.py
@@ -98,5 +98,19 @@ class PlugLayoutTest( GafferUITest.TestCase ) :
 		self.assertTrue( isinstance( p.customWidget( "test", lazy = False ), self.CustomWidget ) )
 		self.assertTrue( p.customWidget( "test" ).node.isSame( n ) )
 
+	def testLazyBuilding( self ) :
+
+		n = Gaffer.Node()
+		n["a"] = Gaffer.IntPlug()
+
+		with GafferUI.Window() as window :
+			plugLayout = GafferUI.PlugLayout( n )
+
+		self.assertTrue( plugLayout.plugValueWidget( n["a"], lazy = True ) is None )
+
+		window.setVisible( True )
+
+		self.assertTrue( plugLayout.plugValueWidget( n["a"], lazy = True ) is not None )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/__init__.py
+++ b/python/GafferUITest/__init__.py
@@ -102,6 +102,7 @@ from ViewportGadgetTest import ViewportGadgetTest
 from VectorDataWidgetTest import VectorDataWidgetTest
 from DotNodeGadgetTest import DotNodeGadgetTest
 from DocumentationTest import DocumentationTest
+from LazyMethodTest import LazyMethodTest
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This improves SceneInspector performance by only updating the sections which aren't collapsed, deferring the update of collapses sections until they become visible. It does this using a new LazyMethod decorator which makes it very easy to defer update in this manner.

I've marked this as fixing #1050, since I think we've made enough progress here and in previous work to close such a generic ticket. We can open more specific ones later if necessary...