### PR TITLE
SceneInspector : Fixed bug in setTargetPaths() method.

### DIFF
--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -195,7 +195,7 @@ class SceneInspector( GafferUI.NodeSetEditor ) :
 		assert( paths is None or len( paths ) == 1 or len( paths ) == 2 )
 
 		self.__targetPaths = paths
-		self.__scheduleUpdate()
+		self.__updateLazily()
 
 	## Returns the last value passed to setTargetPaths().
 	def getTargetPaths( self ) :

--- a/python/GafferSceneUITest/SceneInspectorTest.py
+++ b/python/GafferSceneUITest/SceneInspectorTest.py
@@ -61,6 +61,18 @@ class SceneInspectorTest( GafferUITest.TestCase ) :
 		self.assertTrue( t.object().isSame( t.object() ) )
 		self.assertTrue( t.globals().isSame( t.globals() ) )
 
+	def testTargetPathsAccessors( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		inspector = GafferSceneUI.SceneInspector( script )
+		self.assertEqual( inspector.getTargetPaths(), None )
+
+		inspector.setTargetPaths( [ "/plane" ] )
+		self.assertEqual( inspector.getTargetPaths(), [ "/plane" ] )
+
+		self.assertRaises( Exception, inspector.setTargetPaths, [ "/too", "/many", "/paths" ] )
+
 if __name__ == "__main__":
 	unittest.main()
 


### PR DESCRIPTION
It was calling the old __scheduleUpdate() method rather than the new __updateLazily() method. This meant that the inheritance and history windows in the SceneInspector were broken.