### PR TITLE
SConstruct : Fixed appleseed packaging.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1045,6 +1045,7 @@ dependenciesManifest = [
 	"renderMan",
 	"arnold",
 	"appleseed",
+	"appleseedDisplays",
 
 ]
 


### PR DESCRIPTION
We were omitting the directory which contains the Cortex display driver for Appleseed.