### PR TITLE
GafferAppleseed: attributes and options changes.

### DIFF
--- a/python/GafferAppleseedTest/AppleseedRenderTest.py
+++ b/python/GafferAppleseedTest/AppleseedRenderTest.py
@@ -214,8 +214,6 @@ class AppleseedRenderTest( GafferTest.TestCase ) :
 
 		s["fileName"].setValue( "/tmp/test.gfr" )
 
-		# check it can cope with everything already existing
-
 		with s.context() :
 			s["render"].execute()
 

--- a/python/GafferAppleseedTest/AppleseedRenderTest.py
+++ b/python/GafferAppleseedTest/AppleseedRenderTest.py
@@ -103,6 +103,7 @@ class AppleseedRenderTest( GafferTest.TestCase ) :
 		s["render"]["fileName"].setValue( "/tmp/test.appleseed" )
 
 		s["fileName"].setValue( self.__scriptFileName )
+		s.save()
 
 		s["render"].execute()
 
@@ -211,8 +212,10 @@ class AppleseedRenderTest( GafferTest.TestCase ) :
 		self.assertFalse( os.path.exists( "/tmp/renderTests" ) )
 		self.assertFalse( os.path.exists( "/tmp/appleseedTests" ) )
 		self.assertFalse( os.path.exists( "/tmp/appleseedTests/test.0001.appleseed" ) )
+		self.assertFalse( os.path.exists( self.__scriptFileName ) )
 
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.__scriptFileName )
+		s.save()
 
 		with s.context() :
 			s["render"].execute()
@@ -220,6 +223,7 @@ class AppleseedRenderTest( GafferTest.TestCase ) :
 		self.assertTrue( os.path.exists( "/tmp/renderTests" ) )
 		self.assertTrue( os.path.exists( "/tmp/appleseedTests" ) )
 		self.assertTrue( os.path.exists( "/tmp/appleseedTests/test.0001.appleseed" ) )
+		self.assertTrue( os.path.exists( self.__scriptFileName ) )
 
 		# check it can cope with everything already existing
 
@@ -245,6 +249,7 @@ class AppleseedRenderTest( GafferTest.TestCase ) :
 			"/tmp/appleseedTests/test.0001.appleseed",
 			"/tmp/appleseedTests",
 			"/tmp/test.exr",
+			self.__scriptFileName
 		) :
 			if os.path.isfile( f ) :
 				os.remove( f )

--- a/python/GafferAppleseedUI/AppleseedAttributesUI.py
+++ b/python/GafferAppleseedUI/AppleseedAttributesUI.py
@@ -48,8 +48,6 @@ def __visibilitySummary( plug ) :
 		( "camera", "Camera" ),
 		( "light", "Light" ),
 		( "shadow", "Shadow" ),
-		( "transparency", "Transparency" ),
-		( "probe", "Probe" ),
 		( "diffuse", "Diffuse" ),
 		( "specular", "Specular" ),
 		( "glossy", "Glossy" ),
@@ -78,15 +76,6 @@ def __alphaMapSummary( plug ) :
 
 	return ", ".join( info )
 
-def __photonsSummary( plug ) :
-
-	info = []
-	if plug["photonTarget"]["enabled"].getValue() :
-		if plug["photonTarget"]["value"].getValue() :
-			info.append( "Photon Target" )
-
-	return ", ".join( info )
-
 Gaffer.Metadata.registerNode(
 
 	GafferAppleseed.AppleseedAttributes,
@@ -100,7 +89,6 @@ Gaffer.Metadata.registerNode(
 			"layout:section:Visibility:summary", __visibilitySummary,
 			"layout:section:Shading:summary", __shadingSummary,
 			"layout:section:Alpha Map:summary", __alphaMapSummary,
-			"layout:section:Photons:summary", __photonsSummary,
 
 		],
 
@@ -124,20 +112,6 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "Visibility",
 			"label", "Shadow",
-
-		],
-
-		"attributes.transparencyVisibility" : [
-
-			"layout:section", "Visibility",
-			"label", "Transparency",
-
-		],
-
-		"attributes.probeVisibility" : [
-
-			"layout:section", "Visibility",
-			"label", "Probe",
 
 		],
 
