### PR TITLE
ParentConstraint now constrains objects as if they had been parented

### DIFF
--- a/include/GafferScene/AimConstraint.h
+++ b/include/GafferScene/AimConstraint.h
@@ -62,7 +62,7 @@ class AimConstraint : public Constraint
 
 		virtual bool affectsConstraint( const Gaffer::Plug *input ) const;
 		virtual void hashConstraint( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::M44f computeConstraint( const Imath::M44f &fullTargetTransform, const Imath::M44f &fullInputTransform ) const;
+		virtual Imath::M44f computeConstraint( const Imath::M44f &fullTargetTransform, const Imath::M44f &fullInputTransform, const Imath::M44f &inputTransform ) const;
 
 	private :
 

--- a/include/GafferScene/Constraint.h
+++ b/include/GafferScene/Constraint.h
@@ -91,7 +91,7 @@ class Constraint : public SceneElementProcessor
 		virtual void hashConstraint( const Gaffer::Context *context, IECore::MurmurHash &h ) const = 0;
 		/// Must be implemented to return a new full (absolute in world space) transform constraining fullInputTransform to
 		/// fullTargetTransform in some way.
-		virtual Imath::M44f computeConstraint( const Imath::M44f &fullTargetTransform, const Imath::M44f &fullInputTransform ) const = 0;
+		virtual Imath::M44f computeConstraint( const Imath::M44f &fullTargetTransform, const Imath::M44f &fullInputTransform, const Imath::M44f &inputTransform ) const = 0;
 
 	private :
 

--- a/include/GafferScene/ParentConstraint.h
+++ b/include/GafferScene/ParentConstraint.h
@@ -61,7 +61,7 @@ class ParentConstraint : public Constraint
 
 		virtual bool affectsConstraint( const Gaffer::Plug *input ) const;
 		virtual void hashConstraint( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::M44f computeConstraint( const Imath::M44f &fullTargetTransform, const Imath::M44f &fullInputTransform ) const;
+		virtual Imath::M44f computeConstraint( const Imath::M44f &fullTargetTransform, const Imath::M44f &fullInputTransform, const Imath::M44f &inputTransform ) const;
 
 	private :
 

--- a/include/GafferScene/PointConstraint.h
+++ b/include/GafferScene/PointConstraint.h
@@ -68,7 +68,7 @@ class PointConstraint : public Constraint
 
 		virtual bool affectsConstraint( const Gaffer::Plug *input ) const;
 		virtual void hashConstraint( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::M44f computeConstraint( const Imath::M44f &fullTargetTransform, const Imath::M44f &fullInputTransform ) const;
+		virtual Imath::M44f computeConstraint( const Imath::M44f &fullTargetTransform, const Imath::M44f &fullInputTransform, const Imath::M44f &inputTransform ) const;
 
 	private :
 

--- a/python/GafferSceneTest/ParentConstraintTest.py
+++ b/python/GafferSceneTest/ParentConstraintTest.py
@@ -131,5 +131,35 @@ class ParentConstraintTest( GafferSceneTest.SceneTestCase ) :
 			set( plugs )
 		)
 
+	def testParentNodeEquivalence( self ) :
+
+		plane1 = GafferScene.Plane()
+		plane1["name"].setValue( "target" )
+
+		plane2 = GafferScene.Plane()
+		plane2["name"].setValue( "constrained" )
+
+		plane1["transform"]["rotate"]["y"].setValue( 45 )
+		plane2["transform"]["translate"]["x"].setValue( 1 )
+
+		parent = GafferScene.Parent()
+		parent["in"].setInput( plane1["out"] )
+		parent["parent"].setValue( "/target" )
+		parent["child"].setInput( plane2["out"] )
+
+		group = GafferScene.Group()
+		group["in"].setInput( plane1["out"] )
+		group["in1"].setInput( plane2["out"] )
+
+		constraint = GafferScene.ParentConstraint()
+		constraint["in"].setInput( group["out"] )
+		constraint["target"].setValue( "/group/target" )
+
+		filter = GafferScene.PathFilter()
+		filter["paths"].setValue( IECore.StringVectorData( [ "/group/constrained" ] ) )
+		constraint["filter"].setInput( filter["out"] )
+
+		self.assertEqual( parent["out"].fullTransform( "/target/constrained" ), constraint["out"].fullTransform( "/group/constrained" ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/AimConstraint.cpp
+++ b/src/GafferScene/AimConstraint.cpp
@@ -89,7 +89,7 @@ void AimConstraint::hashConstraint( const Gaffer::Context *context, IECore::Murm
 	upPlug()->hash( h );
 }
 
-Imath::M44f AimConstraint::computeConstraint( const Imath::M44f &fullTargetTransform, const Imath::M44f &fullInputTransform ) const
+Imath::M44f AimConstraint::computeConstraint( const Imath::M44f &fullTargetTransform, const Imath::M44f &fullInputTransform, const Imath::M44f &inputTransform ) const
 {
 	// decompose into scale, shear, rotate and translate
 	V3f s, h, r, t;

--- a/src/GafferScene/Constraint.cpp
+++ b/src/GafferScene/Constraint.cpp
@@ -176,7 +176,7 @@ Imath::M44f Constraint::computeProcessedTransform( const ScenePath &path, const 
 
 	fullTargetTransform.translate( targetOffsetPlug()->getValue() );
 
-	const M44f fullConstrainedTransform = computeConstraint( fullTargetTransform, fullInputTransform );
+	const M44f fullConstrainedTransform = computeConstraint( fullTargetTransform, fullInputTransform, inputTransform );
 	return fullConstrainedTransform * parentTransform.inverse();
 }
 

--- a/src/GafferScene/ParentConstraint.cpp
+++ b/src/GafferScene/ParentConstraint.cpp
@@ -76,5 +76,5 @@ void ParentConstraint::hashConstraint( const Gaffer::Context *context, IECore::M
 
 Imath::M44f ParentConstraint::computeConstraint( const Imath::M44f &fullTargetTransform, const Imath::M44f &fullInputTransform, const Imath::M44f &inputTransform ) const
 {
-	return relativeTransformPlug()->matrix() * fullTargetTransform;
+	return inputTransform * relativeTransformPlug()->matrix() * fullTargetTransform;
 }

--- a/src/GafferScene/ParentConstraint.cpp
+++ b/src/GafferScene/ParentConstraint.cpp
@@ -74,7 +74,7 @@ void ParentConstraint::hashConstraint( const Gaffer::Context *context, IECore::M
 	relativeTransformPlug()->hash( h );
 }
 
-Imath::M44f ParentConstraint::computeConstraint( const Imath::M44f &fullTargetTransform, const Imath::M44f &fullInputTransform ) const
+Imath::M44f ParentConstraint::computeConstraint( const Imath::M44f &fullTargetTransform, const Imath::M44f &fullInputTransform, const Imath::M44f &inputTransform ) const
 {
 	return relativeTransformPlug()->matrix() * fullTargetTransform;
 }

--- a/src/GafferScene/PointConstraint.cpp
+++ b/src/GafferScene/PointConstraint.cpp
@@ -117,7 +117,7 @@ void PointConstraint::hashConstraint( const Gaffer::Context *context, IECore::Mu
 	zEnabledPlug()->hash( h );
 }
 
-Imath::M44f PointConstraint::computeConstraint( const Imath::M44f &fullTargetTransform, const Imath::M44f &fullInputTransform ) const
+Imath::M44f PointConstraint::computeConstraint( const Imath::M44f &fullTargetTransform, const Imath::M44f &fullInputTransform, const Imath::M44f &inputTransform ) const
 {
 	const V3f worldPosition = fullTargetTransform.translation() + offsetPlug()->getValue();
 	M44f result = fullInputTransform;


### PR DESCRIPTION
As one might reasonably expect given the name of the node. Thanks to @danieldresser for making the case for this, and convincing me out of my muddled thinking on the matter.

This breaks both binary compatibility and also changes the default behaviour of the ParentConstraint node. At Image Engine we're happy to take that hit in return for getting the change of behaviour we want without adding extra plugs or other complications. But we do have a backup plan for maintaining backwards compatibility for old scripts if anyone wants to request it.