### PR TITLE
DeleteChannels : Fixed hashChannelNames() method.

### DIFF
--- a/src/GafferImage/DeleteChannels.cpp
+++ b/src/GafferImage/DeleteChannels.cpp
@@ -120,7 +120,7 @@ GafferImage::Format DeleteChannels::computeFormat( const Gaffer::Context *contex
 
 void DeleteChannels::hashChannelNames( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	ImageProcessor::hash( output, context, h );
+	ImageProcessor::hashChannelNames( output, context, h );
 
 	inPlug()->channelNamesPlug()->hash( h );
 	modePlug()->hash( h );


### PR DESCRIPTION
It was calling the wrong base class method prior to adding its own hashing.