### PR TITLE
PlugLayout : Fixed ObjectWriterUI.

### DIFF
--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -336,7 +336,7 @@ class PlugLayout( GafferUI.Widget ) :
 			if result is None :
 				return result
 
- 		if not result.hasLabel() and Gaffer.Metadata.plugValue( plug, "label" ) != "" :
+		if isinstance( result, GafferUI.PlugValueWidget ) and not result.hasLabel() and Gaffer.Metadata.plugValue( plug, "label" ) != "" :
  			result = GafferUI.PlugWidget( result )
 			if self.__layout.orientation() == GafferUI.ListContainer.Orientation.Horizontal :
 				# undo the annoying fixed size the PlugWidget has applied


### PR DESCRIPTION
The ObjectWriter is very naughty and registers a ParameterValueWidget in place of a PlugValueWidget. Really we need to refactor GafferCortexUI so that this is not necessary, but in the meantime we make PlugLayout tolerant of the behaviour in the same way that StandardNodeUI was. This fixes a bug introduced by 0cec503cf5e1c868a9b74d3cec42d87b97f001e0.