### PR TITLE
UIEditor improvements

### DIFF
--- a/include/Gaffer/Metadata.h
+++ b/include/Gaffer/Metadata.h
@@ -93,6 +93,12 @@ class Metadata
 		template<typename T>
 		static typename T::ConstPtr nodeValue( const Node *node, IECore::InternedString key, bool inherit = true, bool instanceOnly = false );
 
+		/// Deregisters a previously registered node value.
+		static void deregisterNodeValue( IECore::TypeId nodeTypeId, IECore::InternedString key );
+		/// Deregisters a previously registered node value.
+		/// \undoable
+		static void deregisterNodeValue( Node *node, IECore::InternedString key );
+
 		/// Utility method calling registerNodeValue( nodeTypeId, "description", description ).
 		static void registerNodeDescription( IECore::TypeId nodeTypeId, const std::string &description );
 		static void registerNodeDescription( IECore::TypeId nodeTypeId, NodeValueFunction description );
@@ -119,6 +125,12 @@ class Metadata
 		/// then the search falls through to the base classes of the node if the node itself doesn't have a value.
 		template<typename T>
 		static typename T::ConstPtr plugValue( const Plug *plug, IECore::InternedString key, bool inherit = true, bool instanceOnly = false );
+
+		/// Deregisters a previously registered plug value.
+		static void deregisterPlugValue( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, IECore::InternedString key );
+		/// Deregisters a previously registered plug value.
+		/// \undoable
+		static void deregisterPlugValue( Plug *plug, IECore::InternedString key );
 
 		/// Utility function calling registerPlugValue( nodeTypeId, plugPath, "description", description )
 		static void registerPlugDescription( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, const std::string &description );

--- a/python/GafferArnoldUI/ArnoldRenderUI.py
+++ b/python/GafferArnoldUI/ArnoldRenderUI.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import IECore
+
 import Gaffer
 import GafferUI
 import GafferArnold
@@ -75,6 +77,7 @@ Gaffer.Metadata.registerNode(
 			"preset:Generate expanded .ass", "expand",
 
 			"nodule:type", "",
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 
 		],
 
@@ -86,6 +89,10 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"nodule:type", "",
+			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
+			"pathPlugValueWidget:bookmarks", "ass",
+			"pathPlugValueWidget:leaf", True,
+			"fileSystemPathPlugValueWidget:extensions", IECore.StringVectorData( [ "ass" ] ),
 
 		],
 
@@ -105,33 +112,10 @@ Gaffer.Metadata.registerNode(
 			"preset:6", 6,
 
 			"nodule:type", "",
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 
 		],
 
-}
+	}
 
-)
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferArnold.ArnoldRender,
-	"mode",
-	GafferUI.PresetsPlugValueWidget,
-)
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferArnold.ArnoldRender,
-	"fileName",
-	lambda plug : GafferUI.PathPlugValueWidget( plug,
-		path = Gaffer.FileSystemPath( "/", filter = Gaffer.FileSystemPath.createStandardFilter() ),
-		pathChooserDialogueKeywords = {
-			"bookmarks" : GafferUI.Bookmarks.acquire( plug, category = "ass" ),
-			"leaf" : True,
-		},
-	),
-)
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferArnold.ArnoldRender,
-	"verbosity",
-	GafferUI.PresetsPlugValueWidget,
 )

--- a/python/GafferCortexUI/ObjectReaderUI.py
+++ b/python/GafferCortexUI/ObjectReaderUI.py
@@ -62,6 +62,12 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"nodule:type", "",
+			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
+			"pathPlugValueWidget:leaf", True,
+			"pathPlugValueWidget:valid", True,
+			"pathPlugValueWidget:bookmarks", "cortex",
+			"fileSystemPathPlugValueWidget:extensions", IECore.StringVectorData( IECore.Reader.supportedExtensions() ),
+			"fileSystemPathPlugValueWidget:extensionsLabel", "Show only supported files",
 
 		],
 
@@ -74,6 +80,8 @@ Gaffer.Metadata.registerNode(
 			module.
 			""",
 
+			"plugValueWidget:type", "",
+
 		]
 
 	}
@@ -84,28 +92,8 @@ Gaffer.Metadata.registerNode(
 # PlugValueWidgets
 ##########################################################################
 
-GafferUI.PlugValueWidget.registerCreator(
-	GafferCortex.ObjectReader,
-	"fileName",
-	lambda plug : GafferUI.PathPlugValueWidget(
-		plug,
-		path = Gaffer.FileSystemPath(
-			"/",
-			filter = Gaffer.FileSystemPath.createStandardFilter(
-				extensions = IECore.Reader.supportedExtensions(),
-				extensionsLabel = "Show only supported files",
-			),
-		),
-		pathChooserDialogueKeywords = {
-			"bookmarks" : GafferUI.Bookmarks.acquire( plug, category = "cortex" ),
-			"leaf" : True,
-		},
-	),
-)
-
 def __createParameterWidget( plug ) :
 
 	return GafferCortexUI.CompoundParameterValueWidget( plug.node().parameterHandler(), collapsible=False )
 
 GafferUI.PlugValueWidget.registerCreator( GafferCortex.ObjectReader, "parameters", __createParameterWidget )
-GafferUI.PlugValueWidget.registerCreator( GafferCortex.ObjectReader, "out", None )

--- a/python/GafferCortexUI/ObjectWriterUI.py
+++ b/python/GafferCortexUI/ObjectWriterUI.py
@@ -61,6 +61,8 @@ Gaffer.Metadata.registerNode(
 			The object to be written to disk.
 			""",
 
+			"plugValueWidget:type", "",
+
 		],
 
 		"fileName" : [
@@ -71,6 +73,11 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"nodule:type", "",
+			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
+			"pathPlugValueWidget:leaf", True,
+			"pathPlugValueWidget:bookmarks", "cortex",
+			"fileSystemPathPlugValueWidget:extensions", IECore.StringVectorData( IECore.Reader.supportedExtensions() ),
+			"fileSystemPathPlugValueWidget:extensionsLabel", "Show only supported files",
 
 		],
 
@@ -99,24 +106,4 @@ def __createParameterWidget( plug ) :
 
 	return GafferCortexUI.CompoundParameterValueWidget( plug.node().parameterHandler(), collapsible=False )
 
-GafferUI.PlugValueWidget.registerCreator(
-	GafferCortex.ObjectWriter.staticTypeId(),
-	"fileName",
-	lambda plug : GafferUI.PathPlugValueWidget(
-		plug,
-		path = Gaffer.FileSystemPath(
-			"/",
-			filter = Gaffer.FileSystemPath.createStandardFilter(
-				extensions = IECore.Reader.supportedExtensions(),
-				extensionsLabel = "Show only supported files",
-			),
-		),
-		pathChooserDialogueKeywords = {
-			"bookmarks" : GafferUI.Bookmarks.acquire( plug, category = "cortex" ),
-			"leaf" : True,
-		},
-	),
-)
-
 GafferUI.PlugValueWidget.registerCreator( GafferCortex.ObjectWriter, "parameters", __createParameterWidget )
-GafferUI.PlugValueWidget.registerCreator( GafferCortex.ObjectWriter, "in", None )

--- a/python/GafferImageUI/DeleteChannelsUI.py
+++ b/python/GafferImageUI/DeleteChannelsUI.py
@@ -63,6 +63,8 @@ Gaffer.Metadata.registerNode(
 			"preset:Delete", GafferImage.DeleteChannels.Mode.Delete,
 			"preset:Keep", GafferImage.DeleteChannels.Mode.Keep,
 
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
 		],
 
 		"channels" : [
@@ -79,5 +81,4 @@ Gaffer.Metadata.registerNode(
 
 )
 
-GafferUI.PlugValueWidget.registerCreator( GafferImage.DeleteChannels, "mode", GafferUI.PresetsPlugValueWidget )
 GafferUI.PlugValueWidget.registerCreator( GafferImage.DeleteChannels, "channels", GafferImageUI.ChannelMaskPlugValueWidget, inputImagePlug = "in" )

--- a/python/GafferImageUI/ImageReaderUI.py
+++ b/python/GafferImageUI/ImageReaderUI.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import IECore
+
 import Gaffer
 import GafferUI
 import GafferImage
@@ -59,6 +61,12 @@ Gaffer.Metadata.registerNode(
 			as a placeholder for the frame numbers.
 			""",
 
+			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
+			"pathPlugValueWidget:leaf", True,
+			"pathPlugValueWidget:bookmarks", "image",
+			"fileSystemPathPlugValueWidget:extensions", IECore.StringVectorData( GafferImage.ImageReader.supportedExtensions() ),
+			"fileSystemPathPlugValueWidget:extensionsLabel", "Show only image files",
+
 		],
 
 		"refreshCount" : [
@@ -74,24 +82,6 @@ Gaffer.Metadata.registerNode(
 
 	}
 
-)
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferImage.ImageReader,
-	"fileName",
-	lambda plug : GafferUI.PathPlugValueWidget( plug,
-		path = Gaffer.FileSystemPath(
-			"/",
-			filter = Gaffer.FileSystemPath.createStandardFilter(
-				extensions = GafferImage.ImageReader.supportedExtensions(),
-				extensionsLabel = "Show only image files",
-			)
-		),
-		pathChooserDialogueKeywords = {
-			"bookmarks" : GafferUI.Bookmarks.acquire( plug, category = "image" ),
-			"leaf" : True,
-		},
-	)
 )
 
 GafferUI.PlugValueWidget.registerCreator( GafferImage.ImageReader, "refreshCount", GafferUI.IncrementingPlugValueWidget, label = "Refresh", undoable = False )

--- a/python/GafferImageUI/ImageTransformUI.py
+++ b/python/GafferImageUI/ImageTransformUI.py
@@ -62,6 +62,8 @@ Gaffer.Metadata.registerNode(
 			value is specified in degrees.
 			""",
 
+			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
+
 		],
 
 		"filter" : [
@@ -78,5 +80,3 @@ Gaffer.Metadata.registerNode(
 	}
 
 )
-
-GafferUI.PlugValueWidget.registerCreator( GafferImage.ImageTransform, "transform", GafferUI.LayoutPlugValueWidget )

--- a/python/GafferImageUI/ImageWriterUI.py
+++ b/python/GafferImageUI/ImageWriterUI.py
@@ -91,6 +91,7 @@ Gaffer.Metadata.registerNode(
 			"preset:Tile", 1,
 
 			"nodule:type", "",
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 
 		],
 
@@ -139,4 +140,3 @@ GafferUI.PlugValueWidget.registerCreator(
 )
 
 GafferUI.PlugValueWidget.registerCreator( GafferImage.ImageWriter, "channels", GafferImageUI.ChannelMaskPlugValueWidget, inputImagePlug = "in" )
-GafferUI.PlugValueWidget.registerCreator( GafferImage.ImageWriter, "writeMode", GafferUI.PresetsPlugValueWidget )

--- a/python/GafferImageUI/ImageWriterUI.py
+++ b/python/GafferImageUI/ImageWriterUI.py
@@ -34,7 +34,7 @@
 #
 ##########################################################################
 
-import fnmatch
+import IECore
 
 import Gaffer
 import GafferUI
@@ -73,6 +73,11 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"nodule:type", "",
+			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
+			"pathPlugValueWidget:leaf", True,
+			"pathPlugValueWidget:bookmarks", "image",
+			"fileSystemPathPlugValueWidget:extensions", IECore.StringVectorData( GafferImage.ImageReader.supportedExtensions() ),
+			"fileSystemPathPlugValueWidget:extensionsLabel", "Show only image files",
 
 		],
 
@@ -119,24 +124,6 @@ Gaffer.Metadata.registerNode(
 
 	}
 
-)
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferImage.ImageWriter,
-	"fileName",
-	lambda plug : GafferUI.PathPlugValueWidget( plug,
-		path = Gaffer.FileSystemPath(
-			"/",
-			filter = Gaffer.FileSystemPath.createStandardFilter(
-				extensions = GafferImage.ImageReader.supportedExtensions(),
-				extensionsLabel = "Show only image files",
-			)
-		),
-		pathChooserDialogueKeywords = {
-			"bookmarks" : GafferUI.Bookmarks.acquire( plug, category = "image" ),
-			"leaf" : True,
-		},
-	)
 )
 
 GafferUI.PlugValueWidget.registerCreator( GafferImage.ImageWriter, "channels", GafferImageUI.ChannelMaskPlugValueWidget, inputImagePlug = "in" )

--- a/python/GafferImageUI/MergeUI.py
+++ b/python/GafferImageUI/MergeUI.py
@@ -101,10 +101,10 @@ Gaffer.Metadata.registerNode(
 			"preset:Subtract", GafferImage.Merge.Operation.Subtract,
 			"preset:Under", GafferImage.Merge.Operation.Under,
 
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
 		],
 
 	}
 
 )
-
-GafferUI.PlugValueWidget.registerCreator( GafferImage.Merge, "operation", GafferUI.PresetsPlugValueWidget )

--- a/python/GafferImageUI/OpenColorIOUI.py
+++ b/python/GafferImageUI/OpenColorIOUI.py
@@ -78,6 +78,8 @@ Gaffer.Metadata.registerNode(
 			"presetNames", __colorSpacePresetNames,
 			"presetValues", __colorSpacePresetValues,
 
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
 		],
 
 		"outputSpace" : [
@@ -90,15 +92,10 @@ Gaffer.Metadata.registerNode(
 			"presetNames", __colorSpacePresetNames,
 			"presetValues", __colorSpacePresetValues,
 
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
 		]
 
 	}
 
 )
-
-for plugName in ( "inputSpace", "outputSpace" ) :
-	GafferUI.PlugValueWidget.registerCreator(
-		GafferImage.OpenColorIO,
-		plugName,
-		GafferUI.PresetsPlugValueWidget,
-	)

