### PR TITLE
Dispatcher/ExecutableNode : Removed use of CompoundPlug

### DIFF
--- a/include/Gaffer/Dispatcher.h
+++ b/include/Gaffer/Dispatcher.h
@@ -57,7 +57,6 @@ namespace Gaffer
 {
 
 IE_CORE_FORWARDDECLARE( Dispatcher )
-IE_CORE_FORWARDDECLARE( CompoundPlug )
 IE_CORE_FORWARDDECLARE( StringPlug )
 
 namespace Detail
@@ -163,14 +162,14 @@ class Dispatcher : public Node
 		typedef boost::function<DispatcherPtr ()> Creator;
 		/// SetupPlugsFn may be registered along with a Dispatcher Creator. It will be called by setupPlugs,
 		/// along with all other registered SetupPlugsFns. It is recommended that each registered dispatcher
-		/// store its plugs contained within a dedicated CompoundPlug, named according to the registration
+		/// store its plugs contained within a dedicated parent Plug, named according to the registration
 		/// type. The SetupPlugsFn must be implemented in a way that gracefully accepts situations where the
 		/// plugs already exist (i.e. nodes loaded from a script may already have the necessary dispatcher plugs).
 		/// One way to avoid this issue is to always create non-dynamic plugs. Since setupPlugs is called from
 		/// the ExecutableNode constructor, the non-dynamic plugs will always be created according to the current
 		/// definition, and will not be serialized into scripts. The downside of using non-dynamic plugs is that
 		/// loading a script before all Dispatchers have been registered could result in lost settings.
-		typedef boost::function<void ( CompoundPlug *parentPlug )> SetupPlugsFn;
+		typedef boost::function<void ( Plug *parentPlug )> SetupPlugsFn;
 		
 		//! @name Registration
 		/// Utility functions for registering and retrieving Dispatchers.
@@ -241,8 +240,8 @@ class Dispatcher : public Node
 		/// Dispatchers are able to create custom plugs on ExecutableNodes when they are constructed.
 		/////////////////////////////////////////////////////////////////////////////////////////////
 		//@{
-		/// Adds the custom plugs from all registered Dispatchers to the given CompoundPlug.
-		static void setupPlugs( CompoundPlug *parentPlug );
+		/// Adds the custom plugs from all registered Dispatchers to the given parent Plug.
+		static void setupPlugs( Plug *parentPlug );
 		//@}
 
 	private :

--- a/include/Gaffer/ExecutableNode.h
+++ b/include/Gaffer/ExecutableNode.h
@@ -98,11 +98,11 @@ class ExecutableNode : public Node
 		Plug *requirementPlug();
 		const Plug *requirementPlug() const;
 
-		/// Compound plug used by Dispatchers to expose per-node dispatcher settings.
+		/// Parent plug used by Dispatchers to expose per-node dispatcher settings.
 		/// See the "ExecutableNode Customization" section of the Gaffer::Dispatcher
 		/// documentation for more details.
-		CompoundPlug *dispatcherPlug();
-		const CompoundPlug *dispatcherPlug() const;
+		Plug *dispatcherPlug();
+		const Plug *dispatcherPlug() const;
 
 		/// Fills requirements with all Tasks that must be completed before execute
 		/// can be called with the given context. The default implementation collects

--- a/python/Gaffer/LocalDispatcher.py
+++ b/python/Gaffer/LocalDispatcher.py
@@ -435,11 +435,7 @@ class LocalDispatcher( Gaffer.Dispatcher ) :
 	@staticmethod
 	def _doSetupPlugs( parentPlug ) :
 
-		if "local" not in parentPlug :
-			localPlug = Gaffer.CompoundPlug( "local" )
-			parentPlug.addChild( localPlug )
-
-		parentPlug["local"].clearChildren()
+		parentPlug["local"] = Gaffer.Plug()
 
 		foregroundPlug = Gaffer.BoolPlug( "executeInForeground", defaultValue = False )
 		parentPlug["local"].addChild( foregroundPlug )

--- a/python/GafferUI/LocalDispatcherUI.py
+++ b/python/GafferUI/LocalDispatcherUI.py
@@ -82,8 +82,36 @@ Gaffer.Metadata.registerNode(
 
 )
 
-Gaffer.Metadata.registerPlugDescription( Gaffer.ExecutableNode, "dispatcher.local", "Settings used by the local dispatcher." )
-Gaffer.Metadata.registerPlugDescription( Gaffer.ExecutableNode, "dispatcher.local.executeInForeground", "Forces the tasks from this node (and all preceding tasks) to execute on the current thread." )
+Gaffer.Metadata.registerNode(
+
+	Gaffer.ExecutableNode,
+
+	plugs = {
+
+		"dispatcher.local" : [
+
+			"description",
+			"""
+			Settings used by the local dispatcher.
+			""",
+
+			"layout:widgetType", "GafferUI.LayoutPlugValueWidget",
+			"layout:section", "Local",
+
+		],
+
+		"dispatcher.local.executeInForeground" : [
+
+			"description",
+			"""
+			Forces the tasks from this node (and all preceding tasks) to execute on the current thread.
+			"""
+
+		]
+
+	}
+
+)
 
 ##########################################################################
 # Public functions

--- a/src/Gaffer/Dispatcher.cpp
+++ b/src/Gaffer/Dispatcher.cpp
@@ -288,7 +288,7 @@ Dispatcher::PostDispatchSignal &Dispatcher::postDispatchSignal()
 	return g_postDispatchSignal;
 }
 