@@ -175,14 +149,6 @@ Gaffer.Metadata.registerNode(
 		"attributes.alphaMap" : [
 
 			"layout:section", "Alpha Map",
-
-		],
-
-		# Photons
-
-		"attributes.photonTarget" : [
-
-			"layout:section", "Photons",
 
 		],
 

--- a/python/GafferAppleseedUI/AppleseedOptionsUI.py
+++ b/python/GafferAppleseedUI/AppleseedOptionsUI.py
@@ -48,10 +48,6 @@ def __mainSummary( plug ) :
 		info.append( "Sampler %s" % plug["sampler"]["value"].getValue() )
 	if plug["aaSamples"]["enabled"].getValue() :
 		info.append( "AA Samples %d" % plug["aaSamples"]["value"].getValue() )
-	if plug["forceAA"]["enabled"].getValue() and plug["forceAA"]["value"].getValue() :
-		info.append( "Force AA" )
-	if plug["decorrelatePixels"]["enabled"].getValue() and plug["decorrelatePixels"]["value"].getValue() :
-		info.append( "Decorrelate Pixels" )
 	if plug["lightingEngine"]["enabled"].getValue() :
 		info.append( "Lighting Engine %s" % plug["lightingEngine"]["value"].getValue() )
 	if plug["meshFileFormat"]["enabled"].getValue() :
@@ -76,12 +72,10 @@ def __drtSummary( plug ) :
 		info.append( "IBL" )
 	if plug["drtMaxBounces"]["enabled"].getValue() :
 		info.append( "Max Bounces %d" % plug["drtMaxBounces"]["value"].getValue() )
-	if plug["drtRRStartBounce"]["enabled"].getValue() :
-		info.append( "Min Bounces %d" % plug["drtRRStartBounce"]["value"].getValue() )
 	if plug["drtLightingSamples"]["enabled"].getValue() :
-		info.append( "Lighting samples %d" % plug["drtLightingSamples"]["value"].getValue() )
+		info.append( "Lighting samples %f" % plug["drtLightingSamples"]["value"].getValue() )
 	if plug["drtIBLSamples"]["enabled"].getValue() :
-		info.append( "IBL samples %d" % plug["drtIBLSamples"]["value"].getValue() )
+		info.append( "IBL samples %f" % plug["drtIBLSamples"]["value"].getValue() )
 
 	return ", ".join( info )
 
@@ -96,14 +90,10 @@ def __ptSummary( plug ) :
 		info.append( "Caustics" )
 	if plug["ptMaxBounces"]["enabled"].getValue() :
 		info.append( "Max Bounces %d" % plug["ptMaxBounces"]["value"].getValue() )
-	if plug["ptRRStartBounce"]["enabled"].getValue() :
-		info.append( "Min Bounces %d" % plug["ptRRStartBounce"]["value"].getValue() )
-	if plug["ptNextEvent"]["enabled"].getValue() and plug["ptNextEvent"]["value"].getValue() :
-		info.append( "Next Event Estimation" )
 	if plug["ptLightingSamples"]["enabled"].getValue() :
-		info.append( "Lighting Samples %d" % plug["ptLightingSamples"]["value"].getValue() )
+		info.append( "Lighting Samples %f" % plug["ptLightingSamples"]["value"].getValue() )
 	if plug["ptIBLSamples"]["enabled"].getValue() :
-		info.append( "IBL Samples %d" % plug["ptIBLSamples"]["value"].getValue() )
+		info.append( "IBL Samples %f" % plug["ptIBLSamples"]["value"].getValue() )
 	if plug["ptMaxRayIntensity"]["enabled"].getValue() :
 		info.append( "Max Ray Intensity %f" % plug["ptMaxRayIntensity"]["value"].getValue() )
 
@@ -122,12 +112,8 @@ def __sppmSummary( plug ) :
 		info.append( "Caustics" )
 	if plug["sppmPhotonMaxBounces"]["enabled"].getValue() :
 		info.append( "Max Photon Bounces %d" % plug["sppmPhotonMaxBounces"]["value"].getValue() )
-	if plug["sppmPhotonRRStartBounce"]["enabled"].getValue() :
-		info.append( "Min Photon Bounces %d" % plug["sppmPhotonRRStartBounce"]["value"].getValue() )
 	if plug["sppmPathMaxBounces"]["enabled"].getValue() :
 		info.append( "Max Path Bounces %d" % plug["sppmPathMaxBounces"]["value"].getValue() )
-	if plug["sppmPathRRStartBounce"]["enabled"].getValue() :
-		info.append( "Min Path Bounces %d" % plug["sppmPathRRStartBounce"]["value"].getValue() )
 	if plug["sppmLightPhotons"]["enabled"].getValue() :
 		info.append( "Light Photons %d" % plug["sppmLightPhotons"]["value"].getValue() )
 	if plug["sppmEnvPhotons"]["enabled"].getValue() :
@@ -151,7 +137,7 @@ def __systemSummary( plug ) :
 	if plug["interactiveRenderFps"]["enabled"].getValue() :
 		info.append( "Interactive Render Fps %d" % plug["interactiveRenderFps"]["value"].getValue() )
 	if plug["textureMem"]["enabled"].getValue() :
-		info.append( "Texture Mem %d Kb" % plug["textureMem"]["value"].getValue() )
+		info.append( "Texture Mem %d bytes" % plug["textureMem"]["value"].getValue() )
 	if plug["tileOrdering"]["enabled"].getValue() :
 		info.append( "Tile Ordering %s" % plug["tileOrdering"]["value"].getValue().capitalize() )
 
@@ -202,19 +188,6 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "Main",
 			"label", "AA Samples",
-
-		],
-
-		"options.forceAA" : [
-
-			"layout:section", "Main",
-			"label", "Force Antialiasing",
-
-		],
-
-		"options.decorrelatePixels" : [
-
-			"layout:section", "Main",
 
 		],
 
