### PR TITLE
Apps : Fixed errors caused by special characters in .gfr filenames.

### DIFF
--- a/apps/browser/browser-1.py
+++ b/apps/browser/browser-1.py
@@ -73,10 +73,11 @@ class browser( Gaffer.Application ) :
 		
 	def _run( self, args ) :
 	
-		self.root()["scripts"]["script1"] = Gaffer.ScriptNode()
+		scriptNode = Gaffer.ScriptNode()
+		self.root()["scripts"].addChild( scriptNode )
 		
 		with GafferUI.Window( "Gaffer Browser" ) as self.__window :
-			browser = GafferUI.BrowserEditor( self.root()["scripts"]["script1"] )
+			browser = GafferUI.BrowserEditor( scriptNode )
 		
 		if args["initialPath"].value :
 			initialPath = os.path.abspath( args["initialPath"].value )

--- a/apps/execute/execute-1.py
+++ b/apps/execute/execute-1.py
@@ -104,7 +104,7 @@ class execute( Gaffer.Application ) :
 		
 	def _run( self, args ) :
 			
-		scriptNode = Gaffer.ScriptNode( os.path.splitext( os.path.basename( args["script"].value ) )[0] )
+		scriptNode = Gaffer.ScriptNode()
 		scriptNode["fileName"].setValue( os.path.abspath( args["script"].value ) )
 		try :
 			scriptNode.load( continueOnError = args["ignoreScriptLoadErrors"].value )

--- a/apps/gui/gui-1.py
+++ b/apps/gui/gui-1.py
@@ -84,7 +84,7 @@ class gui( Gaffer.Application ) :
 		
 		if len( args["scripts"] ) :
 			for fileName in args["scripts"] :
-				scriptNode = Gaffer.ScriptNode( os.path.splitext( os.path.basename( fileName ) )[0] )
+				scriptNode = Gaffer.ScriptNode()
 				scriptNode["fileName"].setValue( os.path.abspath( fileName ) )
 				# \todo: Display load errors in a dialog, like in python/GafferUI/FileMenu.py
 				scriptNode.load( continueOnError = True )
@@ -92,7 +92,7 @@ class gui( Gaffer.Application ) :
 				GafferUI.FileMenu.addRecentFile( self, fileName )
 				del scriptNode
 		else :
-			self.root()["scripts"]["script1"] = Gaffer.ScriptNode()
+			self.root()["scripts"].addChild( Gaffer.ScriptNode() )
 		
 		if args["fullScreen"].value :
 			primaryScript = self.root()["scripts"][-1]

--- a/apps/screengrab/screengrab-1.py
+++ b/apps/screengrab/screengrab-1.py
@@ -101,7 +101,7 @@ class screengrab( Gaffer.Application ) :
 		
 		#load the specified gfr file
 		fileName = str(args["script"])
-		script = Gaffer.ScriptNode( os.path.splitext( os.path.basename( fileName ) )[0] )
+		script = Gaffer.ScriptNode()
 		script["fileName"].setValue( os.path.abspath( fileName ) )
 		script.load()
 		self.root()["scripts"].addChild( script )

--- a/python/GafferUI/FileMenu.py
+++ b/python/GafferUI/FileMenu.py
@@ -67,7 +67,7 @@ def new( menu ) :
 	scriptWindow = menu.ancestor( GafferUI.ScriptWindow )
 	application = scriptWindow.scriptNode().ancestor( Gaffer.ApplicationRoot )
 
-	newScript = Gaffer.ScriptNode( "script" )
+	newScript = Gaffer.ScriptNode()
 	application["scripts"].addChild( newScript )
 
 ## A function suitable as the command for a File/Open menu item. It must be invoked from a menu which


### PR DESCRIPTION
Several of the apps tried to name the ScriptNode based on the filename, resulting in errors because filenames may contain characters not accepted as GraphComponent names. Since our apps (and the FileMenu) were inconsistent in the names they were applying anyway (and there was no syncing of the node name on subsequent filename changes), we now simply just use the default name for the ScriptNode.