-void Dispatcher::setupPlugs( CompoundPlug *parentPlug )
+void Dispatcher::setupPlugs( Plug *parentPlug )
 {
 	if ( const ExecutableNode *node = parentPlug->ancestor<const ExecutableNode>() )
 	{
@@ -370,7 +370,7 @@ Dispatcher::TaskBatchPtr Dispatcher::acquireBatch( const ExecutableNode::Task &t
 		TaskBatchPtr batch = bIt->second;
 
 		std::vector<float> &frames = batch->frames();
-		const CompoundPlug *dispatcherPlug = task.node()->dispatcherPlug();
+		const Plug *dispatcherPlug = task.node()->dispatcherPlug();
 		const IntPlug *batchSizePlug = dispatcherPlug->getChild<const IntPlug>( g_batchSize );
 		size_t batchSize = ( batchSizePlug ) ? batchSizePlug->getValue() : 1;
 

--- a/src/Gaffer/ExecutableNode.cpp
+++ b/src/Gaffer/ExecutableNode.cpp
@@ -97,7 +97,7 @@ ExecutableNode::ExecutableNode( const std::string &name )
 	addChild( new ArrayPlug( "requirements", Plug::In, new Plug( "requirement0" ) ) );
 	addChild( new Plug( "requirement", Plug::Out ) );
 
-	CompoundPlugPtr dispatcherPlug = new CompoundPlug( "dispatcher", Plug::In );
+	PlugPtr dispatcherPlug = new Plug( "dispatcher", Plug::In );
 	addChild( dispatcherPlug );
 
 	Dispatcher::setupPlugs( dispatcherPlug.get() );
@@ -127,14 +127,14 @@ const Plug *ExecutableNode::requirementPlug() const
 	return getChild<Plug>( g_firstPlugIndex + 1 );
 }
 
-CompoundPlug *ExecutableNode::dispatcherPlug()
+Plug *ExecutableNode::dispatcherPlug()
 {
-	return getChild<CompoundPlug>( g_firstPlugIndex + 2 );
+	return getChild<Plug>( g_firstPlugIndex + 2 );
 }
 
-const CompoundPlug *ExecutableNode::dispatcherPlug() const
+const Plug *ExecutableNode::dispatcherPlug() const
 {
-	return getChild<CompoundPlug>( g_firstPlugIndex + 2 );
+	return getChild<Plug>( g_firstPlugIndex + 2 );
 }
 
 void ExecutableNode::requirements( const Context *context, Tasks &requirements ) const

--- a/src/GafferBindings/DispatcherBinding.cpp
+++ b/src/GafferBindings/DispatcherBinding.cpp
@@ -212,17 +212,14 @@ struct DispatcherHelper
 		return 0;
 	}
 	
-	void operator()( CompoundPlug *parentPlug )
+	void operator()( Plug *parentPlug )
 	{
+		IECorePython::ScopedGILLock gilLock;
 		if ( m_setupFn )
 		{
-			CompoundPlugPtr tmpPointer = parentPlug;
-			
-			IECorePython::ScopedGILLock gilLock;
-			
 			try
 			{
-				m_setupFn( tmpPointer );
+				m_setupFn( PlugPtr( parentPlug ) );
 			}
 			catch( const boost::python::error_already_set &e )
 			{


### PR DESCRIPTION
As per #1323 - I'll be doing this bit by bit as time allows. This does require a major version bump, but I believe because all our dispatcher implementations are in Python, it shouldn't actually affect anything in reality. I suggest we get a new minor version out before merging this, since this one isn't urgent in any way.