### PR TITLE
Changed GafferUI.GLWidget ownership structure

### DIFF
--- a/python/GafferUI/GLWidget.py
+++ b/python/GafferUI/GLWidget.py
@@ -101,7 +101,7 @@ class GLWidget( GafferUI.Widget ) :
 		self.__overlay = overlay
 		self.__overlay._setStyleSheet()
 
-		item = self.__graphicsScene.addWidget( self.__overlay._qtWidget() )
+		item = self.__graphicsScene.addOverlay( self.__overlay )
 
 	## Called whenever the widget is resized. May be reimplemented by derived
 	# classes if necessary. The appropriate OpenGL context will already be current
@@ -376,14 +376,15 @@ class _GLGraphicsScene( QtGui.QGraphicsScene ) :
 		self.__backgroundDrawFunction = backgroundDrawFunction
 		self.sceneRectChanged.connect( self.__sceneRectChanged )
 
-	def addWidget( self, widget ) :
+	def addOverlay( self, widget ) :
 
-		if widget.layout() is not None :
+		self.__widget = widget
+		if widget._qtWidget().layout() is not None :
 			# removing the size constraint is necessary to keep the widget the
 			# size we tell it to be in __updateItemGeometry.
-			widget.layout().setSizeConstraint( QtGui.QLayout.SetNoConstraint )
+			widget._qtWidget().layout().setSizeConstraint( QtGui.QLayout.SetNoConstraint )
 
-		item = QtGui.QGraphicsScene.addWidget( self, widget )
+		item = QtGui.QGraphicsScene.addWidget( self, widget._qtWidget() )
 		self.__updateItemGeometry( item, self.sceneRect() )
 
 		return item


### PR DESCRIPTION
There was a funny crash happening in maya 2014 when you executed this code:
```
import IECore
import Gaffer
import GafferUI
import GafferScene
import GafferSceneUI

class _LookThroughPlugValueWidget( GafferUI.PlugValueWidget ) :

        def __init__( self, plug, **kw ) :
                import GafferScene
                row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal )

                GafferUI.PlugValueWidget.__init__( self, row, plug, **kw )

                with row :
                        GafferUI.PathPlugValueWidget(
                                plug["camera"],
                                path = GafferScene.ScenePath( plug.node()["in"], plug.node().getContext(), "/" ),
                        )


class _PlugLayout( GafferUI.Widget ) :

        def __init__( self, parent, orientation = GafferUI.ListContainer.Orientation.Vertical, **kw ) :

                assert( isinstance( parent, ( Gaffer.Node, Gaffer.CompoundPlug ) ) )

                mainContainer = GafferUI.ListContainer( orientation, spacing = 4 )

                GafferUI.Widget.__init__( self, mainContainer, **kw )
               
                with mainContainer:
                        import sys
                        GafferUI.UserPlugValueWidget( parent["user"] )
                        _LookThroughPlugValueWidget( parent["lookThrough"] )


class _StandardNodeToolbar( GafferUI.NodeToolbar ) :

        def __init__( self, node, **kw ) :

                self.__row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 )

                GafferUI.NodeToolbar.__init__( self, node, self.__row, **kw )

                self.__row.append( GafferUI.Spacer( IECore.V2i( 1, 1 ) ), expand = True )
                self.__row.append( _PlugLayout( node, orientation = GafferUI.ListContainer.Orientation.Horizontal ) )


class ThingyViewer( GafferUI.NodeSetEditor ) :

        def __init__( self, scriptNode, **kw ) :

                gadgetWidget = GafferUI.GadgetWidget(
                        bufferOptions = set( (
                                GafferUI.GLWidget.BufferOptions.Depth,
                                GafferUI.GLWidget.BufferOptions.Double )
                        ),
                )

                GafferUI.NodeSetEditor.__init__( self, gadgetWidget, scriptNode, **kw )

                with GafferUI.ListContainer( borderWidth = 2, spacing = 2 ) as toolbarColumn :
                        with GafferUI.ListContainer( borderWidth = 0, spacing = 2, orientation = GafferUI.ListContainer.Orientation.Horizontal ) :
                                toolbarFrame = GafferUI.Frame( borderWidth = 0, borderStyle=GafferUI.Frame.BorderStyle.None )
                gadgetWidget.addOverlay( toolbarColumn )

                currentView = None

                import GafferSceneUI
                currentView = GafferSceneUI.SceneView()
                viewToolbar = _StandardNodeToolbar( currentView )

                gadgetWidget.setViewportGadget( currentView.viewportGadget() )
                toolbarFrame.setChild( viewToolbar )

        def __repr__( self ) :

                return "ThingyViewer( scriptNode )"

class ThingyWindow( GafferUI.Window ) :

        def __init__( self, script, **kw ) :

                GafferUI.Window.__init__( self, **kw )

                self.__listContainer = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Vertical, spacing = 2 )
                self.__listContainer.append(
                        GafferUI.CompoundEditor(
                                script, children = (
                                        GafferUI.SplitContainer.Orientation.Horizontal, 0.70, (
                                                (
                                                        GafferUI.SplitContainer.Orientation.Vertical, 0.48,
                                                        (
                                                                {'tabs': (ThingyViewer( script ),), 'tabsVisible': True, 'currentTab': 0},
                                                                {'tabs': (), 'tabsVisible': True},
                                                        )
                                                ),
                                                {'tabs': (), 'tabsVisible': True},
                                        )
                                )
                        ), expand=True
                )

                self.setChild( self.__listContainer )

scriptNode = Gaffer.ScriptNode()
scriptWindow = ThingyWindow(scriptNode)
del scriptWindow
```
Some code executed by the GafferUI.Widget._EventFilter was picking up a python object while it was being deleted for some reason, which was leading to a double deletion. I never really managed to get to the bottom of why this was happening (it happens in maya, but not in standalone gaffer), but it only had the opportunity to do it because the ownership structure of the GLWidget was a bit off - the QT hierarchy didn't exactly mirror the GafferUI hierarchy. This pull request fixes that, and stops the crash (which just spawned its 5th or 6th shotgun ticket at IE, so it's high time I fixed it)