### PR TITLE
Shader : Retyped parametersPlug() as Plug rather than CompoundPlug.

### DIFF
--- a/include/GafferRenderMan/RenderManShader.h
+++ b/include/GafferRenderMan/RenderManShader.h
@@ -86,7 +86,7 @@ class RenderManShader : public GafferScene::Shader
 		/// \todo Perhaps some other code sharing mechanism makes more sense?
 		friend class RenderManLight;
 
-		static void loadShaderParameters( const IECore::Shader *shader, Gaffer::CompoundPlug *parametersPlug, bool keepExistingValues=false );
+		static void loadShaderParameters( const IECore::Shader *shader, Gaffer::Plug *parametersPlug, bool keepExistingValues=false );
 
 };
 

--- a/include/GafferScene/Shader.h
+++ b/include/GafferScene/Shader.h
@@ -77,8 +77,8 @@ class Shader : public Gaffer::DependencyNode
 		const Gaffer::StringPlug *typePlug() const;
 
 		/// Plug under which the shader parameters are defined.
-		Gaffer::CompoundPlug *parametersPlug();
-		const Gaffer::CompoundPlug *parametersPlug() const;
+		Gaffer::Plug *parametersPlug();
+		const Gaffer::Plug *parametersPlug() const;
 
 		/// Plug which defines the shader's output - this should
 		/// be connected to a ShaderAssignment::shaderPlug() or

--- a/src/GafferOSL/OSLShader.cpp
+++ b/src/GafferOSL/OSLShader.cpp
@@ -250,7 +250,7 @@ static void transferConnectionOrValue( Plug *sourcePlug, Plug *destinationPlug )
 	}
 }
 