--- a/python/GafferOSLUI/OSLShaderUI.py
+++ b/python/GafferOSLUI/OSLShaderUI.py
@@ -125,7 +125,7 @@ Gaffer.Metadata.registerPlugValue( GafferOSL.OSLShader, "parameters.*", "label",
 Gaffer.Metadata.registerPlugValue( GafferOSL.OSLShader, "parameters.*", "divider", __plugDivider )
 Gaffer.Metadata.registerPlugValue( GafferOSL.OSLShader, "parameters.*", "presetNames", __plugPresetNames )
 Gaffer.Metadata.registerPlugValue( GafferOSL.OSLShader, "parameters.*", "presetValues", __plugPresetValues )
-Gaffer.Metadata.registerPlugValue( GafferOSL.OSLShader, "parameters.*", "layout:widgetType", __plugWidgetType )
+Gaffer.Metadata.registerPlugValue( GafferOSL.OSLShader, "parameters.*", "plugValueWidget:type", __plugWidgetType )
 
 ##########################################################################
 # Nodules

--- a/python/GafferRenderManUI/RenderManOptionsUI.py
+++ b/python/GafferRenderManUI/RenderManOptionsUI.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import IECore
+
 import Gaffer
 import GafferUI
 import GafferRenderMan
@@ -155,6 +157,8 @@ Gaffer.Metadata.registerNode(
 			"preset:Hidden", "hidden",
 			"preset:Raytrace", "raytrace",
 
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
 		],
 
 		"options.hiderDepthFilter" : [
@@ -177,6 +181,8 @@ Gaffer.Metadata.registerNode(
 			"preset:Max", "max",
 			"preset:Average", "average",
 			"preset:Midpoint", "midpoint",
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 
 		],
 
@@ -267,6 +273,8 @@ Gaffer.Metadata.registerNode(
 			"preset:2", 2,
 			"preset:3 (Most Verbose)", 3,
 
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
 		],
 
 		"options.statisticsFileName" : [
@@ -279,6 +287,15 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "Statistics",
 			"label", "File Name",
+
+		],
+
+		"options.statisticsFileName.value" : [
+
+			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
+			"pathPlugValueWidget:leaf", True,
+			"pathPlugValueWidget:bookmarks", "statistics",
+			"fileSystemPathPlugValueWidget:extensions", IECore.StringVectorData( [ "htm", "html", "txt", "stats" ] ),
 
 		],
 
@@ -373,34 +390,4 @@ Gaffer.Metadata.registerNode(
 
 	}
 
-)
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferRenderMan.RenderManOptions,
-	"options.hider.value",
-	GafferUI.PresetsPlugValueWidget,
-)
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferRenderMan.RenderManOptions,
-	"options.hiderDepthFilter.value",
-	GafferUI.PresetsPlugValueWidget,
-)
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferRenderMan.RenderManOptions,
-	"options.statisticsLevel.value",
-	GafferUI.PresetsPlugValueWidget,
-)
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferRenderMan.RenderManOptions,
-	"options.statisticsFileName.value",
-	lambda plug : GafferUI.PathPlugValueWidget( plug,
-		path = Gaffer.FileSystemPath( "/", filter = Gaffer.FileSystemPath.createStandardFilter( extensions = ( "htm", "html", "txt", "stats" ) ) ),
-		pathChooserDialogueKeywords = {
-			"bookmarks" : GafferUI.Bookmarks.acquire( plug, category = "statistics" ),
-			"leaf" : True,
-		},
-	)
 )

--- a/python/GafferRenderManUI/RenderManRenderUI.py
+++ b/python/GafferRenderManUI/RenderManRenderUI.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import IECore
+
 import Gaffer
 import GafferUI
 import GafferRenderMan
@@ -74,6 +76,8 @@ Gaffer.Metadata.registerNode(
 			"preset:Generate RIB only", "generate",
 
 			"nodule:type", "",
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
 
 		],
 
@@ -85,6 +89,10 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"nodule:type", "",
+			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
+			"pathPlugValueWidget:leaf", True,
+			"pathPlugValueWidget:bookmarks", "rib",
+			"fileSystemPathPlugValueWidget:extensions", IECore.StringVectorData( [ "rib" ] ),
 
 		],
 
@@ -104,22 +112,4 @@ Gaffer.Metadata.registerNode(
 
 	},
 
-)
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferRenderMan.RenderManRender,
-	"mode",
-	GafferUI.PresetsPlugValueWidget,
-)
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferRenderMan.RenderManRender,
-	"ribFileName",
-	lambda plug : GafferUI.PathPlugValueWidget( plug,
-		path = Gaffer.FileSystemPath( "/", filter = Gaffer.FileSystemPath.createStandardFilter() ),
-		pathChooserDialogueKeywords = {
-			"bookmarks" : GafferUI.Bookmarks.acquire( plug, category = "rib" ),
-			"leaf" : True,
-		},
-	),
 )

--- a/python/GafferSceneUI/AlembicSourceUI.py
+++ b/python/GafferSceneUI/AlembicSourceUI.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import IECore
+
 import Gaffer
 import GafferUI
 import GafferScene
@@ -65,6 +67,12 @@ Gaffer.Metadata.registerNode(
 			older HDF5 and newer Ogawa caches are supported.
 			""",
 
+			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
+			"pathPlugValueWidget:leaf", True,
+			"pathPlugValueWidget:valid", True,
+			"pathPlugValueWidget:bookmarks", "sceneCache",
+			"fileSystemPathPlugValueWidget:extensions", IECore.StringVectorData( [ "abc" ] ),
+
 		],
 
 		"refreshCount" : [
@@ -85,18 +93,6 @@ Gaffer.Metadata.registerNode(
 ##########################################################################
 # PlugValueWidgets
 ##########################################################################
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.AlembicSource,
-	"fileName",
-	lambda plug : GafferUI.PathPlugValueWidget( plug,
-		path = Gaffer.FileSystemPath( "/", filter = Gaffer.FileSystemPath.createStandardFilter( extensions = [ "abc" ] ) ),
-		pathChooserDialogueKeywords = {
-			"bookmarks" : GafferUI.Bookmarks.acquire( plug, category = "sceneCache" ),
-			"leaf" : True,
-		},
-	)
-)
 
 GafferUI.PlugValueWidget.registerCreator(
 	GafferScene.AlembicSource,

--- a/python/GafferSceneUI/AttributeVisualiserUI.py
+++ b/python/GafferSceneUI/AttributeVisualiserUI.py
@@ -89,6 +89,8 @@ Gaffer.Metadata.registerNode(
 			"preset:Random", GafferScene.AttributeVisualiser.Mode.Random,
 			"preset:Shader Node Color", GafferScene.AttributeVisualiser.Mode.ShaderNodeColor,
 
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
 		],
 
 		"min" : [
@@ -170,5 +172,3 @@ Gaffer.Metadata.registerNode(
 	}
 
 )
-
-GafferUI.PlugValueWidget.registerCreator( GafferScene.AttributeVisualiser, "mode", GafferUI.PresetsPlugValueWidget )

--- a/python/GafferSceneUI/BranchCreatorUI.py
+++ b/python/GafferSceneUI/BranchCreatorUI.py
@@ -52,18 +52,17 @@ Gaffer.Metadata.registerNode(
 	Base class for nodes creating a new branch in the scene hierarchy.
 	""",
 
-	# Deliberately not documenting parent plug, so that
-	# is given documentation more specific to each
-	# derived class.
+	plugs = {
 
-)
+		"parent" : [
 
-##########################################################################
-# Widgets and nodules
-##########################################################################
+			# Deliberately not documenting parent plug, so that
+			# it is given documentation more specific to each
+			# derived class.
 
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.BranchCreator,
-	"parent",
-	GafferSceneUI.ScenePathPlugValueWidget
+			"plugValueWidget:type", "GafferSceneUI.ScenePathPlugValueWidget",
+
+		],
+
+	}
 )

--- a/python/GafferSceneUI/CameraUI.py
+++ b/python/GafferSceneUI/CameraUI.py
@@ -64,6 +64,8 @@ Gaffer.Metadata.registerNode(
 			"preset:Perspective", "perspective",
 			"preset:Orthographic", "orthographic",
 
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
 		],
 
 		"fieldOfView" : [
@@ -89,9 +91,3 @@ Gaffer.Metadata.registerNode(
 	}
 
 )
-
-##########################################################################
-# Widgets and nodules
-##########################################################################
-
-GafferUI.PlugValueWidget.registerCreator( GafferScene.Camera, "projection", GafferUI.PresetsPlugValueWidget )

--- a/python/GafferSceneUI/ConstraintUI.py
+++ b/python/GafferSceneUI/ConstraintUI.py
@@ -65,6 +65,8 @@ Gaffer.Metadata.registerNode(
 			and targetOffset values before the constraint is applied.
 			""",
 
+			"plugValueWidget:type", "GafferSceneUI.ScenePathPlugValueWidget",
+
 		],
 
 		"targetMode" : [
@@ -79,6 +81,8 @@ Gaffer.Metadata.registerNode(
 			"preset:BoundMin", GafferScene.Constraint.TargetMode.BoundMin,
 			"preset:BoundMax", GafferScene.Constraint.TargetMode.BoundMax,
 			"preset:BoundCenter", GafferScene.Constraint.TargetMode.BoundCenter,
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 
 		],
 
@@ -95,20 +99,4 @@ Gaffer.Metadata.registerNode(
 
 	},
 
-)
-
-##########################################################################
-# PlugValueWidgets
-##########################################################################
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.Constraint,
-	"target",
-	GafferSceneUI.ScenePathPlugValueWidget
-)
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.Constraint,
-	"targetMode",
-	GafferUI.PresetsPlugValueWidget,
 )

--- a/python/GafferSceneUI/DuplicateUI.py
+++ b/python/GafferSceneUI/DuplicateUI.py
@@ -64,6 +64,10 @@ Gaffer.Metadata.registerNode(
 			For internal use only.
 			""",
 
+			# we hide the parent (which comes from the base class) because
+			# the value for it is computed from the target plug automatically.
+			"plugValueWidget:type", "",
+
 		],
 
 		"target" : [
@@ -72,6 +76,8 @@ Gaffer.Metadata.registerNode(
 			"""
 			The part of the scene to be duplicated.
 			""",
+
+			"plugValueWidget:type", "GafferSceneUI.ScenePathPlugValueWidget",
 
 		],
 
@@ -112,18 +118,4 @@ Gaffer.Metadata.registerNode(
 		],
 
 	}
-)
-
-##########################################################################
-# Widgets and nodules
-##########################################################################
-
-# we hide the parent (which comes from the base class) because the value for it is
-# computed from the target plug automatically.
-GafferUI.PlugValueWidget.registerCreator( GafferScene.Duplicate, "parent", None )
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.Duplicate,
-	"target",
-	GafferSceneUI.ScenePathPlugValueWidget
 )

--- a/python/GafferSceneUI/ExternalProceduralUI.py
+++ b/python/GafferSceneUI/ExternalProceduralUI.py
@@ -44,37 +44,56 @@ import GafferScene
 # Metadata
 ##########################################################################
 
-Gaffer.Metadata.registerNodeDescription(
+Gaffer.Metadata.registerNode(
 
-GafferScene.ExternalProcedural,
+	GafferScene.ExternalProcedural,
 
-"""References external geometry procedurals and archives.""",
+	"description",
+	"""
+	References external geometry procedurals and archives.
+	""",
 
-"fileName",
-"The path to the external procedural or archive.",
+	plugs = {
 
-"bound",
-"The bounding box of the external procedural or archive.",
+		"fileName" : [
 
-"parameters",
-"An arbitrary set of parameters to be passed to the external procedural."
+			"description",
+			"""
+			The path to the external procedural or archive.
+			""",
+
+			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
+			"pathPlugValueWidget:leaf", True,
+			"pathPlugValueWidget:bookmarks", "procedurals",
+
+
+		],
+
+		"bound" : [
+
+			"description",
+			"""
+			The bounding box of the external procedural or archive.
+			""",
+
+		],
+
+
+		"parameters" : [
+
+			"description",
+			"""
+			An arbitrary set of parameters to be passed to the external procedural.
+			""",
+
+		],
+
+	}
 
 )
 
 ##########################################################################
 # Widgets
 ##########################################################################
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.ExternalProcedural,
-	"fileName",
-	lambda plug : GafferUI.PathPlugValueWidget( plug,
-		path = Gaffer.FileSystemPath( "/", filter = Gaffer.FileSystemPath.createStandardFilter() ),
-		pathChooserDialogueKeywords = {
-			"bookmarks" : GafferUI.Bookmarks.acquire( plug, category = "procedurals" ),
-			"leaf" : True,
-		},
-	)
-)
 
 GafferUI.PlugValueWidget.registerCreator( GafferScene.ExternalProcedural, "parameters", GafferUI.CompoundDataPlugValueWidget, collapsed=None )

--- a/python/GafferSceneUI/FilterSwitchUI.py
+++ b/python/GafferSceneUI/FilterSwitchUI.py
@@ -50,6 +50,12 @@ Gaffer.Metadata.registerNode(
 
 	plugs = {
 
+		"in*" : [
+
+			"plugValueWidget:type", "",
+
+		],
+
 		"index" : [
 
 			"description",
@@ -61,12 +67,10 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"nodule:type", "",
+			"plugValueWidget:type", "GafferUI.NumericPlugValueWidget",
 
 		],
 
 	},
 
 )
-
-GafferUI.PlugValueWidget.registerCreator( GafferScene.Filter, "in", None )
-GafferUI.PlugValueWidget.registerCreator( GafferScene.Filter, "in[0-9]*", None )

