### PR TITLE
using ets keys for ValuePlug and Context

### DIFF
--- a/src/Gaffer/Context.cpp
+++ b/src/Gaffer/Context.cpp
@@ -475,7 +475,7 @@ void Context::substituteInternal( const char *s, std::string &result, const int 
 //////////////////////////////////////////////////////////////////////////
 
 typedef std::stack<const Context *> ContextStack;
-typedef tbb::enumerable_thread_specific<ContextStack> ThreadSpecificContextStack;
+typedef tbb::enumerable_thread_specific<ContextStack, tbb::cache_aligned_allocator<ContextStack>, tbb::ets_key_per_instance> ThreadSpecificContextStack;
 
 static ThreadSpecificContextStack g_threadContexts;
 static ContextPtr g_defaultContext = new Context;

--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -446,7 +446,7 @@ class ValuePlug::Computation
 			const Plug *errorSource;
 		};
 
-		static tbb::enumerable_thread_specific<ThreadData> g_threadData;
+		static tbb::enumerable_thread_specific<ThreadData, tbb::cache_aligned_allocator<ThreadData>, tbb::ets_key_per_instance > g_threadData;
 
 		const ValuePlug *m_resultPlug;
 		const IECore::MurmurHash *m_precomputedHash;
@@ -467,7 +467,7 @@ class ValuePlug::Computation
 
 };
 
-tbb::enumerable_thread_specific<ValuePlug::Computation::ThreadData> ValuePlug::Computation::g_threadData;
+tbb::enumerable_thread_specific<ValuePlug::Computation::ThreadData, tbb::cache_aligned_allocator<ValuePlug::Computation::ThreadData>, tbb::ets_key_per_instance > ValuePlug::Computation::g_threadData;
 ValuePlug::Computation::ValueCache ValuePlug::Computation::g_valueCache( nullGetter, 1024 * 1024 * 500 );
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Here are some scene traversal times (averages over 4 runs on my highly instanced test scene):

no modifications:  42.6 sec
ets key on ValuePlug:  41.5 sec
+ ets key on Context:  39.9 sec