### PR TITLE
FileSystemPathTest : Fixed testModificationTimes().

### DIFF
--- a/include/Gaffer/FileSystemPath.h
+++ b/include/Gaffer/FileSystemPath.h
@@ -59,6 +59,12 @@ class FileSystemPath : public Path
 		virtual bool isValid() const;
 		virtual bool isLeaf() const;
 		virtual void propertyNames( std::vector<IECore::InternedString> &names ) const;
+		/// Supported properties :
+		///
+		/// "fileSystem:owner" -> StringData
+		/// "fileSystem:group" -> StringData
+		/// "fileSystem:modificationTime" -> DateTimeData, in UTC time
+		/// "fileSystem:size" -> UInt64Data, in bytes
 		virtual IECore::ConstRunTimeTypedPtr property( const IECore::InternedString &name ) const;
 		virtual PathPtr copy() const;
 

--- a/python/GafferTest/FileSystemPathTest.py
+++ b/python/GafferTest/FileSystemPathTest.py
@@ -183,7 +183,7 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 
 		mt = p.property( "fileSystem:modificationTime" )
 		self.assertTrue( isinstance( mt, datetime.datetime ) )
-		self.assertTrue( (mt - datetime.datetime.now()).total_seconds() < 0.1 )
+		self.assertTrue( (datetime.datetime.utcnow() - mt).total_seconds() < 1 )
 
 		time.sleep( 1 )
 
@@ -192,7 +192,7 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 
 		mt = p.property( "fileSystem:modificationTime" )
 		self.assertTrue( isinstance( mt, datetime.datetime ) )
-		self.assertTrue( (mt - datetime.datetime.now()).total_seconds() < 0.1 )
+		self.assertTrue( (datetime.datetime.utcnow() - mt).total_seconds() < 1 )
 
 	def testOwner( self ) :
 


### PR DESCRIPTION
I'm not sure I've ever packed so many bugs into one line before. First off, I was subtracting "now" from a time known to have occurred previously, which would naturally give us a negative number. You might think that therefore the test would always pass, but it failed in Canada. This was because the FileSystemPath class returns UTC time, but python's `datetime.now()` returns local time. So in timezones with a positive offset from UTC we were comparing a large negative number of seconds, and in timezones with a negative offset in UTC we were comparing a large positive number of seconds, and getting a failure. Finally, the threshold for the comparison was smaller than a second, but the filesystem on OS X only has second resolution, so the threshold needed raising.

Also documented the available FileSystemPath properties, including the fact that UTC time is used, to help avoid similar mistakes in the future.