--- a/python/GafferSceneUI/FilterUI.py
+++ b/python/GafferSceneUI/FilterUI.py
@@ -70,10 +70,10 @@ Gaffer.Metadata.registerNode(
 			the "filter" plug of a FilteredSceneProcessor.
 			""",
 
+			"plugValueWidget:type", "",
+
 		]
 
 	}
 
 )
-
-GafferUI.PlugValueWidget.registerCreator( GafferScene.Filter, "out", None )

--- a/python/GafferSceneUI/FilteredSceneProcessorUI.py
+++ b/python/GafferSceneUI/FilteredSceneProcessorUI.py
@@ -70,6 +70,7 @@ Gaffer.Metadata.registerNode(
 			"nodeGadget:nodulePosition", "right",
 			"layout:index", -3, # Just before the enabled plug,
 			"nodule:type", "GafferUI::StandardNodule",
+			"plugValueWidget:type", "GafferSceneUI.FilterPlugValueWidget",
 
 		],
 
@@ -78,14 +79,8 @@ Gaffer.Metadata.registerNode(
 )
 
 ##########################################################################
-# Widgets and Gadgets
+# Gadgets
 ##########################################################################
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.FilteredSceneProcessor,
-	"filter",
-	GafferSceneUI.FilterPlugValueWidget,
-)
 
 def __nodeGadget( node ) :
 

--- a/python/GafferSceneUI/GroupUI.py
+++ b/python/GafferSceneUI/GroupUI.py
@@ -56,6 +56,12 @@ Gaffer.Metadata.registerNode(
 
 	plugs = {
 
+		"in*" : [
+
+			"plugValueWidget:type", "",
+
+		],
+
 		"name" : [
 
 			"description",
@@ -79,10 +85,3 @@ Gaffer.Metadata.registerNode(
 	}
 
 )
-
-##########################################################################
-# Widgets and nodules
-##########################################################################
-
-
-GafferUI.PlugValueWidget.registerCreator( GafferScene.Group, "in[0-9]*", None )

--- a/python/GafferSceneUI/InstancerUI.py
+++ b/python/GafferSceneUI/InstancerUI.py
@@ -101,14 +101,10 @@ Gaffer.Metadata.registerNode(
 			variations.
 			""",
 
+			"plugValueWidget:type", "",
+
 		],
 
 	}
 
 )
-
-##########################################################################
-# Widgets and nodules
-##########################################################################
-
-GafferUI.PlugValueWidget.registerCreator( GafferScene.Instancer, "instance", None )

--- a/python/GafferSceneUI/InteractiveRenderUI.py
+++ b/python/GafferSceneUI/InteractiveRenderUI.py
@@ -93,6 +93,9 @@ Gaffer.Metadata.registerNode(
 			"preset:Running", GafferScene.InteractiveRender.State.Running,
 			"preset:Paused", GafferScene.InteractiveRender.State.Paused,
 
+			## \todo Make a custom UI with play/pause/stop/restart buttons.
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
 		],
 
 		"updateLights" : [
@@ -138,15 +141,4 @@ Gaffer.Metadata.registerNode(
 		],
 
 	}
-)
-
-##########################################################################
-# Widgets
-##########################################################################
-
-## \todo Make a custom UI with play/pause/stop/restart buttons.
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.InteractiveRender,
-	"state",
-	GafferUI.PresetsPlugValueWidget,
 )

--- a/python/GafferSceneUI/IsolateUI.py
+++ b/python/GafferSceneUI/IsolateUI.py
@@ -63,6 +63,8 @@ Gaffer.Metadata.registerNode(
 			this will be removed.
 			""",
 
+			"plugValueWidget:type", "GafferSceneUI.ScenePathPlugValueWidget",
+
 		],
 
 		"adjustBounds" : [
@@ -80,14 +82,4 @@ Gaffer.Metadata.registerNode(
 
 	}
 
-)
-
-##########################################################################
-# Widgets and nodules
-##########################################################################
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.Isolate,
-	"from",
-	GafferSceneUI.ScenePathPlugValueWidget
 )

--- a/python/GafferSceneUI/LightUI.py
+++ b/python/GafferSceneUI/LightUI.py
@@ -39,15 +39,28 @@ import GafferUI
 
 import GafferScene
 
-Gaffer.Metadata.registerNodeDescription(
+Gaffer.Metadata.registerNode(
 
-GafferScene.Light,
+	GafferScene.Light,
 
-"""Creates a scene with a single light in it.""",
+	"description",
+	"""
+	Creates a scene with a single light in it.
+	""",
 
-"parameters",
-"""The parameters of the light shader - these will vary based on the light type.""",
+	plugs = {
+
+		"parameters" : [
+
+			"description",
+			"""
+			The parameters of the light shader - these will vary based on the light type.
+			""",
+
+			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
+
+		],
+
+	}
 
 )
-
-GafferUI.PlugValueWidget.registerCreator( GafferScene.Light, "parameters", GafferUI.LayoutPlugValueWidget )

--- a/python/GafferSceneUI/MapProjectionUI.py
+++ b/python/GafferSceneUI/MapProjectionUI.py
@@ -65,6 +65,10 @@ Gaffer.Metadata.registerNode(
 			The location of the camera to use for the projection.
 			""",
 
+			"plugValueWidget:type", "GafferSceneUI.ScenePathPlugValueWidget",
+			"scenePathPlugValueWidget:setNames", IECore.StringVectorData( [ "__cameras" ] ),
+			"scenePathPlugValueWidget:setsLabel", "Show only cameras",
+
 		],
 
 		"sName" : [
@@ -93,26 +97,4 @@ Gaffer.Metadata.registerNode(
 
 	}
 
-)
-
-##########################################################################
-# PlugValueWidgets
-##########################################################################
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.MapProjection,
-	"camera",
-	GafferSceneUI.ScenePathPlugValueWidget
-)
-
-Gaffer.Metadata.registerPlugValue(
-	GafferScene.MapProjection,
-	"camera",
-	"scenePathPlugValueWidget:setNames", IECore.StringVectorData( [ "__cameras" ] )
-)
-
-Gaffer.Metadata.registerPlugValue(
-	GafferScene.MapProjection,
-	"camera",
-	"scenePathPlugValueWidget:setsLabel", "Show only cameras"
 )

--- a/python/GafferSceneUI/MeshTypeUI.py
+++ b/python/GafferSceneUI/MeshTypeUI.py
@@ -70,6 +70,8 @@ Gaffer.Metadata.registerNode(
 			"preset:Polygon", "linear",
 			"preset:Subdivision Surface", "catmullClark",
 
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
 		],
 
 		"calculatePolygonNormals" : [
@@ -100,9 +102,3 @@ Gaffer.Metadata.registerNode(
 	}
 
 )
-
-##########################################################################
-# Widgets and nodules
-##########################################################################
-
-GafferUI.PlugValueWidget.registerCreator( GafferScene.MeshType, "meshType", GafferUI.PresetsPlugValueWidget )

--- a/python/GafferSceneUI/OpenGLAttributesUI.py
+++ b/python/GafferSceneUI/OpenGLAttributesUI.py
@@ -299,6 +299,8 @@ Gaffer.Metadata.registerNode(
 			"preset:For Particles And Disks", "forParticlesAndDisks",
 			"preset:For All", "forAll",
 
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
 		],
 
 		"attributes.pointsPrimitiveGLPointWidth" : [
@@ -362,14 +364,4 @@ Gaffer.Metadata.registerNode(
 
 	}
 
-)
-
-##########################################################################
-# PlugValueWidgets
-##########################################################################
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.OpenGLAttributes,
-	"attributes.pointsPrimitiveUseGLPoints.value",
-	GafferUI.PresetsPlugValueWidget
 )

--- a/python/GafferSceneUI/OutputsUI.py
+++ b/python/GafferSceneUI/OutputsUI.py
@@ -85,6 +85,15 @@ Gaffer.Metadata.registerNode(
 			"preset:16 bit", IECore.IntVectorData( [ 0, 65535, 0, 65535 ] ),
 			"preset:Float", IECore.IntVectorData( [ 0, 0, 0, 0 ] ),
 
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
+		],
+
+		"outputs.*.fileName" : [
+
+			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
+			"pathPlugValueWidget:bookmarks", "image",
+			"pathPlugValueWidget:leaf", True,
 
 		],
 
@@ -254,22 +263,4 @@ GafferUI.PlugValueWidget.registerCreator(
 	"outputs.*.active",
 	GafferUI.BoolPlugValueWidget,
 	displayMode = GafferUI.BoolWidget.DisplayMode.Switch,
-)
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.Outputs,
-	re.compile( "outputs.*.parameters.quantize" ),
-	GafferUI.PresetsPlugValueWidget
-)
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.Outputs,
-	"outputs.*.name",
-	lambda plug : GafferUI.PathPlugValueWidget( plug,
-		path = Gaffer.FileSystemPath( "/", filter = Gaffer.FileSystemPath.createStandardFilter() ),
-		pathChooserDialogueKeywords = {
-			"bookmarks" : GafferUI.Bookmarks.acquire( plug, category = "image" ),
-			"leaf" : True,
-		},
-	)
 )

--- a/python/GafferSceneUI/ParentUI.py
+++ b/python/GafferSceneUI/ParentUI.py
@@ -70,15 +70,10 @@ Gaffer.Metadata.registerNode(
 			The child hierarchy to be parented.
 			""",
 
+			"plugValueWidget:type", ""
+
 		],
 
 	}
 
 )
-
-##########################################################################
-# Widgets and nodules
-##########################################################################
-
-GafferUI.PlugValueWidget.registerCreator( GafferScene.Parent, "child", None )
-

--- a/python/GafferSceneUI/PointsTypeUI.py
+++ b/python/GafferSceneUI/PointsTypeUI.py
@@ -65,9 +65,9 @@ Gaffer.Metadata.registerNode(
 			"preset:Patch", "patch",
 			"preset:Blobby", "blobby",
 
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
 		],
 
 	}
 )
-
-GafferUI.PlugValueWidget.registerCreator( GafferScene.PointsType, "type", GafferUI.PresetsPlugValueWidget )

--- a/python/GafferSceneUI/SceneReaderUI.py
+++ b/python/GafferSceneUI/SceneReaderUI.py
@@ -63,6 +63,13 @@ Gaffer.Metadata.registerNode(
 			in any of the formats supported by Cortex's SceneInterfaces.
 			""",
 
+			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
+			"pathPlugValueWidget:leaf", True,
+			"pathPlugValueWidget:valid", True,
+			"pathPlugValueWidget:bookmarks", "sceneCache",
+			"fileSystemPathPlugValueWidget:extensions", lambda plug : IECore.StringVectorData( IECore.SceneInterface.supportedExtensions() ),
+			"fileSystemPathPlugValueWidget:extensionsLabel", "Show only cache files",
+
 		],
 
 		"refreshCount" : [
@@ -93,18 +100,6 @@ Gaffer.Metadata.registerNode(
 ##########################################################################
 # Widgets
 ##########################################################################
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.SceneReader,
-	"fileName",
-	lambda plug : GafferUI.PathPlugValueWidget( plug,
-		path = Gaffer.FileSystemPath( "/", filter = Gaffer.FileSystemPath.createStandardFilter( extensions = IECore.SceneInterface.supportedExtensions() ) ),
-		pathChooserDialogueKeywords = {
-			"bookmarks" : GafferUI.Bookmarks.acquire( plug, category = "sceneCache" ),
-			"leaf" : True,
-		},
-	)
-)
 
 GafferUI.PlugValueWidget.registerCreator(
 	GafferScene.SceneReader,

--- a/python/GafferSceneUI/SceneSwitchUI.py
+++ b/python/GafferSceneUI/SceneSwitchUI.py
@@ -50,6 +50,12 @@ Gaffer.Metadata.registerNode(
 
 	plugs = {
 
+		"in*" : [
+
+			"plugValueWidget:type", "",
+
+		],
+
 		"index" : [
 
 			"description",
@@ -58,13 +64,12 @@ Gaffer.Metadata.registerNode(
 			of 0 chooses the first input, 1 the second and so on. Values
 			larger than the number of available inputs wrap back around to
 			the beginning.
-			"""
+			""",
+
+			"plugValueWidget:type", "GafferUI.NumericPlugValueWidget",
 
 		]
 
 	}
 
 )
-
-
-GafferUI.PlugValueWidget.registerCreator( GafferScene.SceneSwitch, "in[0-9]*", None )

--- a/python/GafferSceneUI/SceneWriterUI.py
+++ b/python/GafferSceneUI/SceneWriterUI.py
@@ -63,6 +63,11 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"nodule:type", "",
+			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
+			"pathPlugValueWidget:leaf", True,
+			"pathPlugValueWidget:bookmarks", "sceneCache",
+			"fileSystemPathPlugValueWidget:extensions", lambda plug : IECore.StringVectorData( IECore.SceneInterface.supportedExtensions( IECore.IndexedIO.OpenMode.Write ) ),
+			"fileSystemPathPlugValueWidget:extensionsLabel", "Show only cache files",
 
 		],
 
@@ -88,22 +93,4 @@ Gaffer.Metadata.registerNode(
 
 	}
 
-)
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.SceneWriter,
-	"fileName",
-	lambda plug : GafferUI.PathPlugValueWidget(
-		plug,
-		path = Gaffer.FileSystemPath(
-			"/",
-			filter = Gaffer.FileSystemPath.createStandardFilter(
-				extensions = IECore.SceneInterface.supportedExtensions( IECore.IndexedIO.OpenMode.Write )
-			)
-		),
-		pathChooserDialogueKeywords = {
-			"bookmarks" : GafferUI.Bookmarks.acquire( plug, category = "sceneCache" ),
-			"leaf" : True,
-		},
-	),
 )

--- a/python/GafferSceneUI/SeedsUI.py
+++ b/python/GafferSceneUI/SeedsUI.py
@@ -100,10 +100,10 @@ Gaffer.Metadata.registerNode(
 			"preset:Patch", "patch",
 			"preset:Blobby", "blobby",
 
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
 		]
 
 	}
 
 )
-
-GafferUI.PlugValueWidget.registerCreator( GafferScene.Seeds, "pointType", GafferUI.PresetsPlugValueWidget )

--- a/python/GafferSceneUI/SetUI.py
+++ b/python/GafferSceneUI/SetUI.py
@@ -76,6 +76,8 @@ Gaffer.Metadata.registerNode(
 			"preset:Add", GafferScene.Set.Mode.Add,
 			"preset:Remove", GafferScene.Set.Mode.Remove,
 
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
 		],
 
 		"name" : [
@@ -105,12 +107,6 @@ Gaffer.Metadata.registerNode(
 
 # PlugValueWidget registrations
 ##########################################################################
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.Set,
-	"mode",
-	GafferUI.PresetsPlugValueWidget,
-)
 
 def __pathsPlugWidgetCreator( plug ) :
 

--- a/python/GafferSceneUI/ShaderSwitchUI.py
+++ b/python/GafferSceneUI/ShaderSwitchUI.py
@@ -57,6 +57,7 @@ Gaffer.Metadata.registerNode(
 		"in*" : [
 
 			"nodeGadget:nodulePosition", "left",
+			"plugValueWidget:type", "",
 
 		],
 
@@ -78,19 +79,17 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"nodeGadget:nodulePosition", "right",
+			"plugValueWidget:type", "",
 
 		],
 
 		"index" : [
 
 			"nodule:type", "",
+			"plugValueWidget:type", "GafferUI.NumericPlugValueWidget",
 
 		],
 
 	},
 
 )
