### PR TITLE
manual string comparison in context::hash

### DIFF
--- a/src/Gaffer/Context.cpp
+++ b/src/Gaffer/Context.cpp
@@ -230,11 +230,16 @@ IECore::MurmurHash Context::hash() const
 		/// \todo Perhaps at some point the UI should use a different container for
 		/// these "not computationally important" values, so we wouldn't have to skip
 		/// them here.
-		if( it->first.string().compare( 0, 3, "ui:" ) )
+		const std::string& name = it->first.string();
+		if(	name.size() > 2 &&
+			name[0] == 'u' &&
+			name[1] == 'i' &&
+			name[2] == ':' )
 		{
-			m_hash.append( it->first );
-			it->second.data->hash( m_hash );
+			continue;
 		}
+		m_hash.append( it->first );
+		it->second.data->hash( m_hash );
 	}
 	m_hashValid = true;
 	return m_hash;


### PR DESCRIPTION
This knocked about 1.6 seconds off a 40 second scene traversal, so why not