@@ -277,13 +250,6 @@ Gaffer.Metadata.registerNode(
 
 		],
 
-		"options.drtRRStartBounce" : [
-
-			"layout:section", "Distribution Ray Tracer",
-			"label", "RR Start Bounce",
-
-		],
-
 		"options.drtLightingSamples" : [
 
 			"layout:section", "Distribution Ray Tracer",
@@ -325,20 +291,6 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "Unidirectional Path Tracer",
 			"label", "Max Bounces",
-
-		],
-
-		"options.ptRRStartBounce" : [
-
-			"layout:section", "Unidirectional Path Tracer",
-			"label", "RR Start Bounce",
-
-		],
-
-		"options.ptNextEvent" : [
-
-			"layout:section", "Unidirectional Path Tracer",
-			"label", "Next Event Estimation",
 
 		],
 
@@ -415,24 +367,10 @@ Gaffer.Metadata.registerNode(
 
 		],
 
-		"options.sppmPhotonRRStartBounce" : [
-
-			"layout:section", "SPPM",
-			"label", "Photon RR Start Bounce",
-
-		],
-
 		"options.sppmPathMaxBounces" : [
 
 			"layout:section", "SPPM",
 			"label", "Max Path Bounces",
-
-		],
-
-		"options.sppmPathRRStartBounce" : [
-
-			"layout:section", "SPPM",
-			"label", "Path RR Start Bounce",
 
 		],
 

--- a/src/GafferAppleseed/AppleseedAttributes.cpp
+++ b/src/GafferAppleseed/AppleseedAttributes.cpp
@@ -51,20 +51,15 @@ AppleseedAttributes::AppleseedAttributes( const std::string &name )
 	attributes->addOptionalMember( "as:visibility:camera", new IECore::BoolData( true ), "cameraVisibility", Gaffer::Plug::Default, false );
 	attributes->addOptionalMember( "as:visibility:light", new IECore::BoolData( true ), "lightVisibility", Gaffer::Plug::Default, false );
 	attributes->addOptionalMember( "as:visibility:shadow", new IECore::BoolData( true ), "shadowVisibility", Gaffer::Plug::Default, false );
-	attributes->addOptionalMember( "as:visibility:transparency", new IECore::BoolData( true ), "transparencyVisibility", Gaffer::Plug::Default, false );
-	attributes->addOptionalMember( "as:visibility:probe", new IECore::BoolData( true ), "probeVisibility", Gaffer::Plug::Default, false );
 	attributes->addOptionalMember( "as:visibility:diffuse", new IECore::BoolData( true ), "diffuseVisibility", Gaffer::Plug::Default, false );
 	attributes->addOptionalMember( "as:visibility:specular", new IECore::BoolData( true ), "specularVisibility", Gaffer::Plug::Default, false );
 	attributes->addOptionalMember( "as:visibility:glossy", new IECore::BoolData( true ), "glossyVisibility", Gaffer::Plug::Default, false );
 
 	// shading parameters