-
-GafferUI.PlugValueWidget.registerCreator( GafferScene.ShaderSwitch, "in", None )
-GafferUI.PlugValueWidget.registerCreator( GafferScene.ShaderSwitch, "in[0-9]*", None )
-GafferUI.PlugValueWidget.registerCreator( GafferScene.ShaderSwitch, "out", None )

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -74,6 +74,7 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "",
 			"nodule:type", "",
+			"plugValueWidget:type", "GafferSceneUI.ShaderUI._ShaderNamePlugValueWidget",
 
 		],
 
@@ -88,6 +89,7 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "",
 			"nodule:type", "",
+			"plugValueWidget:type", "",
 
 		],
 
@@ -102,6 +104,7 @@ Gaffer.Metadata.registerNode(
 			"nodule:type", "GafferUI::CompoundNodule",
 			"compoundNodule:orientation", "y",
 			"compoundNodule:spacing", 0.2,
+			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
 
 		],
 
@@ -124,6 +127,7 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"nodeGadget:nodulePosition", "right",
+			"plugValueWidget:type", "",
 
 		],
 
@@ -135,7 +139,7 @@ Gaffer.Metadata.registerNode(
 # PlugValueWidgets
 ##########################################################################
 
-class __ShaderNamePlugValueWidget( GafferUI.PlugValueWidget ) :
+class _ShaderNamePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __init__( self, plug, **kw ) :
 
@@ -174,11 +178,6 @@ class __ShaderNamePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		with Gaffer.UndoContext( node.ancestor( Gaffer.ScriptNode ) ) :
 			node.loadShader( node["name"].getValue(), keepExistingValues = True )
-
-GafferUI.PlugValueWidget.registerCreator( GafferScene.Shader, "name", __ShaderNamePlugValueWidget )
-GafferUI.PlugValueWidget.registerCreator( GafferScene.Shader, "parameters", GafferUI.LayoutPlugValueWidget )
-GafferUI.PlugValueWidget.registerCreator( GafferScene.Shader, "out", None )
-GafferUI.PlugValueWidget.registerCreator( GafferScene.Shader, "type", None )
 
 ##########################################################################
 # NodeFinderDialogue mode

--- a/python/GafferSceneUI/SphereUI.py
+++ b/python/GafferSceneUI/SphereUI.py
@@ -65,6 +65,8 @@ Gaffer.Metadata.registerNode(
 			"preset:Primitive", GafferScene.Sphere.Type.Primitive,
 			"preset:Mesh", GafferScene.Sphere.Type.Mesh,
 
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
 		],
 
 		"radius" : [
@@ -122,9 +124,3 @@ Gaffer.Metadata.registerNode(
 	}
 
 )
-
-##########################################################################
-# Widgets and nodules
-##########################################################################
-
-GafferUI.PlugValueWidget.registerCreator( GafferScene.Sphere, "type", GafferUI.PresetsPlugValueWidget )

--- a/python/GafferSceneUI/StandardOptionsUI.py
+++ b/python/GafferSceneUI/StandardOptionsUI.py
@@ -124,6 +124,14 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"options.renderCamera.value" : [
+
+			"plugValueWidget:type", "GafferSceneUI.ScenePathPlugValueWidget",
+			"scenePathPlugValueWidget:setNames", IECore.StringVectorData( [ "__cameras" ] ),
+			"scenePathPlugValueWidget:setsLabel", "Show only cameras",
+
+		],
+
 		"options.renderResolution" : [
 
 			"description",
@@ -305,26 +313,4 @@ Gaffer.Metadata.registerNode(
 
 	}
 
-)
-
-##########################################################################
-# PlugValueWidgets
-##########################################################################
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.StandardOptions,
-	"options.renderCamera.value",
-	GafferSceneUI.ScenePathPlugValueWidget
-)
-
-Gaffer.Metadata.registerPlugValue(
-	GafferScene.StandardOptions,
-	"options.renderCamera.value",
-	"scenePathPlugValueWidget:setNames", IECore.StringVectorData( [ "__cameras" ] )
-)
-
-Gaffer.Metadata.registerPlugValue(
-	GafferScene.StandardOptions,
-	"options.renderCamera.value",
-	"scenePathPlugValueWidget:setsLabel", "Show only cameras"
 )

--- a/python/GafferSceneUI/StandardOptionsUI.py
+++ b/python/GafferSceneUI/StandardOptionsUI.py
@@ -127,6 +127,7 @@ Gaffer.Metadata.registerNode(
 		"options.renderCamera.value" : [
 
 			"plugValueWidget:type", "GafferSceneUI.ScenePathPlugValueWidget",
+			"pathPlugValueWidget:valid", True,
 			"scenePathPlugValueWidget:setNames", IECore.StringVectorData( [ "__cameras" ] ),
 			"scenePathPlugValueWidget:setsLabel", "Show only cameras",
 

--- a/python/GafferSceneUI/SubTreeUI.py
+++ b/python/GafferSceneUI/SubTreeUI.py
@@ -62,6 +62,8 @@ Gaffer.Metadata.registerNode(
 			be discarded.
 			""",
 
+			"plugValueWidget:type", "GafferSceneUI.ScenePathPlugValueWidget",
+
 		],
 
 		"includeRoot" : [
@@ -81,14 +83,4 @@ Gaffer.Metadata.registerNode(
 
 	}
 
-)
-
-##########################################################################
-# Widgets and Gadgets
-##########################################################################
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.SubTree,
-	"root",
-	GafferSceneUI.ScenePathPlugValueWidget
 )

--- a/python/GafferSceneUI/TextUI.py
+++ b/python/GafferSceneUI/TextUI.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import IECore
+
 import Gaffer
 import GafferUI
 import GafferScene
@@ -73,25 +75,14 @@ Gaffer.Metadata.registerNode(
 			environment variable.
 			""",
 
+			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
+			"pathPlugValueWidget:bookmarks", "font",
+			"pathPlugValueWidget:leaf", True,
+			"pathPlugValueWidget:valid", True,
+			"fileSystemPathPlugValueWidget:extensions", IECore.StringVectorData( [ "ttf" ] ),
+
 		],
 
 	}
 
-)
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.Text,
-	"font",
-	lambda plug : GafferUI.PathPlugValueWidget( plug,
-		path = Gaffer.FileSystemPath(
-			"/",
-			filter = Gaffer.FileSystemPath.createStandardFilter(
-				extensions = [ "ttf" ],
-			)
-		),
-		pathChooserDialogueKeywords = {
-			"bookmarks" : GafferUI.Bookmarks.acquire( plug, category = "font" ),
-			"leaf" : True,
-		},
-	)
 )

--- a/python/GafferSceneUI/UnionFilterUI.py
+++ b/python/GafferSceneUI/UnionFilterUI.py
@@ -59,16 +59,10 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"nodule:type", "GafferUI::CompoundNodule",
+			"plugValueWidget:type", "",
 
 		],
 
 	}
 
 )
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.UnionFilter,
-	"in",
-	None,
-)
-

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -757,6 +757,99 @@ class MetadataTest( GafferTest.TestCase ) :
 		Gaffer.Metadata.registerNodeValue( n, "maskTest", None )
 		self.assertEqual( Gaffer.Metadata.nodeValue( n, "maskTest" ), None )
 
+	def testDeregisterNodeValue( self ) :
+
+		n = GafferTest.AddNode()
+		self.assertEqual( Gaffer.Metadata.nodeValue( n, "deleteMe" ), None )
+
+		Gaffer.Metadata.registerNodeValue( Gaffer.Node, "deleteMe", 10 )
+		self.assertEqual( Gaffer.Metadata.nodeValue( n, "deleteMe" ), 10 )
+
+		Gaffer.Metadata.registerNodeValue( Gaffer.ComputeNode, "deleteMe", 20 )
+		self.assertEqual( Gaffer.Metadata.nodeValue( n, "deleteMe" ), 20 )
+
+		Gaffer.Metadata.deregisterNodeValue( Gaffer.ComputeNode, "deleteMe" )
+		self.assertEqual( Gaffer.Metadata.nodeValue( n, "deleteMe" ), 10 )
+
+		Gaffer.Metadata.deregisterNodeValue( Gaffer.Node, "deleteMe" )
+		self.assertEqual( Gaffer.Metadata.nodeValue( n, "deleteMe" ), None )
+
+	def testDeregisterNodeInstanceValue( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["n"] = GafferTest.AddNode()
+
+		self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "deleteMe" ), None )
+
+		Gaffer.Metadata.registerNodeValue( GafferTest.AddNode, "deleteMe", 10 )
+		self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "deleteMe" ), 10 )
+
+		Gaffer.Metadata.registerNodeValue( s["n"], "deleteMe", 20 )
+		self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "deleteMe" ), 20 )
+		self.assertTrue( "Metadata" in s.serialise() )
+
+		with Gaffer.UndoContext( s ) :
+			Gaffer.Metadata.deregisterNodeValue( s["n"], "deleteMe" )
+			self.assertTrue( "Metadata" not in s.serialise() )
+			self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "deleteMe" ), 10 )
+
+		s.undo()
+		self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "deleteMe" ), 20 )
+		self.assertTrue( "Metadata" in s.serialise() )
+
+		s.redo()
+		self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "deleteMe" ), 10 )
+		self.assertTrue( "Metadata" not in s.serialise() )
+
+		Gaffer.Metadata.deregisterNodeValue( GafferTest.AddNode, "deleteMe" )
+		self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "deleteMe" ), None )
+
+		self.assertTrue( "Metadata" not in s.serialise() )
+
+	def testDeregisterPlugValue( self ) :
+
+		n = GafferTest.AddNode()
+		self.assertEqual( Gaffer.Metadata.plugValue( n["op1"], "deleteMe" ), None )
+
+		Gaffer.Metadata.registerPlugValue( Gaffer.Node, "op1", "deleteMe", 10 )
+		self.assertEqual( Gaffer.Metadata.plugValue( n["op1"], "deleteMe" ), 10 )
+
+		Gaffer.Metadata.deregisterPlugValue( Gaffer.Node, "op1", "deleteMe" )
+		self.assertEqual( Gaffer.Metadata.plugValue( n["op1"], "deleteMe" ), None )
+
+	def testDeregisterPlugInstanceValue( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["n"] = GafferTest.AddNode()
+
+		self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["op1"], "deleteMe" ), None )
+
+		Gaffer.Metadata.registerPlugValue( GafferTest.AddNode, "op1", "deleteMe", 10 )
+		self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["op1"], "deleteMe" ), 10 )
+		self.assertTrue( "Metadata" not in s.serialise() )
+
+		Gaffer.Metadata.registerPlugValue( s["n"]["op1"], "deleteMe", 20 )
+		self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["op1"], "deleteMe" ), 20 )
+		self.assertTrue( "Metadata" in s.serialise() )
+
+		with Gaffer.UndoContext( s ) :
+			Gaffer.Metadata.deregisterPlugValue( s["n"]["op1"], "deleteMe" )
+			self.assertTrue( "Metadata" not in s.serialise() )
+			self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["op1"], "deleteMe" ), 10 )
+
+		s.undo()
+		self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["op1"], "deleteMe" ), 20 )
+		self.assertTrue( "Metadata" in s.serialise() )
+
+		s.redo()
+		self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["op1"], "deleteMe" ), 10 )
+		self.assertTrue( "Metadata" not in s.serialise() )
+
+		Gaffer.Metadata.deregisterPlugValue( GafferTest.AddNode, "op1", "deleteMe" )
+		self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["op1"], "deleteMe" ), None )
+
+		self.assertTrue( "Metadata" not in s.serialise() )
+
 if __name__ == "__main__":
 	unittest.main()
 

--- a/python/GafferUI/DispatcherUI.py
+++ b/python/GafferUI/DispatcherUI.py
@@ -98,7 +98,10 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			A directory to store temporary files used by the dispatcher.
-			"""
+			""",
+
+			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
+			"pathPlugValueWidget:leaf", False,
 
 		),
 
@@ -462,17 +465,6 @@ class __FrameRangePlugValueWidget( GafferUI.StringPlugValueWidget ) :
 
 Gaffer.Metadata.registerPlugValue( Gaffer.ExecutableNode, "requirement", "layout:section", "" )
 Gaffer.Metadata.registerPlugDescription( Gaffer.ExecutableNode, "dispatcher.batchSize", "Maximum number of frames to batch together when dispatching execution tasks." )
-
-GafferUI.PlugValueWidget.registerCreator(
-	Gaffer.Dispatcher,
-	"jobsDirectory",
-	lambda plug : GafferUI.PathPlugValueWidget( plug,
-		path = Gaffer.FileSystemPath( "/", filter = Gaffer.FileSystemPath.createStandardFilter( [ "gfr" ] ) ),
-		pathChooserDialogueKeywords = {
-			"leaf" : False,
-		},
-	)
-)
 
 GafferUI.PlugValueWidget.registerCreator( Gaffer.Dispatcher, "user", None )
 GafferUI.PlugValueWidget.registerCreator( Gaffer.Dispatcher, "framesMode", __FramesModePlugValueWidget )

--- a/python/GafferUI/DotUI.py
+++ b/python/GafferUI/DotUI.py
@@ -57,16 +57,35 @@ def connect( applicationRoot ) :
 # Metadata
 ##########################################################################
 
-Gaffer.Metadata.registerNodeDescription(
+Gaffer.Metadata.registerNode(
 
-Gaffer.Dot,
+	Gaffer.Dot,
 
-"""A utility node which can be used for organising large graphs.""",
+	"description",
+	"""
+	A utility node which can be used for organising large graphs.
+	""",
+
+	"nodeGadget:minWidth", 0.0,
+	"nodeGadget:padding", 0.5,
+
+	plugs = {
+
+		"in" : [
+
+			"plugValueWidget:type", ""
+
+		],
+
+		"out" : [
+
+			"plugValueWidget:type", ""
+
+		],
+
+	},
 
 )
-
-Gaffer.Metadata.registerNodeValue( Gaffer.Dot, "nodeGadget:minWidth", 0.0 )
-Gaffer.Metadata.registerNodeValue( Gaffer.Dot, "nodeGadget:padding", 0.5 )
 
 ##########################################################################
 # NodeGraph menus
@@ -117,10 +136,3 @@ def __connectionContextMenu( nodeGraph, destinationPlug, menuDefinition ) :
 	)
 
 __connectionContextMenuConnection = GafferUI.NodeGraph.connectionContextMenuSignal().connect( __connectionContextMenu )