-static Plug *loadStringParameter( const OSLQuery::Parameter *parameter, Gaffer::CompoundPlug *parent )
+static Plug *loadStringParameter( const OSLQuery::Parameter *parameter, Gaffer::Plug *parent )
 {
 	string defaultValue;
 	if( parameter->sdefault.size() )
@@ -275,7 +275,7 @@ static Plug *loadStringParameter( const OSLQuery::Parameter *parameter, Gaffer::
 }
 
 template<typename PlugType>
-static Plug *loadNumericParameter( const OSLQuery::Parameter *parameter, Gaffer::CompoundPlug *parent )
+static Plug *loadNumericParameter( const OSLQuery::Parameter *parameter, Gaffer::Plug *parent )
 {
 	typedef typename PlugType::ValueType ValueType;
 
@@ -315,7 +315,7 @@ static Plug *loadNumericParameter( const OSLQuery::Parameter *parameter, Gaffer:
 }
 
 template <typename PlugType>
-static Plug *loadCompoundNumericParameter( const OSLQuery::Parameter *parameter, Gaffer::CompoundPlug *parent )
+static Plug *loadCompoundNumericParameter( const OSLQuery::Parameter *parameter, Gaffer::Plug *parent )
 {
 	typedef typename PlugType::ValueType ValueType;
 	typedef typename ValueType::BaseType BaseType;
@@ -369,7 +369,7 @@ static Plug *loadCompoundNumericParameter( const OSLQuery::Parameter *parameter,
 	return plug.get();
 }
 
-static Plug *loadClosureParameter( const OSLQuery::Parameter *parameter, Gaffer::CompoundPlug *parent )
+static Plug *loadClosureParameter( const OSLQuery::Parameter *parameter, Gaffer::Plug *parent )
 {
 	const string name = plugName( parameter );
 	Plug *existingPlug = parent->getChild<Plug>( name );
@@ -388,9 +388,9 @@ static Plug *loadClosureParameter( const OSLQuery::Parameter *parameter, Gaffer:
 }
 
 // forward declaration so loadStructParameter() can call it.
-static Plug *loadShaderParameter( const OSLQuery &query, const OSLQuery::Parameter *parameter, Gaffer::CompoundPlug *parent, bool keepExistingValues );
+static Plug *loadShaderParameter( const OSLQuery &query, const OSLQuery::Parameter *parameter, Gaffer::Plug *parent, bool keepExistingValues );
 
-static Plug *loadStructParameter( const OSLQuery &query, const OSLQuery::Parameter *parameter, Gaffer::CompoundPlug *parent, bool keepExistingValues )
+static Plug *loadStructParameter( const OSLQuery &query, const OSLQuery::Parameter *parameter, Gaffer::Plug *parent, bool keepExistingValues )
 {
 	CompoundPlug *result = NULL;
 
@@ -440,7 +440,7 @@ static Plug *loadStructParameter( const OSLQuery &query, const OSLQuery::Paramet
 	return result;
 }
 
-static Plug *loadShaderParameter( const OSLQuery &query, const OSLQuery::Parameter *parameter, Gaffer::CompoundPlug *parent, bool keepExistingValues )
+static Plug *loadShaderParameter( const OSLQuery &query, const OSLQuery::Parameter *parameter, Gaffer::Plug *parent, bool keepExistingValues )
 {
 	Plug *result = NULL;
 
@@ -505,7 +505,7 @@ static Plug *loadShaderParameter( const OSLQuery &query, const OSLQuery::Paramet
 	return result;
 }
 
-static void loadShaderParameters( const OSLQuery &query, Gaffer::CompoundPlug *parametersPlug, bool keepExistingValues )
+static void loadShaderParameters( const OSLQuery &query, Gaffer::Plug *parametersPlug, bool keepExistingValues )
 {
 
 	// if we're not preserving existing values then remove all existing parameter plugs - the various

--- a/src/GafferRenderMan/RenderManShader.cpp
+++ b/src/GafferRenderMan/RenderManShader.cpp
@@ -349,7 +349,7 @@ IECore::CachedReader *RenderManShader::shaderLoader()
 }
 
 template <typename PlugType>
-static void loadParameter( Gaffer::CompoundPlug *parametersPlug, const std::string &name, const typename PlugType::ValueType &defaultValue )
+static void loadParameter( Gaffer::Plug *parametersPlug, const std::string &name, const typename PlugType::ValueType &defaultValue )
 {
 	PlugType *existingPlug = parametersPlug->getChild<PlugType>( name );
 	if( existingPlug && existingPlug->defaultValue() == defaultValue )
@@ -373,7 +373,7 @@ static void loadParameter( Gaffer::CompoundPlug *parametersPlug, const std::stri
 	parametersPlug->setChild( name, plug );
 }
 
-static void loadCoshaderParameter( Gaffer::CompoundPlug *parametersPlug, const std::string &name )
+static void loadCoshaderParameter( Gaffer::Plug *parametersPlug, const std::string &name )
 {
 	Plug *existingPlug = parametersPlug->getChild<Plug>( name );
 	if( existingPlug && existingPlug->typeId() == Plug::staticTypeId() )
@@ -390,7 +390,7 @@ static void loadCoshaderParameter( Gaffer::CompoundPlug *parametersPlug, const s
 	parametersPlug->setChild( name, plug );
 }
 
-static void loadCoshaderArrayParameter( Gaffer::CompoundPlug *parametersPlug, const std::string &name, const StringVectorData *defaultValue )
+static void loadCoshaderArrayParameter( Gaffer::Plug *parametersPlug, const std::string &name, const StringVectorData *defaultValue )
 {
 	const size_t minSize = std::max( defaultValue->readable().size(), (size_t)1 );
 	const size_t maxSize = defaultValue->readable().size() ? defaultValue->readable().size() : Imath::limits<size_t>::max();
@@ -432,7 +432,7 @@ static void loadCoshaderArrayParameter( Gaffer::CompoundPlug *parametersPlug, co
 }
 
 template <typename PlugType>
-static void loadNumericParameter( Gaffer::CompoundPlug *parametersPlug, const std::string &name, typename PlugType::ValueType defaultValue, const CompoundData *annotations )
+static void loadNumericParameter( Gaffer::Plug *parametersPlug, const std::string &name, typename PlugType::ValueType defaultValue, const CompoundData *annotations )
 {
 	typename PlugType::ValueType minValue( Imath::limits<typename PlugType::ValueType>::min() );
 	typename PlugType::ValueType maxValue( Imath::limits<typename PlugType::ValueType>::max() );
@@ -477,7 +477,7 @@ static void loadNumericParameter( Gaffer::CompoundPlug *parametersPlug, const st
 	parametersPlug->setChild( name, plug );
 }
 
-static void loadNumericParameter( Gaffer::CompoundPlug *parametersPlug, const std::string &name, float defaultValue, const CompoundData *annotations )
+static void loadNumericParameter( Gaffer::Plug *parametersPlug, const std::string &name, float defaultValue, const CompoundData *annotations )
 {
 	const StringData *typeData = annotations->member<StringData>( name + ".type" );
 	if( typeData && typeData->readable() == "float" )
@@ -506,7 +506,7 @@ static void loadNumericParameter( Gaffer::CompoundPlug *parametersPlug, const st
 }
 
 template <typename PlugType>
-static void loadCompoundNumericParameter( Gaffer::CompoundPlug *parametersPlug, const std::string &name, const typename PlugType::ValueType &defaultValue, const CompoundData *annotations )
+static void loadCompoundNumericParameter( Gaffer::Plug *parametersPlug, const std::string &name, const typename PlugType::ValueType &defaultValue, const CompoundData *annotations )
 {
 	typename PlugType::ValueType minValue( Imath::limits<float>::min() );
 	typename PlugType::ValueType maxValue( Imath::limits<float>::max() );
@@ -557,7 +557,7 @@ static void loadCompoundNumericParameter( Gaffer::CompoundPlug *parametersPlug, 
 }
 
 template<typename PlugType>
-static void loadArrayParameter( Gaffer::CompoundPlug *parametersPlug, const std::string &name, const Data *defaultValue, const CompoundData *annotations )
+static void loadArrayParameter( Gaffer::Plug *parametersPlug, const std::string &name, const Data *defaultValue, const CompoundData *annotations )
 {
 	const typename PlugType::ValueType *typedDefaultValue = static_cast<const typename PlugType::ValueType *>( defaultValue );
 
@@ -585,7 +585,7 @@ static void loadArrayParameter( Gaffer::CompoundPlug *parametersPlug, const std:
 }
 
 template<typename PlugType>
-static void loadSplineParameter( Gaffer::CompoundPlug *parametersPlug, const std::string &name, const FloatVectorData *defaultPositions, const Data *defaultValues )
+static void loadSplineParameter( Gaffer::Plug *parametersPlug, const std::string &name, const FloatVectorData *defaultPositions, const Data *defaultValues )
 {
 	PlugType *existingPlug = parametersPlug->getChild<PlugType>( name );
 	if( existingPlug )
@@ -728,7 +728,7 @@ static IECore::Color3fVectorDataPtr parseColors( const std::string &value )
 	return result;
 }
 
-void RenderManShader::loadShaderParameters( const IECore::Shader *shader, Gaffer::CompoundPlug *parametersPlug, bool keepExistingValues )
+void RenderManShader::loadShaderParameters( const IECore::Shader *shader, Gaffer::Plug *parametersPlug, bool keepExistingValues )
 {
 	const CompoundData *typeHints = shader->blindData()->member<CompoundData>( "ri:parameterTypeHints", true );
 

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -97,14 +97,14 @@ const Gaffer::StringPlug *Shader::typePlug() const
 	return getChild<StringPlug>( g_firstPlugIndex + 1 );
 }
 
-Gaffer::CompoundPlug *Shader::parametersPlug()
+Gaffer::Plug *Shader::parametersPlug()
 {
-	return getChild<CompoundPlug>( g_firstPlugIndex + 2 );
+	return getChild<Plug>( g_firstPlugIndex + 2 );
 }
 
-const Gaffer::CompoundPlug *Shader::parametersPlug() const
+const Gaffer::Plug *Shader::parametersPlug() const
 {
-	return getChild<CompoundPlug>( g_firstPlugIndex + 2 );
+	return getChild<Plug>( g_firstPlugIndex + 2 );
 }
 
 Gaffer::Plug *Shader::outPlug()


### PR DESCRIPTION
This is part of the ongoing effort towards removing CompoundPlug entirely in #1323.

Incompatibilities :

- Changed Shader::parametersPlug() to Plug rather than CompoundPlug.