### PR TITLE
ViewportGadget : Fixed unwanted drag tracking.

### DIFF
--- a/src/GafferUI/ViewportGadget.cpp
+++ b/src/GafferUI/ViewportGadget.cpp
@@ -613,9 +613,14 @@ static double currentTime()
 
 void ViewportGadget::trackDrag( const DragDropEvent &event )
 {
-	// early out if tracking is off for any reason.
+	// early out if tracking is off for any reason, or
+	// the drag didn't originate from within the viewport.
 
-	if( !getDragTracking() || !getCameraEditable() )
+	if(
+		!getDragTracking() ||
+		!getCameraEditable() ||
+		!this->isAncestorOf( event.sourceGadget.get() )
+	)
 	{
 		m_dragTrackingIdleConnection.disconnect();
 		return;


### PR DESCRIPTION
This was occuring when dragging a nodule from one NodeGraph into another NodeGraph - the second NodeGraph would start tracking the drag.

Fixes #1321.