-
-##########################################################################
-# PlugValueWidget registrations
-##########################################################################
-
-GafferUI.PlugValueWidget.registerCreator( Gaffer.Dot, "in", None )
-GafferUI.PlugValueWidget.registerCreator( Gaffer.Dot, "out", None )

--- a/python/GafferUI/ExecutableNodeUI.py
+++ b/python/GafferUI/ExecutableNodeUI.py
@@ -63,6 +63,8 @@ Gaffer.Metadata.registerNode(
 			"nodule:type", "GafferUI::CompoundNodule",
 			"compoundNodule:spacing", 0.4,
 
+			"plugValueWidget:type", "",
+
 		),
 
 		"requirement" : (
@@ -92,9 +94,3 @@ Gaffer.Metadata.registerNode(
 	}
 
 )
-
-##########################################################################
-# Metadata, PlugValueWidgets and Nodules
-##########################################################################
-
-GafferUI.PlugValueWidget.registerCreator( Gaffer.ExecutableNode, "requirements", None )

--- a/python/GafferUI/FileSystemPathPlugValueWidget.py
+++ b/python/GafferUI/FileSystemPathPlugValueWidget.py
@@ -1,0 +1,63 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferUI
+
+## Supported plug metadata :
+#
+# - "fileSystemPathPlugValueWidget:extensions"
+# - "fileSystemPathPlugValueWidget:extensionsLabel"
+class FileSystemPathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
+
+	def __init__( self, plug, **kw ) :
+
+		extensions = Gaffer.Metadata.plugValue( plug, "fileSystemPathPlugValueWidget:extensions" ) or []
+		if isinstance( extensions, str ) :
+			extensions = extensions.split()
+
+		GafferUI.PathPlugValueWidget.__init__(
+			self,
+			plug,
+			Gaffer.FileSystemPath(
+				"/",
+				filter =  Gaffer.FileSystemPath.createStandardFilter(
+					list( extensions ),
+					Gaffer.Metadata.plugValue( plug, "fileSystemPathPlugValueWidget:extensionsLabel" ) or ""
+				)
+			),
+			**kw
+		)

