### PR TITLE
"Select Affected Objects" improvements

### DIFF
--- a/python/GafferSceneUI/FilteredSceneProcessorUI.py
+++ b/python/GafferSceneUI/FilteredSceneProcessorUI.py
@@ -123,3 +123,15 @@ def appendNodeContextMenuDefinitions( nodeGraph, node, menuDefinition ) :
 
 	menuDefinition.append( "/FilteredSceneProcessorDivider", { "divider" : True } )
 	menuDefinition.append( "/Select Affected Objects", { "command" : IECore.curry( __selectAffected, node, nodeGraph.getContext() ) } )
+
+##########################################################################
+# NodeEditor tool menu
+##########################################################################
+
+def appendNodeEditorToolMenuDefinitions( nodeEditor, node, menuDefinition ) :
+
+	if not isinstance( node, ( GafferScene.FilteredSceneProcessor, GafferScene.Filter ) ) :
+		return
+
+	menuDefinition.append( "/FilteredSceneProcessorDivider", { "divider" : True } )
+	menuDefinition.append( "/Select Affected Objects", { "command" : IECore.curry( __selectAffected, node, nodeEditor.getContext() ) } )

--- a/python/GafferSceneUI/FilteredSceneProcessorUI.py
+++ b/python/GafferSceneUI/FilteredSceneProcessorUI.py
@@ -94,14 +94,31 @@ GafferUI.Nodule.registerNodule( GafferScene.FilteredSceneProcessor, "filter", Ga
 
 def __selectAffected( node, context ) :
 
+	if isinstance( node, GafferScene.FilteredSceneProcessor ) :
+		filter = node["filter"]
+		scenes = [ node["in"] ]
+	else :
+		filter = node
+		scenes = []
+		def walkOutputs( plug ) :
+			for output in plug.outputs() :
+				node = output.node()
+				if isinstance( node, GafferScene.FilteredSceneProcessor ) and output.isSame( node["filter"] ) :
+					scenes.append( node["in"] )
+				walkOutputs( output )
+
+		walkOutputs( filter["out"] )
+
+	pathMatcher = GafferScene.PathMatcher()
 	with context :
-		pathMatcher = GafferScene.PathMatcher()
-		GafferScene.matchingPaths( node["filter"], node["in"], pathMatcher )
-		context["ui:scene:selectedPaths"] = IECore.StringVectorData( pathMatcher.paths() )
+		for scene in scenes :
+			GafferScene.matchingPaths( filter, scene, pathMatcher )
+
+	context["ui:scene:selectedPaths"] = IECore.StringVectorData( pathMatcher.paths() )
 
 def appendNodeContextMenuDefinitions( nodeGraph, node, menuDefinition ) :
 
-	if not isinstance( node, GafferScene.FilteredSceneProcessor ) :
+	if not isinstance( node, ( GafferScene.FilteredSceneProcessor, GafferScene.Filter ) ) :
 		return
 
 	menuDefinition.append( "/FilteredSceneProcessorDivider", { "divider" : True } )

--- a/startup/gui/nodeEditor.py
+++ b/startup/gui/nodeEditor.py
@@ -34,9 +34,13 @@
 #
 ##########################################################################
 
+import GafferUI
+import GafferSceneUI
+
 def __toolMenu( nodeEditor, node, menuDefinition ) :
 
 	GafferUI.UIEditor.appendNodeEditorToolMenuDefinitions( nodeEditor, node, menuDefinition )
 	GafferUI.BoxUI.appendNodeEditorToolMenuDefinitions( nodeEditor, node, menuDefinition )
+	GafferSceneUI.FilteredSceneProcessorUI.appendNodeEditorToolMenuDefinitions( nodeEditor, node, menuDefinition )
 
 __nodeEditorToolMenuConnection = GafferUI.NodeEditor.toolMenuSignal().connect( __toolMenu )


### PR DESCRIPTION
This adds the "Selected Affected Objects" menu item to Filter nodes in the NodeGraph, where it selects the union of all the objects affected by all the nodes the filter is attached to. It also adds the same menu item into the NodeEditor tool menu.