-	attributes->addOptionalMember( "as:shading_samples", new IECore::IntData( 1.0f ), "shadingSamples", Gaffer::Plug::Default, false );
+	attributes->addOptionalMember( "as:shading_samples", new IECore::IntData( 1 ), "shadingSamples", Gaffer::Plug::Default, false );
 
 	// alpha map parameters
 	attributes->addOptionalMember( "as:alpha_map", new IECore::StringData(), "alphaMap", Gaffer::Plug::Default, false );
-
-	// photon target parameters
-	attributes->addOptionalMember( "as:photon_target", new IECore::BoolData( false ), "photonTarget", Gaffer::Plug::Default, false );
 }
 
 AppleseedAttributes::~AppleseedAttributes()

--- a/src/GafferAppleseed/AppleseedOptions.cpp
+++ b/src/GafferAppleseed/AppleseedOptions.cpp
@@ -50,8 +50,6 @@ AppleseedOptions::AppleseedOptions( const std::string &name )
 	options->addOptionalMember( "as:cfg:generic_frame_renderer:passes", new IECore::IntData( 1 ), "renderPasses", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "as:cfg:sampling_mode", new IECore::StringData( "rng" ), "sampler", Gaffer::Plug::Default, false );	
 	options->addOptionalMember( "as:cfg:uniform_pixel_renderer:samples", new IECore::IntData( 64 ), "aaSamples", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "as:cfg:uniform_pixel_renderer:force_antialiasing", new IECore::BoolData( false ), "forceAA", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "as:cfg:uniform_pixel_renderer:decorrelate_pixels", new IECore::BoolData( true ), "decorrelatePixels", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "as:cfg:lighting_engine", new IECore::StringData( "pt" ), "lightingEngine", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "as:mesh_file_format", new IECore::StringData( "binarymesh" ), "meshFileFormat", Gaffer::Plug::Default, false );
 