--- a/python/GafferUI/LocalDispatcherUI.py
+++ b/python/GafferUI/LocalDispatcherUI.py
@@ -95,7 +95,7 @@ Gaffer.Metadata.registerNode(
 			Settings used by the local dispatcher.
 			""",
 
-			"layout:widgetType", "GafferUI.LayoutPlugValueWidget",
+			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
 			"layout:section", "Local",
 
 		],

--- a/python/GafferUI/NodeUI.py
+++ b/python/GafferUI/NodeUI.py
@@ -63,6 +63,7 @@ Gaffer.Metadata.registerNode(
 			"layout:index", -1, # Last
 			"layout:section", "User",
 			"nodule:type", "",
+			"plugValueWidget:type", "GafferUI.UserPlugValueWidget",
 
 		),
 

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -430,7 +430,7 @@ class PlugLayout( GafferUI.Widget ) :
 		if not self.visible() :
 			return
 
-		if plug is not None and not self.__parent.isSame( plug.parent() ) :
+		if plug is not None and not self.__parent.isSame( plug ) and not self.__parent.isSame( plug.parent() ) :
 			return
 			
 		if not self.__node().isInstanceOf( nodeTypeId ) :
@@ -440,6 +440,9 @@ class PlugLayout( GafferUI.Widget ) :
 			# we often see sequences of several metadata changes - so
 			# we schedule a lazy update to batch them into one ui update.
 			self.__layoutDirty = True
+			self.__updateLazily()
+		elif re.match( "layout:section:.*:summary", key ) :
+			self.__summariesDirty = True
 			self.__updateLazily()
 
 	def __plugDirtied( self, plug ) :

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -52,7 +52,6 @@ QtGui = GafferUI._qtImport( "QtGui" )
 #	- "layout:index" controls ordering of plugs within the layout
 #	- "layout:section" places the plug in a named section of the layout
 #	- "divider" specifies whether or not a plug should be followed by a divider
-#	- "layout:widgetType" the class name for the widget type of a particular plug
 #	- "layout:activator" the name of an activator to control editability
 #
 # Per-parent metadata support :
@@ -321,20 +320,9 @@ class PlugLayout( GafferUI.Widget ) :
 
  	def __createPlugWidget( self, plug ) :
 
-		widgetType = Gaffer.Metadata.plugValue( plug, "layout:widgetType" )
-		if widgetType is not None :
-
-			if widgetType == "None" :
-				return None
-			else :
-				widgetClass = self.__import( widgetType )
-				result = widgetClass( plug )
-
-		else :
-
-			result = GafferUI.PlugValueWidget.create( plug )
-			if result is None :
-				return result
+		result = GafferUI.PlugValueWidget.create( plug )
+		if result is None :
+			return result
 
 		if isinstance( result, GafferUI.PlugValueWidget ) and not result.hasLabel() and Gaffer.Metadata.plugValue( plug, "label" ) != "" :
  			result = GafferUI.PlugWidget( result )

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -566,6 +566,10 @@ class _TabLayout( _Layout ) :
 				for name, tab in updatedTabs.items() :
 					self.__tabbedContainer.append( tab, label = name )
 
+		for index, subsection in enumerate( section.subsections.values() ) :
+			## \todo Consider how/if we should add a public tooltip API to TabbedContainer.
+			self.__tabbedContainer._qtWidget().setTabToolTip( index, subsection.summary )
+
 		if not len( existingTabs ) :
 			currentTabIndex = self.__section.restoreState( "currentTab" ) or 0
 			if currentTabIndex < len( self.__tabbedContainer ) :

--- a/python/GafferUI/PreferencesUI.py
+++ b/python/GafferUI/PreferencesUI.py
@@ -56,7 +56,7 @@ Gaffer.Metadata.registerNode(
 
 		"user" : [
 
-			"layout:widgetType", "None",
+			"plugValueWidget:type", "",
 
 		],
 

--- a/python/GafferUI/RandomUI.py
+++ b/python/GafferUI/RandomUI.py
@@ -141,6 +141,8 @@ Gaffer.Metadata.registerNode(
 			and float range plugs.
 			""",
 
+			"plugValueWidget:type", "",
+
 		],
 
 		"outColor" : [
@@ -151,12 +153,13 @@ Gaffer.Metadata.registerNode(
 			colour, hue, saturation and value plugs.
 			""",
 
+			"plugValueWidget:type", "GafferUI.RandomUI._RandomColorPlugValueWidget",
+
 		]
 
 	}
 
 )
-
 
 # PlugValueWidget registrations
 ##########################################################################
@@ -186,9 +189,6 @@ class _RandomColorPlugValueWidget( GafferUI.PlugValueWidget ) :
 			for y in range( 0, gridSize.y ) :
 				self.__grid[x,y].setColor( node.randomColor( seed ) )
 				seed += 1
-
-GafferUI.PlugValueWidget.registerCreator( Gaffer.Random, "outColor", _RandomColorPlugValueWidget )
-GafferUI.PlugValueWidget.registerCreator( Gaffer.Random, "outFloat", None )
 
 # PlugValueWidget popup menu
 ##########################################################################

--- a/python/GafferUI/ScriptNodeUI.py
+++ b/python/GafferUI/ScriptNodeUI.py
@@ -67,6 +67,8 @@ Gaffer.Metadata.registerNode(
 			modified since it was last saved.
 			""",
 
+			"plugValueWidget:type", "",
+
 		),
 
 		"frameRange" : (
@@ -79,6 +81,8 @@ Gaffer.Metadata.registerNode(
 			ranges, and by the UI to define the range of the
 			time slider.
 			""",
+
+			"plugValueWidget:type", "GafferUI.CompoundNumericPlugValueWidget",
 
 		),
 
@@ -120,18 +124,6 @@ Gaffer.Metadata.registerNode(
 
 	},
 
-)
-
-GafferUI.PlugValueWidget.registerCreator(
-	Gaffer.ScriptNode,
-	"unsavedChanges",
-	None
-)
-
-GafferUI.PlugValueWidget.registerCreator(
-	Gaffer.ScriptNode,
-	"frameRange",
-	GafferUI.CompoundNumericPlugValueWidget
 )
 
 GafferUI.PlugValueWidget.registerCreator(

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -66,47 +66,29 @@ class UIEditor( GafferUI.NodeSetEditor ) :
 		with self.__tabbedContainer :
 
 			# Node tab
-			with GafferUI.GridContainer( spacing = 4, borderWidth = 8, parenting = { "label" : "Node" } ) as self.__nodeTab :
+			with GafferUI.ListContainer( spacing = 4, borderWidth = 8, parenting = { "label" : "Node" } ) as self.__nodeTab :
 
-				GafferUI.Label(
-					"Name",
-					parenting = {
-						"index" : ( 0, 0 ),
-						"alignment" : ( GafferUI.HorizontalAlignment.Right, GafferUI.VerticalAlignment.Center )
-					}
-				)
+				with _Row() :
 
-				self.__nodeNameWidget = GafferUI.NameWidget( None, parenting = { "index" : ( 1, 0 ) } )
+					_Label( "Name" )
 
-				GafferUI.Label(
-					"Description",
-					parenting = {
-						"index" : ( 0, 1 ),
-						"alignment" : ( GafferUI.HorizontalAlignment.Right, GafferUI.VerticalAlignment.Top )
-					}
-				)
+					self.__nodeNameWidget = GafferUI.NameWidget( None )
 
-				self.__nodeMetadataWidgets.append(
-					_MultiLineStringMetadataWidget(
-						key = "description",
-						parenting = { "index" : ( 1, 1 ) }
+				with _Row() :
+
+					_Label( "Description", parenting = { "verticalAlignment" : GafferUI.ListContainer.VerticalAlignment.Top } )
+
+					self.__nodeMetadataWidgets.append(
+						_MultiLineStringMetadataWidget( key = "description" )
 					)
-				)
 
-				GafferUI.Label(
-					"Color",
-					parenting = {
-						"index" : ( 0, 2 ),
-						"alignment" : ( GafferUI.HorizontalAlignment.Right, GafferUI.VerticalAlignment.Top )
-					}
-				)
+				with _Row() :
 
-				self.__nodeMetadataWidgets.append(
-					_ColorSwatchMetadataWidget(
-						key = "nodeGadget:color",
-						parenting = { "index" : ( 1, 2 ) }
+					_Label( "Color" )
+
+					self.__nodeMetadataWidgets.append(
+						_ColorSwatchMetadataWidget( key = "nodeGadget:color" )
 					)
-				)
 
 			# Plugs tab
 			with GafferUI.SplitContainer( orientation=GafferUI.SplitContainer.Orientation.Horizontal, borderWidth = 8, parenting = { "label" : "Plugs" } ) as self.__plugTab :
@@ -271,6 +253,28 @@ def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 	menuDefinition.append( "/Edit UI...", { "command" : IECore.curry( __editPlugUI, node, plug ), "active" : not plugValueWidget.getReadOnly() } )
 
 __plugPopupMenuConnection = GafferUI.PlugValueWidget.popupMenuSignal().connect( __plugPopupMenu )
+
+##########################################################################
+# Simple fixed width label and row classes
+##########################################################################
+
+class _Label( GafferUI.Label ) :
+
+	def __init__( self, *args, **kw ) :
+
+		GafferUI.Label.__init__(
+			self,
+			horizontalAlignment = GafferUI.Label.HorizontalAlignment.Right,
+			*args, **kw
+		)
+
+		self._qtWidget().setFixedWidth( 75 )
+
+class _Row( GafferUI.ListContainer ) :
+
+	def __init__( self, *args, **kw ) :
+
+		GafferUI.ListContainer.__init__( self, GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 )
 
 ##########################################################################
 # Hierarchical representation of a plug layout, suitable for manipulating
@@ -918,55 +922,34 @@ class _PlugEditor( GafferUI.Widget ) :
 
 	def __init__( self, **kw ) :
 
-		grid = GafferUI.GridContainer( spacing = 4, borderWidth = 8 )
-		GafferUI.Widget.__init__( self, grid, **kw )
+		column = GafferUI.ListContainer( spacing = 4, borderWidth = 8 )
+		GafferUI.Widget.__init__( self, column, **kw )
 
 		self.__metadataWidgets = []
 
-		with grid :
+		with column :
 
-			GafferUI.Label(
-				"Name",
-				parenting = {
-					"index" : ( 0, 0 ),
-					"alignment" : ( GafferUI.HorizontalAlignment.Right, GafferUI.VerticalAlignment.Center )
-				}
-			)
+			with _Row() :
 
-			self.__nameWidget = GafferUI.NameWidget( None, parenting = { "index" : ( 1, 0 ) } )
+				_Label( "Name" )
 
-			GafferUI.Label(
-				"Description",
-				parenting = {
-					"index" : ( 0, 1 ),
-					"alignment" : ( GafferUI.HorizontalAlignment.Right, GafferUI.VerticalAlignment.Top )
-				}
-			)
+				self.__nameWidget = GafferUI.NameWidget( None )
 
-			self.__metadataWidgets.append(
-				_MultiLineStringMetadataWidget(
-					key = "description",
-					parenting = { "index" : ( 1, 1 ) }
+			with _Row() :
+
+				_Label( "Description", parenting = { "verticalAlignment" : GafferUI.ListContainer.VerticalAlignment.Top } )
+
+				self.__metadataWidgets.append(
+					_MultiLineStringMetadataWidget( key = "description" )
 				)
-			)
 
-			GafferUI.Label(
-				"Divider",
-				parenting = {
-					"index" : ( 0, 2 ),
-					"alignment" : ( GafferUI.HorizontalAlignment.Right, GafferUI.VerticalAlignment.Center )
-				}
-			)
+			with _Row() :
 
-			self.__metadataWidgets.append(
-				_BoolMetadataWidget(
-					key = "divider",
-					parenting = {
-						"index" : ( 1, 2 ),
-						"alignment" : ( GafferUI.HorizontalAlignment.Left, GafferUI.VerticalAlignment.Center )
-					}
+				_Label( "Divider" )
+
+				self.__metadataWidgets.append(
+					_BoolMetadataWidget( key = "divider" )
 				)
-			)
 
 		self.__plug = None
 
@@ -993,34 +976,23 @@ class _SectionEditor( GafferUI.Widget ) :
 
 	def __init__( self, **kw ) :
 
-		grid = GafferUI.GridContainer( spacing = 4, borderWidth = 8 )
-		GafferUI.Widget.__init__( self, grid, **kw )
+		column = GafferUI.ListContainer( spacing = 4, borderWidth = 8 )
+		GafferUI.Widget.__init__( self, column, **kw )
 
-		with grid :
+		with column :
 
-			GafferUI.Label(
-				"Name",
-				parenting = {
-					"index" : ( 0, 0 ),
-					"alignment" : ( GafferUI.HorizontalAlignment.Right, GafferUI.VerticalAlignment.Center )
-				}
-			)
+			with _Row() :
 
-			self.__nameWidget = GafferUI.TextWidget( parenting = { "index" : ( 1, 0 ) } )
-			self.__nameWidgetEditingFinishedConnection = self.__nameWidget.editingFinishedSignal().connect( Gaffer.WeakMethod( self.__nameWidgetEditingFinished ) )
+				_Label( "Name" )
 
-			GafferUI.Label(
-				"Summary",
-				parenting = {
-					"index" : ( 0, 1 ),
-					"alignment" : ( GafferUI.HorizontalAlignment.Right, GafferUI.VerticalAlignment.Top )
-				}
-			)
+				self.__nameWidget = GafferUI.TextWidget()
+				self.__nameWidgetEditingFinishedConnection = self.__nameWidget.editingFinishedSignal().connect( Gaffer.WeakMethod( self.__nameWidgetEditingFinished ) )
 
-			self.__summaryMetadataWidget = _MultiLineStringMetadataWidget(
-				key = "",
-				parenting = { "index" : ( 1, 1 ) }
-			)
+			with _Row() :
+
+				_Label( "Summary", parenting = { "verticalAlignment" : GafferUI.ListContainer.VerticalAlignment.Top } )
+
+				self.__summaryMetadataWidget = _MultiLineStringMetadataWidget( key = "" )
 
 		self.__section = ""
 		self.__plugParent = None

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -408,6 +408,10 @@ class _StringMetadataWidget( _MetadataWidget ) :
 			Gaffer.WeakMethod( self.__editingFinished )
 		)
 
+	def textWidget( self ) :
+
+		return self.__textWidget
+
 	def _updateFromValue( self, value ) :
 
 		self.__textWidget.setText( value if value is not None else "" )
@@ -426,6 +430,10 @@ class _MultiLineStringMetadataWidget( _MetadataWidget ) :
 		self.__editingFinishedConnection = self.__textWidget.editingFinishedSignal().connect(
 			Gaffer.WeakMethod( self.__editingFinished )
 		)
+
+	def textWidget( self ) :
+
+		return self.__textWidget
 
 	def _updateFromValue( self, value ) :
 
@@ -1130,6 +1138,7 @@ class _PresetsEditor( GafferUI.Widget ) :
 				self.__pathListing.setSortable( False )
 				self.__pathListing.setHeaderVisible( False )
 				self.__pathListing._qtWidget().setFixedWidth( 200 )
+				self.__pathListing._qtWidget().setFixedHeight( 200 )
 
 				self.__pathListingSelectionChangedConnection = self.__pathListing.selectionChangedSignal().connect( Gaffer.WeakMethod( self.__selectionChanged ) )
 				self.__dragEnterConnection = self.__pathListing.dragEnterSignal().connect( Gaffer.WeakMethod( self.__dragEnter ) )
@@ -1343,12 +1352,13 @@ class _PlugEditor( GafferUI.Widget ) :
 
 	def __init__( self, **kw ) :
 
-		column = GafferUI.ListContainer( spacing = 4, borderWidth = 8 )
-		GafferUI.Widget.__init__( self, column, **kw )
+		scrolledContainer = GafferUI.ScrolledContainer( horizontalMode = GafferUI.ScrolledContainer.ScrollMode.Never, borderWidth = 8 )
+		GafferUI.Widget.__init__( self, scrolledContainer, **kw )
 
 		self.__metadataWidgets = {}
 
-		with column :
+		scrolledContainer.setChild( GafferUI.ListContainer( spacing = 4 ) )
+		with scrolledContainer.getChild() :
 
 			with _Row() :
 
@@ -1360,6 +1370,7 @@ class _PlugEditor( GafferUI.Widget ) :
 
 				_Label( "Description", parenting = { "verticalAlignment" : GafferUI.ListContainer.VerticalAlignment.Top } )
 				self.__metadataWidgets["description"] = _MultiLineStringMetadataWidget( key = "description" )
+				self.__metadataWidgets["description"].textWidget().setFixedLineHeight( 10 )
 
 			with _Row() :
 

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -38,6 +38,7 @@ import weakref
 import functools
 import types
 import re
+import collections
 
 import IECore
 
@@ -914,6 +915,233 @@ class _PlugListing( GafferUI.Widget ) :
 			self.__updateMetadata()
 
 ##########################################################################
+# _PresetsEditor. This provides a ui for editing the presets for a plug.
+##########################################################################
+
+class _PresetsEditor( GafferUI.Widget ) :
+
+	def __init__( self, **kw ) :
+
+		row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 8 )
+		GafferUI.Widget.__init__( self, row, **kw )
+
+		with row :
+
+			with GafferUI.ListContainer( spacing = 4 ) :
+
+				self.__pathListing = GafferUI.PathListingWidget(
+					Gaffer.DictPath( collections.OrderedDict(), "/" ),
+					columns = ( GafferUI.PathListingWidget.defaultNameColumn, ),
+				)
+				self.__pathListing.setDragPointer( "" )
+				self.__pathListing.setSortable( False )
+				self.__pathListing.setHeaderVisible( False )
+				self.__pathListing._qtWidget().setFixedWidth( 200 )
+
+				self.__pathListingSelectionChangedConnection = self.__pathListing.selectionChangedSignal().connect( Gaffer.WeakMethod( self.__selectionChanged ) )
+				self.__dragEnterConnection = self.__pathListing.dragEnterSignal().connect( Gaffer.WeakMethod( self.__dragEnter ) )
+				self.__dragMoveConnection = self.__pathListing.dragMoveSignal().connect( Gaffer.WeakMethod( self.__dragMove ) )
+				self.__dragEndConnection = self.__pathListing.dragEndSignal().connect( Gaffer.WeakMethod( self.__dragEnd ) )
+
+				with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
+
+					self.__addButton = GafferUI.Button( image = "plus.png", hasFrame = False )
+					self.__addButtonClickedConnection = self.__addButton.clickedSignal().connect( Gaffer.WeakMethod( self.__addButtonClicked ) )
+
+					self.__deleteButton = GafferUI.Button( image = "minus.png", hasFrame = False )
+					self.__deleteButtonClickedConnection = self.__deleteButton.clickedSignal().connect( Gaffer.WeakMethod( self.__deleteButtonClicked ) )
+
+			with GafferUI.ListContainer( spacing = 4 ) as self.__editingColumn :
+
+				GafferUI.Label( "Name" )
+
+				self.__nameWidget = GafferUI.TextWidget()
+				self.__nameEditingFinishedConnection = self.__nameWidget.editingFinishedSignal().connect( Gaffer.WeakMethod( self.__nameEditingFinished ) )
+
+				GafferUI.Spacer( IECore.V2i( 4 ), maximumSize = IECore.V2i( 4 ) )
+
+				GafferUI.Label( "Value" )
+
+		# We make a UI for editing preset values by copying the plug
+		# onto this node and then making a PlugValueWidget for it.
+		self.__valueNode = Gaffer.Node( "PresetEditor" )
+		self.__valuePlugSetConnection = self.__valueNode.plugSetSignal().connect( Gaffer.WeakMethod( self.__valuePlugSet ) )
+
+	def setPlug( self, plug ) :
+
+		self.__plug = plug
+
+		self.__plugMetadataChangedConnection = None
+		del self.__editingColumn[4:]
+
+		if self.__plug is not None :
+			self.__plugMetadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal().connect( Gaffer.WeakMethod( self.__plugMetadataChanged ) )
+			self.__valueNode["presetValue"] = plug.createCounterpart( "presetValue", plug.Direction.In )
+			self.__editingColumn.append( GafferUI.PlugValueWidget.create( self.__valueNode["presetValue"], useTypeOnly = True ) )
+		else :
+			self.__editingColumn.append( GafferUI.TextWidget() )
+
+		self.__editingColumn.append( GafferUI.Spacer( IECore.V2i( 0 ), expand = True ) )
+
+		self.__updatePath()
+
+		self.__addButton.setEnabled( hasattr( self.__plug, "getValue" ) )
+
+	def getPlug( self ) :
+
+		return self.__plug
+
+	def __updatePath( self ) :
+
+		d = self.__pathListing.getPath().dict()
+		d.clear()
+		if self.__plug is not None :
+			for name in _registeredMetadata( self.__plug, instanceOnly = True, persistentOnly = True ) :
+				if name.startswith( "preset:" ) :
+					d[name[7:]] = _metadata( self.__plug, name )
+
+		self.__pathListing.getPath().pathChangedSignal()( self.__pathListing.getPath() )
+
+	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
+
+		if plug is None or not plug.isSame( self.__plug ) :
+			return
+
+		if key.startswith( "preset:" ) :
+			self.__updatePath()
+
+	def __selectionChanged( self, listing ) :
+
+		selectedPaths = listing.getSelectedPaths()
+
+		self.__nameWidget.setText( selectedPaths[0][0] if selectedPaths else "" )
+		self.__editingColumn.setEnabled( bool( selectedPaths ) )
+		self.__deleteButton.setEnabled( bool( selectedPaths ) )
+
+	def __dragEnter( self, listing, event ) :
+
+		if event.sourceWidget is not self.__pathListing :
+			return False
+		if not isinstance( event.data, IECore.StringVectorData ) :
+			return False
+
+		return True
+
+	def __dragMove( self, listing, event ) :
+
+		d = self.__pathListing.getPath().dict()
+
+		srcPath = self.__pathListing.getPath().copy().setFromString( event.data[0] )
+		srcIndex = d.keys().index( srcPath[0] )
+
+		targetPath = self.__pathListing.pathAt( event.line.p0 )
+		if targetPath is not None :
+			targetIndex = d.keys().index( targetPath[0] )
+		else :
+			targetIndex = 0 if event.line.p0.y < 1 else len( d )
+
+		if srcIndex == targetIndex :
+			return True
+
+		items = d.items()
+		item = items[srcIndex]
+		del items[srcIndex]
+		items.insert( targetIndex, item )
+
+		d.clear()
+		d.update( items )
+
+		self.__pathListing.getPath().pathChangedSignal()( self.__pathListing.getPath() )
+
+		return True
+
+	def __dragEnd( self, listing, event ) :
+
+		d = self.__pathListing.getPath().dict()
+		with Gaffer.BlockedConnection( self.__plugMetadataChangedConnection ) :
+			with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+				# reorder by removing everything and reregistering in the order we want
+				for item in d.items() :
+					Gaffer.Metadata.deregisterPlugValue( self.getPlug(), "preset:" + item[0] )
+				for item in d.items() :
+					Gaffer.Metadata.registerPlugValue( self.getPlug(), "preset:" + item[0], item[1] )
+
+		self.__updatePath()
+
+		return True
+
+	def __addButtonClicked( self, button ) :
+
+		existingNames = [ p[0] for p in self.__pathListing.getPath().children() ]
+
+		name = "New Preset"
+		index = 1
+		while name in existingNames :
+			name = "New Preset %d" % index
+			index += 1
+
+		with Gaffer.UndoContext( self.__plug.ancestor( Gaffer.ScriptNode ) ) :
+			Gaffer.Metadata.registerPlugValue( self.__plug, "preset:" + name, self.__plug.getValue() )
+
+		self.__pathListing.setSelectedPaths(
+			self.__pathListing.getPath().copy().setFromString( "/" + name )
+		)
+
+		self.__nameWidget.grabFocus()
+		self.__nameWidget.setSelection( 0, len( name ) )
+
+		return True
+
+	def __deleteButtonClicked( self, button ) :
+
+		paths = self.__pathListing.getPath().children()
+		selectedPreset = self.__pathListing.getSelectedPaths()[0][0]
+		selectedIndex = [ p[0] for p in paths ].index( selectedPreset )
+
+		with Gaffer.UndoContext( self.__plug.ancestor( Gaffer.ScriptNode ) ) :
+			Gaffer.Metadata.deregisterPlugValue( self.__plug, "preset:" + selectedPreset )
+
+		del paths[selectedIndex]
+		if len( paths ) :
+			self.__pathListing.setSelectedPaths( [ paths[min(selectedIndex,len( paths )-1)] ] )
+
+		return True
+
+	def __nameEditingFinished( self, nameWidget ) :
+
+		selectedPaths = self.__pathListing.getSelectedPaths()
+		if not len( selectedPaths ) :
+			return True
+
+		oldName = selectedPaths[0][0]
+		newName = nameWidget.getText()
+
+		items = self.__pathListing.getPath().dict().items()
+		with Gaffer.BlockedConnection( self.__plugMetadataChangedConnection ) :
+			with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+				# retain order by removing and reregistering everything
+				for item in items :
+					Gaffer.Metadata.deregisterPlugValue( self.getPlug(), "preset:" + item[0] )
+				for item in items :
+					Gaffer.Metadata.registerPlugValue( self.getPlug(), "preset:" + (item[0] if item[0] != oldName else newName), item[1] )
+
+		self.__updatePath()
+		self.__pathListing.setSelectedPaths( [ self.__pathListing.getPath().copy().setFromString( "/" + newName ) ] )
+
+		return True
+
+	def __valuePlugSet( self, plug ) :
+
+		if not plug.isSame( self.__valueNode["presetValue"] ) :
+			return
+
+		selectedPaths = self.__pathListing.getSelectedPaths()
+		preset = selectedPaths[0][0]
+
+		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+			Gaffer.Metadata.registerPlugValue( self.getPlug(), "preset:" + preset, plug.getValue() )
+
+##########################################################################
 # _PlugEditor. This provides a panel for editing a specific plug's name,
 # description, etc.
 ##########################################################################
@@ -951,6 +1179,15 @@ class _PlugEditor( GafferUI.Widget ) :
 					_BoolMetadataWidget( key = "divider" )
 				)
 
+			with GafferUI.Collapsible( "Presets", collapsed = True ) :
+
+				with _Row() :
+
+					_Label( "" )
+					self.__presetsEditor = _PresetsEditor()
+
+			GafferUI.Spacer( IECore.V2i( 0 ), parenting = { "expand" : True } )
+
 		self.__plug = None
 
 	def setPlug( self, plug ) :
@@ -960,6 +1197,8 @@ class _PlugEditor( GafferUI.Widget ) :
 		self.__nameWidget.setGraphComponent( self.__plug )
 		for widget in self.__metadataWidgets :
 			widget.setTarget( self.__plug )
+
+		self.__presetsEditor.setPlug( plug )
 
 		self.setEnabled( self.__plug is not None )
 

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -269,13 +269,206 @@ class _Label( GafferUI.Label ) :
 			*args, **kw
 		)
 
-		self._qtWidget().setFixedWidth( 75 )
+		self._qtWidget().setFixedWidth( 110 )
 
 class _Row( GafferUI.ListContainer ) :
 
 	def __init__( self, *args, **kw ) :
 
 		GafferUI.ListContainer.__init__( self, GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 )
+
+##########################################################################
+# MetadataValueWidgets. These display metadata values, allowing the user
+# to edit them.
+##########################################################################
+
+class _MetadataWidget( GafferUI.Widget ) :
+
+	def __init__( self, topLevelWidget, key, target = None, **kw ) :
+
+		GafferUI.Widget.__init__( self, topLevelWidget, **kw )
+
+		self.__key = key
+		self.__target = None
+
+		self.setTarget( target )
+
+	def setTarget( self, target ) :
+
+		assert( isinstance( target, ( Gaffer.Node, Gaffer.Plug, type( None ) ) ) )
+
+		self.__target = target
+		self.setEnabled( self.__target is not None )
+
+		if isinstance( self.__target, Gaffer.Node ) :
+			self.__metadataChangedConnection = Gaffer.Metadata.nodeValueChangedSignal().connect(
+				Gaffer.WeakMethod( self.__nodeMetadataChanged )
+			)
+		elif isinstance( self.__target, Gaffer.Plug ) :
+			self.__metadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal().connect(
+				Gaffer.WeakMethod( self.__plugMetadataChanged )
+			)
+		else :
+			self.__metadataChangedConnection = None
+
+		self.__update()
+
+	def getTarget( self ) :
+
+		return self.__target
+
+	def setKey( self, key ) :
+
+		if key == self.__key :
+			return
+
+		self.__key = key
+		self.__update()
+
+	def getKey( self, key ) :
+
+		return self.__key
+
+	## Must be implemented in derived classes to update
+	# the widget from the value.
+	def _updateFromValue( self, value ) :
+
+		raise NotImplementedError
+
+	## Must be called by derived classes to update
+	# the Metadata value when the widget value changes.
+	def _updateFromWidget( self, value ) :
+
+		if self.__target is None :
+			return
+
+		with Gaffer.UndoContext( self.__target.ancestor( Gaffer.ScriptNode ) ) :
+			_registerMetadata( self.__target, self.__key, value )
+
+	def __update( self ) :
+
+		if isinstance( self.__target, Gaffer.Node ) :
+			self._updateFromValue( Gaffer.Metadata.nodeValue( self.__target, self.__key ) )
+		elif isinstance( self.__target, Gaffer.Plug ) :
+			self._updateFromValue( Gaffer.Metadata.plugValue( self.__target, self.__key ) )
+		else :
+			self._updateFromValue( None )
+
+	def __nodeMetadataChanged( self, nodeTypeId, key, node ) :
+
+		if self.__key != key :
+			return
+		if node is not None and not node.isSame( self.__target ) :
+			return
+		if not self.__target.isInstanceOf( nodeTypeId ) :
+			return
+
+		self.__update()
+
+	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
+
+		if self.__key != key :
+			return
+		if plug is not None and not plug.isSame( self.__target ) :
+			return
+		if not self.__target.node().isInstanceOf( nodeTypeId ) :
+			return
+		if not Gaffer.match( self.__target.relativeName( self.__target.node() ), plugPath ) :
+			return
+
+		self.__update()
+
+class _BoolMetadataWidget( _MetadataWidget ) :
+
+	def __init__( self, key, target = None, **kw ) :
+
+		self.__boolWidget = GafferUI.BoolWidget()
+		_MetadataWidget.__init__( self, self.__boolWidget, key, target, **kw )
+
+		self.__stateChangedConnection = self.__boolWidget.stateChangedSignal().connect(
+			Gaffer.WeakMethod( self.__stateChanged )
+		)
+
+	def _updateFromValue( self, value ) :
+
+		self.__boolWidget.setState( value if value is not None else False )
+
+	def __stateChanged( self, *unused ) :
+
+		self._updateFromWidget( self.__boolWidget.getState() )
+
+class _StringMetadataWidget( _MetadataWidget ) :
+
+	def __init__( self, key, target = None, **kw ) :
+
+		self.__textWidget = GafferUI.TextWidget()
+		_MetadataWidget.__init__( self, self.__textWidget, key, target, **kw )
+
+		self.__editingFinishedConnection = self.__textWidget.editingFinishedSignal().connect(
+			Gaffer.WeakMethod( self.__editingFinished )
+		)
+
+	def _updateFromValue( self, value ) :
+
+		self.__textWidget.setText( value if value is not None else "" )
+
+	def __editingFinished( self, *unused ) :
+
+		self._updateFromWidget( self.__textWidget.getText() )
+
+class _MultiLineStringMetadataWidget( _MetadataWidget ) :
+
+	def __init__( self, key, target = None, **kw ) :
+
+		self.__textWidget = GafferUI.MultiLineTextWidget()
+		_MetadataWidget.__init__( self, self.__textWidget, key, target, **kw )
+
+		self.__editingFinishedConnection = self.__textWidget.editingFinishedSignal().connect(
+			Gaffer.WeakMethod( self.__editingFinished )
+		)
+
+	def _updateFromValue( self, value ) :
+
+		self.__textWidget.setText( value if value is not None else "" )
+
+	def __editingFinished( self, *unused ) :
+
+		self._updateFromWidget( self.__textWidget.getText() )
+
+class _ColorSwatchMetadataWidget( _MetadataWidget ) :
+
+	def __init__( self, key, target = None, **kw ) :
+
+		self.__swatch = GafferUI.ColorSwatch( useDisplayTransform = False )
+
+		_MetadataWidget.__init__( self, self.__swatch, key, target, **kw )
+
+		self.__swatch._qtWidget().setMaximumHeight( 20 )
+		self.__swatch._qtWidget().setMaximumWidth( 40 )
+		self.__value = None
+
+		self.__buttonReleaseConnection = self.__swatch.buttonReleaseSignal().connect( Gaffer.WeakMethod( self.__buttonRelease ) )
+
+	def _updateFromValue( self, value ) :
+
+		if value is not None :
+			self.__swatch.setColor( value )
+		else :
+			self.__swatch.setColor( IECore.Color4f( 0, 0, 0, 0 ) )
+
+		self.__value = value
+
+	def __buttonRelease( self, swatch, event ) :
+
+		if event.button != event.Buttons.Left :
+			return False
+
+		color = self.__value if self.__value is not None else IECore.Color3f( 1 )
+		dialogue = GafferUI.ColorChooserDialogue( color = color, useDisplayTransform = False )
+		color = dialogue.waitForColor( parentWindow = self.ancestor( GafferUI.Window ) )
+
+		if color is not None :
+			self._updateFromWidget( color )
 
 ##########################################################################
 # Hierarchical representation of a plug layout, suitable for manipulating
@@ -1153,7 +1346,7 @@ class _PlugEditor( GafferUI.Widget ) :
 		column = GafferUI.ListContainer( spacing = 4, borderWidth = 8 )
 		GafferUI.Widget.__init__( self, column, **kw )
 
-		self.__metadataWidgets = []
+		self.__metadataWidgets = {}
 
 		with column :
 
@@ -1166,10 +1359,7 @@ class _PlugEditor( GafferUI.Widget ) :
 			with _Row() :
 
 				_Label( "Description", parenting = { "verticalAlignment" : GafferUI.ListContainer.VerticalAlignment.Top } )
-
-				self.__metadataWidgets.append(
-					_MultiLineStringMetadataWidget( key = "description" )
-				)
+				self.__metadataWidgets["description"] = _MultiLineStringMetadataWidget( key = "description" )
 
 			with _Row() :
 
@@ -1179,20 +1369,27 @@ class _PlugEditor( GafferUI.Widget ) :
 					menu = GafferUI.Menu( Gaffer.WeakMethod( self.__widgetMenuDefinition ) )
 				)
 
-			with _Row() :
-
-				_Label( "Divider" )
-
-				self.__metadataWidgets.append(
-					_BoolMetadataWidget( key = "divider" )
-				)
-
 			with GafferUI.Collapsible( "Presets", collapsed = True ) :
 
 				with _Row() :
 
 					_Label( "" )
 					self.__presetsEditor = _PresetsEditor()
+
+			with GafferUI.Collapsible( "Widget Settings", collapsed = True ) :
+
+				with GafferUI.ListContainer( spacing = 4 ) :
+
+					with _Row() :
+
+						_Label( "Divider" )
+						self.__metadataWidgets["divider"] = _BoolMetadataWidget( key = "divider" )
+
+					for m in self.__metadataDefinitions :
+
+						with _Row() :
+							_Label( m.label )
+							self.__metadataWidgets[m.key] = m.metadataWidgetType( key = m.key )
 
 			GafferUI.Spacer( IECore.V2i( 0 ), parenting = { "expand" : True } )
 
@@ -1205,10 +1402,11 @@ class _PlugEditor( GafferUI.Widget ) :
 		self.__plug = plug
 
 		self.__nameWidget.setGraphComponent( self.__plug )
-		for widget in self.__metadataWidgets :
+		for widget in self.__metadataWidgets.values() :
 			widget.setTarget( self.__plug )
 
 		self.__updateWidgetMenuText()
+		self.__updateWidgetSettings()
 		self.__presetsEditor.setPlug( plug )
 
 		self.setEnabled( self.__plug is not None )
@@ -1230,6 +1428,7 @@ class _PlugEditor( GafferUI.Widget ) :
 
 		if key == "plugValueWidget:type" :
 			self.__updateWidgetMenuText()
+			self.__updateWidgetSettings()
 
 	def __updateWidgetMenuText( self ) :
 
@@ -1244,6 +1443,16 @@ class _PlugEditor( GafferUI.Widget ) :
 				return
 
 		self.__widgetMenu.setText( metadata )
+
+	def __updateWidgetSettings( self ) :
+
+		widgetType = None
+		if self.getPlug() is not None :
+			widgetType = Gaffer.Metadata.plugValue( self.getPlug(), "plugValueWidget:type" )
+
+		for m in self.__metadataDefinitions :
+			widget = self.__metadataWidgets[m.key]
+			widget.parent().setEnabled( m.plugValueWidgetType == widgetType )
 
 	def __widgetMenuDefinition( self ) :
 
@@ -1274,15 +1483,23 @@ class _PlugEditor( GafferUI.Widget ) :
 			else :
 				Gaffer.Metadata.deregisterPlugValue( self.getPlug(), "plugValueWidget:type" )
 
-	__WidgetDefinition = collections.namedtuple( "Widget", ( "label", "plugType", "metadata" ) )
+	__WidgetDefinition = collections.namedtuple( "WidgetDefinition", ( "label", "plugType", "metadata" ) )
 	__widgetDefinitions = (
 		__WidgetDefinition( "Default", Gaffer.Plug, None ),
 		__WidgetDefinition( "Checkbox", Gaffer.IntPlug, "GafferUI.BoolPlugValueWidget" ),
 		__WidgetDefinition( "Text Region", Gaffer.StringPlug, "GafferUI.MultiLineStringPlugValueWidget" ),
-		__WidgetDefinition( "File Chooser", Gaffer.StringPlug, "GafferUI.PathPlugValueWidget" ),
+		__WidgetDefinition( "File Chooser", Gaffer.StringPlug, "GafferUI.FileSystemPathPlugValueWidget" ),
 		__WidgetDefinition( "Presets Menu", Gaffer.ValuePlug, "GafferUI.PresetsPlugValueWidget" ),
 		__WidgetDefinition( "Connection", Gaffer.Plug, "GafferUI.ConnectionPlugValueWidget" ),
 		__WidgetDefinition( "None", Gaffer.Plug, "" ),
+	)
+
+	__MetadataDefinition = collections.namedtuple( "MetadataDefinition", ( "key", "label", "metadataWidgetType", "plugValueWidgetType" ) )
+	__metadataDefinitions = (
+		__MetadataDefinition( "fileSystemPathPlugValueWidget:extensions", "File Extensions", _StringMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
+		__MetadataDefinition( "pathPlugValueWidget:bookmarks", "Bookmarks Category", _StringMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
+		__MetadataDefinition( "pathPlugValueWidget:valid", "File Must Exist", _BoolMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
+		__MetadataDefinition( "pathPlugValueWidget:leaf", "No Directories", _BoolMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
 	)
 
 ##########################################################################
@@ -1385,180 +1602,6 @@ class _SectionEditor( GafferUI.Widget ) :
 
 		self.setSection( ".".join( newSectionPath ) )
 		self.nameChangedSignal()( self, ".".join( oldSectionPath ), ".".join( newSectionPath ) )
-
-##########################################################################
-# MetadataValueWidgets. These display metadata values, allowing the user
-# to edit them.
-##########################################################################
-
-class _MetadataWidget( GafferUI.Widget ) :
-
-	def __init__( self, topLevelWidget, key, target = None, **kw ) :
-
-		GafferUI.Widget.__init__( self, topLevelWidget, **kw )
-
-		self.__key = key
-		self.__target = None
-
-		self.setTarget( target )
-
-	def setTarget( self, target ) :
-
-		assert( isinstance( target, ( Gaffer.Node, Gaffer.Plug, type( None ) ) ) )
-
-		self.__target = target
-		self.setEnabled( self.__target is not None )
-
-		if isinstance( self.__target, Gaffer.Node ) :
-			self.__metadataChangedConnection = Gaffer.Metadata.nodeValueChangedSignal().connect(
-				Gaffer.WeakMethod( self.__nodeMetadataChanged )
-			)
-		elif isinstance( self.__target, Gaffer.Plug ) :
-			self.__metadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal().connect(
-				Gaffer.WeakMethod( self.__plugMetadataChanged )
-			)
-		else :
-			self.__metadataChangedConnection = None
-
-		self.__update()
-
-	def getTarget( self ) :
-
-		return self.__target
-
-	def setKey( self, key ) :
-
-		if key == self.__key :
-			return
-
-		self.__key = key
-		self.__update()
-
-	def getKey( self, key ) :
-
-		return self.__key
-
-	## Must be implemented in derived classes to update
-	# the widget from the value.
-	def _updateFromValue( self, value ) :
-
-		raise NotImplementedError
-
-	## Must be called by derived classes to update
-	# the Metadata value when the widget value changes.
-	def _updateFromWidget( self, value ) :
-
-		if self.__target is None :
-			return
-
-		with Gaffer.UndoContext( self.__target.ancestor( Gaffer.ScriptNode ) ) :
-			_registerMetadata( self.__target, self.__key, value )
-
-	def __update( self ) :
-
-		if isinstance( self.__target, Gaffer.Node ) :
-			self._updateFromValue( Gaffer.Metadata.nodeValue( self.__target, self.__key ) )
-		elif isinstance( self.__target, Gaffer.Plug ) :
-			self._updateFromValue( Gaffer.Metadata.plugValue( self.__target, self.__key ) )
-		else :
-			self._updateFromValue( None )
-
-	def __nodeMetadataChanged( self, nodeTypeId, key, node ) :
-
-		if self.__key != key :
-			return
-		if node is not None and not node.isSame( self.__target ) :
-			return
-		if not self.__target.isInstanceOf( nodeTypeId ) :
-			return
-
-		self.__update()
-
-	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
-
-		if self.__key != key :
-			return
-		if plug is not None and not plug.isSame( self.__target ) :
-			return
-		if not self.__target.node().isInstanceOf( nodeTypeId ) :
-			return
-		if not Gaffer.match( self.__target.relativeName( self.__target.node() ), plugPath ) :
-			return
-
-		self.__update()
-
-class _BoolMetadataWidget( _MetadataWidget ) :
-
-	def __init__( self, key, target = None, **kw ) :
-
-		self.__boolWidget = GafferUI.BoolWidget()
-		_MetadataWidget.__init__( self, self.__boolWidget, key, target, **kw )
-
-		self.__stateChangedConnection = self.__boolWidget.stateChangedSignal().connect(
-			Gaffer.WeakMethod( self.__stateChanged )
-		)
-
-	def _updateFromValue( self, value ) :
-
-		self.__boolWidget.setState( value if value is not None else False )
-
-	def __stateChanged( self, *unused ) :
-
-		self._updateFromWidget( self.__boolWidget.getState() )
-
-class _MultiLineStringMetadataWidget( _MetadataWidget ) :
-
-	def __init__( self, key, target = None, **kw ) :
-
-		self.__textWidget = GafferUI.MultiLineTextWidget()
-		_MetadataWidget.__init__( self, self.__textWidget, key, target, **kw )
-
-		self.__editingFinishedConnection = self.__textWidget.editingFinishedSignal().connect(
-			Gaffer.WeakMethod( self.__editingFinished )
-		)
-
-	def _updateFromValue( self, value ) :
-
-		self.__textWidget.setText( value if value is not None else "" )
-
-	def __editingFinished( self, *unused ) :
-
-		self._updateFromWidget( self.__textWidget.getText() )
-
-class _ColorSwatchMetadataWidget( _MetadataWidget ) :
-
-	def __init__( self, key, target = None, **kw ) :
-
-		self.__swatch = GafferUI.ColorSwatch( useDisplayTransform = False )
-
-		_MetadataWidget.__init__( self, self.__swatch, key, target, **kw )
-
-		self.__swatch._qtWidget().setMaximumHeight( 20 )
-		self.__swatch._qtWidget().setMaximumWidth( 40 )
-		self.__value = None
-
-		self.__buttonReleaseConnection = self.__swatch.buttonReleaseSignal().connect( Gaffer.WeakMethod( self.__buttonRelease ) )
-
-	def _updateFromValue( self, value ) :
-
-		if value is not None :
-			self.__swatch.setColor( value )
-		else :
-			self.__swatch.setColor( IECore.Color4f( 0, 0, 0, 0 ) )
-
-		self.__value = value
-
-	def __buttonRelease( self, swatch, event ) :
-
-		if event.button != event.Buttons.Left :
-			return False
-
-		color = self.__value if self.__value is not None else IECore.Color3f( 1 )
-		dialogue = GafferUI.ColorChooserDialogue( color = color, useDisplayTransform = False )
-		color = dialogue.waitForColor( parentWindow = self.ancestor( GafferUI.Window ) )
-
-		if color is not None :
-			self._updateFromWidget( color )
 
 # Metadata utility methods.
 # \todo We should change the Metadata API to provide overloads

--- a/python/GafferUI/UserPlugValueWidget.py
+++ b/python/GafferUI/UserPlugValueWidget.py
@@ -108,8 +108,6 @@ class UserPlugValueWidget( GafferUI.PlugValueWidget ) :
 			plug = plugType( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 			self.getPlug().addChild( plug )
 
-GafferUI.PlugValueWidget.registerCreator( Gaffer.Node, "user", UserPlugValueWidget )
-
 ##########################################################################
 # Plug menu
 ##########################################################################

--- a/python/GafferUI/UserPlugValueWidget.py
+++ b/python/GafferUI/UserPlugValueWidget.py
@@ -104,15 +104,8 @@ class UserPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __addPlug( self, plugType ) :
 
-		d = GafferUI.TextInputDialogue( initialText = "unnamed", title = "Enter name", confirmLabel = "Create" )
-		name = d.waitForText( parentWindow = self.ancestor( GafferUI.Window ) )
-		d.setVisible( False )
-
-		if not name :
-			return
-
 		with Gaffer.UndoContext( self.getPlug().node().scriptNode() ) :
-			plug = plugType( name, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+			plug = plugType( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 			self.getPlug().addChild( plug )
 
 GafferUI.PlugValueWidget.registerCreator( Gaffer.Node, "user", UserPlugValueWidget )

--- a/python/GafferUI/ViewUI.py
+++ b/python/GafferUI/ViewUI.py
@@ -47,8 +47,22 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "",
 
-		]
+		],
+
+		"in" : [
+
+			"plugValueWidget:type", "",
+
+		],
+
+		"user" : [
+
+			"plugValueWidget:type", "",
+
+		],
 
 	}
 
 )
+
+GafferUI.NodeToolbar.registerCreator( GafferUI.View, GafferUI.StandardNodeToolbar )

--- a/python/GafferUI/Viewer.py
+++ b/python/GafferUI/Viewer.py
@@ -230,11 +230,3 @@ class Viewer( GafferUI.NodeSetEditor ) :
 		return result
 
 GafferUI.EditorWidget.registerType( "Viewer", Viewer )
-
-##########################################################################
-# PlugValueWidget and Toolbar registrations
-##########################################################################
-
-GafferUI.NodeToolbar.registerCreator( GafferUI.View, GafferUI.StandardNodeToolbar )
-GafferUI.PlugValueWidget.registerCreator( GafferUI.View, "in", None )
-GafferUI.PlugValueWidget.registerCreator( GafferUI.View, "user", None )

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -205,6 +205,7 @@ from StringPlugValueWidget import StringPlugValueWidget
 from NumericPlugValueWidget import NumericPlugValueWidget
 from BoolPlugValueWidget import BoolPlugValueWidget
 from PathPlugValueWidget import PathPlugValueWidget
+from FileSystemPathPlugValueWidget import FileSystemPathPlugValueWidget
 from VectorDataPlugValueWidget import VectorDataPlugValueWidget
 from PathVectorDataPlugValueWidget import PathVectorDataPlugValueWidget
 from PlugWidget import PlugWidget

--- a/python/GafferUITest/PlugLayoutTest.py
+++ b/python/GafferUITest/PlugLayoutTest.py
@@ -156,5 +156,38 @@ class PlugLayoutTest( GafferUITest.TestCase ) :
 			[ n["user"]["c"] ],
 		)
 
+	def testChangingWidgetType( self ) :
+
+		n = Gaffer.Node()
+		n["p1"] = Gaffer.IntPlug()
+		n["p2"] = Gaffer.IntPlug()
+
+		l = GafferUI.PlugLayout( n )
+		self.assertTrue( isinstance( l.plugValueWidget( n["p1"], lazy = False ), GafferUI.NumericPlugValueWidget ) )
+		w2 = l.plugValueWidget( n["p2"], lazy = False )
+		self.assertTrue( isinstance( w2, GafferUI.NumericPlugValueWidget ) )
+
+		Gaffer.Metadata.registerPlugValue( n["p1"], "plugValueWidget:type", "GafferUI.ConnectionPlugValueWidget" )
+		self.assertTrue( isinstance( l.plugValueWidget( n["p1"], lazy = False ), GafferUI.ConnectionPlugValueWidget ) )
+		self.assertTrue( w2 is l.plugValueWidget( n["p2"], lazy = False ) )
+
+		Gaffer.Metadata.deregisterPlugValue( n["p1"], "plugValueWidget:type" )
+		self.assertTrue( isinstance( l.plugValueWidget( n["p1"], lazy = False ), GafferUI.NumericPlugValueWidget ) )
+		self.assertTrue( w2 is l.plugValueWidget( n["p2"], lazy = False ) )
+
+	def testRemovingAndAddingWidget( self ) :
+
+		n = Gaffer.Node()
+		n["p"] = Gaffer.IntPlug()
+
+		l = GafferUI.PlugLayout( n )
+		self.assertTrue( isinstance( l.plugValueWidget( n["p"], lazy = False ), GafferUI.NumericPlugValueWidget ) )
+
+		Gaffer.Metadata.registerPlugValue( n["p"], "plugValueWidget:type", "" )
+		self.assertTrue( l.plugValueWidget( n["p"], lazy = False ) is None )
+
+		Gaffer.Metadata.deregisterPlugValue( n["p"], "plugValueWidget:type" )
+		self.assertTrue( isinstance( l.plugValueWidget( n["p"], lazy = False ), GafferUI.NumericPlugValueWidget ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/PlugValueWidgetTest.py
+++ b/python/GafferUITest/PlugValueWidgetTest.py
@@ -86,6 +86,21 @@ class PlugValueWidgetTest( unittest.TestCase ) :
 		w = GafferUI.PlugValueWidget.create( n["p"] )
 		self.assertEqual( w, None )
 
+	def testCreate( self ) :
+
+		n = Gaffer.Node()
+		n["p"] = Gaffer.IntPlug()
+
+		w = GafferUI.PlugValueWidget.create( n["p"] )
+		self.assertTrue( isinstance( w, GafferUI.NumericPlugValueWidget ) )
+		self.assertTrue( w.getPlug().isSame( n["p"] ) )
+
+		Gaffer.Metadata.registerPlugValue( n["p"], "plugValueWidget:type", "GafferUI.ConnectionPlugValueWidget" )
+
+		w = GafferUI.PlugValueWidget.create( n["p"] )
+		self.assertTrue( isinstance( w, GafferUI.ConnectionPlugValueWidget ) )
+		self.assertTrue( w.getPlug().isSame( n["p"] ) )
+
 if __name__ == "__main__":
 	unittest.main()
 

--- a/src/GafferBindings/MetadataBinding.cpp
+++ b/src/GafferBindings/MetadataBinding.cpp
@@ -319,6 +319,10 @@ void bindMetadata()
 		)
 		.staticmethod( "nodeValue" )
 
+		.def( "deregisterNodeValue", (void (*)( IECore::TypeId, InternedString ))&Metadata::deregisterNodeValue )
+		.def( "deregisterNodeValue", (void (*)( Node *, InternedString ))&Metadata::deregisterNodeValue )
+		.staticmethod( "deregisterNodeValue" )
+
 		.def( "registerNodeDescription", boost::python::raw_function( &registerNodeDescription, 2 ) )
 		.staticmethod( "registerNodeDescription" )
 
@@ -363,6 +367,10 @@ void bindMetadata()
 			)
 		)
 		.staticmethod( "plugValue" )
+
+		.def( "deregisterPlugValue", (void (*)( IECore::TypeId, const MatchPattern &, InternedString ))&Metadata::deregisterPlugValue )
+		.def( "deregisterPlugValue", (void (*)( Plug *, InternedString ))&Metadata::deregisterPlugValue )
+		.staticmethod( "deregisterPlugValue" )
 
 		.def( "registerPlugDescription", &registerPlugDescription )
 		.staticmethod( "registerPlugDescription" )


### PR DESCRIPTION
- Added editing of summaries (static at present though)
- Added editing of presets
- Added ability to change widget type
- Added options for file chooser widgets

This also necessitated some improvements to the Metadata API, and various small enhancements to the PlugLayout and PlugValueWidget classes.

Alternative layouts can definitely be up for discussion/iteration - this is just my first stab. I based the current layout on analysis of the existing metadata registrations for Gaffer's build in node types. Absolutely everything has a description, and we want to encourage that for boxes too, so that is front and center in the UI. Next up our most common customisations are to choose a different widget type and add presets, so those come next. Presets take a lot of space so I put them in a collapsible container. Finally widgets have lots of little settings that can be tweaked but are needed less often, so I put them in a second collapsible container at the bottom. Totally open to some direction from some UI gurus or disgruntled users though...