@@ -61,31 +59,26 @@ AppleseedOptions::AppleseedOptions( const std::string &name )
 
 	// drt
 	options->addOptionalMember( "as:cfg:drt:enable_ibl", new IECore::BoolData( true ), "drtIBL", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "as:cfg:drt:max_path_lenght", new IECore::IntData( 16 ), "drtMaxBounces", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "as:cfg:drt:rr_min_path_length", new IECore::IntData( 3 ), "drtRRStartBounce", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "as:cfg:drt:dl_light_samples", new IECore::IntData( 1.0f ), "drtLightingSamples", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "as:cfg:drt:max_path_length", new IECore::IntData( 0 ), "drtMaxBounces", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "as:cfg:drt:dl_light_samples", new IECore::FloatData( 1.0f ), "drtLightingSamples", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "as:cfg:drt:ibl_env_samples", new IECore::FloatData( 1.0f ), "drtIBLSamples", Gaffer::Plug::Default, false );
 
 	// path tracing
 	options->addOptionalMember( "as:cfg:pt:enable_dl", new IECore::BoolData( true ), "ptDirectLighting", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "as:cfg:pt:enable_ibl", new IECore::BoolData( true ), "ptIBL", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "as:cfg:pt:enable_caustics", new IECore::BoolData( false ), "ptCaustics", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "as:cfg:pt:max_path_lenght", new IECore::IntData( 16 ), "ptMaxBounces", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "as:cfg:pt:rr_min_path_length", new IECore::IntData( 3 ), "ptRRStartBounce", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "as:cfg:pt:next_event_estimation", new IECore::BoolData( true ), "ptNextEvent", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "as:cfg:pt:dl_light_samples", new IECore::IntData( 1.0f ), "ptLightingSamples", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "as:cfg:pt:max_path_length", new IECore::IntData( 0 ), "ptMaxBounces", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "as:cfg:pt:dl_light_samples", new IECore::FloatData( 1.0f ), "ptLightingSamples", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "as:cfg:pt:ibl_env_samples", new IECore::FloatData( 1.0f ), "ptIBLSamples", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "as:cfg:pt:max_ray_intensity", new IECore::FloatData( 1.0f ), "ptMaxRayIntensity", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "as:cfg:pt:max_ray_intensity", new IECore::FloatData( 0.0f ), "ptMaxRayIntensity", Gaffer::Plug::Default, false );
 
 	// sppm
 	options->addOptionalMember( "as:cfg:sppm:photon_type", new IECore::StringData( "mono" ), "photonType", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "as:cfg:sppm:dl_type", new IECore::StringData( "rt" ), "sppmDirectLighting", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "as:cfg:sppm:enable_ibl", new IECore::BoolData( true ), "sppmIBL", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "as:cfg:sppm:enable_caustics", new IECore::BoolData( true ), "sppmCaustics", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "as:cfg:sppm:photon_tracing_max_path_length", new IECore::IntData( 16 ), "sppmPhotonMaxBounces", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "as:cfg:sppm:photon_tracing_rr_min_path_length", new IECore::IntData( 3 ), "sppmPhotonRRStartBounce", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "as:cfg:sppm:path_tracing_max_path_length", new IECore::IntData( 16 ), "sppmPathMaxBounces", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "as:cfg:sppm:path_tracing_rr_min_path_length", new IECore::IntData( 3 ), "sppmPathRRStartBounce", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "as:cfg:sppm:photon_tracing_max_path_length", new IECore::IntData( 0 ), "sppmPhotonMaxBounces", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "as:cfg:sppm:path_tracing_max_path_length", new IECore::IntData( 0 ), "sppmPathMaxBounces", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "as:cfg:sppm:light_photons_per_pass", new IECore::IntData( 1000000 ), "sppmLightPhotons", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "as:cfg:sppm:env_photons_per_pass", new IECore::IntData( 1000000 ), "sppmEnvPhotons", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "as:cfg:sppm:initial_radius", new IECore::FloatData( 1.0f ), "sppmInitialRadius", Gaffer::Plug::Default, false );
@@ -94,8 +87,8 @@ AppleseedOptions::AppleseedOptions( const std::string &name )
 
 	// system parameters
 	options->addOptionalMember( "as:searchpath", new IECore::StringData( "" ), "searchPath", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "as:cfg:rendering_threads", new IECore::IntData( 8 ), "numThreads", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "as:cfg:rendering_threads", new IECore::IntData( 0 ), "numThreads", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "as:cfg:progressive_frame_renderer:max_fps", new IECore::FloatData( 5.0f ), "interactiveRenderFps", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "as:cfg:texture_store:max_size", new IECore::IntData( 256 * 1024 ), "textureMem", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "as:cfg:texture_store:max_size", new IECore::IntData( 256 * 1024 * 1024 ), "textureMem", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "as:cfg:generic_frame_renderer:tile_ordering", new IECore::StringData( "spiral" ), "tileOrdering", Gaffer::Plug::Default, false );
 }

--- a/src/GafferAppleseed/InteractiveAppleseedRender.cpp
+++ b/src/GafferAppleseed/InteractiveAppleseedRender.cpp
@@ -38,6 +38,7 @@
 
 #include "GafferAppleseed/InteractiveAppleseedRender.h"
 
+using namespace IECore;
 using namespace GafferScene;
 using namespace GafferAppleseed;
 
@@ -52,7 +53,7 @@ InteractiveAppleseedRender::~InteractiveAppleseedRender()
 {
 }
 
-IECore::RendererPtr InteractiveAppleseedRender::createRenderer() const
+RendererPtr InteractiveAppleseedRender::createRenderer() const
 {
 	return new IECoreAppleseed::Renderer();
 }


### PR DESCRIPTION
Backwards-incompatible changes. Depends on ImageEngine/Cortex#426

While documenting the GafferAppleseed nodes, we reviewed the different options 
and attributes and how they are exposed in Gaffer. We decided to simplify the 
AppleseedAttributes and AppleseedOptions nodes.

Changes:

- Removed transparency and probe visiblity flags from AppleseedAttributes
- Removed photon target attribute
- Removed appleseed options that are not useful in Gaffer
- Fixed defaults for some appleseed options.
- Fixed typo in appleseed options name
