### PR TITLE
Reformat Performance

### DIFF
--- a/include/GafferImage/ChannelDataProcessor.h
+++ b/include/GafferImage/ChannelDataProcessor.h
@@ -70,12 +70,6 @@ class ChannelDataProcessor : public ImageProcessor
 		/// This implementation queries whether or not the requested channel is masked by the channelMaskPlug().
 		virtual bool channelEnabled( const std::string &channel ) const;
 
-		// Reimplemented to assign directly from the input. Format cannot be a direct connection
-		// because it needs to update when the default format changes.
-		/// \todo: make this a direct pass-through once FormatPlug supports it.
-		virtual void hashFormat( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual GafferImage::Format computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const;
-		
 		/// Implemented to initialize the output tile and then call processChannelData()
 		/// All other ImagePlug children are passed through via direct connection to the input values.
 		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const;

--- a/include/GafferImage/ColorProcessor.h
+++ b/include/GafferImage/ColorProcessor.h
@@ -63,12 +63,6 @@ class ColorProcessor : public ImageProcessor
 
 		virtual bool channelEnabled( const std::string &channel ) const;
 
-		// Reimplemented to assign directly from the input. Format cannot be a direct connection
-		// because it needs to update when the default format changes.
-		/// \todo: make this a direct pass-through once FormatPlug supports it.
-		virtual void hashFormat( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual GafferImage::Format computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const;
-		
 		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 		virtual void hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 		

--- a/include/GafferImage/DeleteChannels.h
+++ b/include/GafferImage/DeleteChannels.h
@@ -75,12 +75,6 @@ class DeleteChannels : public ImageProcessor
 
 	protected :
 
-		// Reimplemented to assign directly from the input. Format cannot be a direct connection
-		// because it needs to update when the default format changes.
-		/// \todo: make this a direct pass-through once FormatPlug supports it.
-		virtual void hashFormat( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual GafferImage::Format computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const;
-		
 		// Reimplemented to perform the deletion.
 		virtual void hashChannelNames( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 		virtual IECore::ConstStringVectorDataPtr computeChannelNames( const Gaffer::Context *context, const ImagePlug *parent ) const;

--- a/include/GafferImage/ImageNode.h
+++ b/include/GafferImage/ImageNode.h
@@ -107,8 +107,6 @@ class ImageNode : public Gaffer::ComputeNode
 		///
 		///    * Make an input connection into the corresponding plug, so that the hash and compute methods
 		///      are never called for it.
-		///	\todo The connection option is not currently valid for the FormatPlug, because it prevents
-		///	hashes from updating when the ScriptNode's default format changes.
 		virtual void hashFormat( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 		virtual void hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 		virtual void hashMetadata( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;

--- a/include/GafferImage/Merge.h
+++ b/include/GafferImage/Merge.h
@@ -102,12 +102,6 @@ class Merge : public ImageProcessor
 		/// Reimplementated to check that at least two of the inputs are connected
 		virtual bool enabled() const;
 		
-		// Reimplemented to assign directly from the first input. Format cannot be a direct connection
-		// because it needs to update when the default format changes.
-		/// \todo: make this a direct pass-through once FormatPlug supports it.
-		virtual void hashFormat( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual GafferImage::Format computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const;
-		
 		/// Reimplemented to hash the connected input plugs
 		virtual void hashDataWindow( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 		virtual void hashChannelNames( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;

--- a/include/GafferImage/MetadataProcessor.h
+++ b/include/GafferImage/MetadataProcessor.h
@@ -60,12 +60,6 @@ class MetadataProcessor : public ImageProcessor
 
 	protected :
 
-		// Reimplemented to assign directly from the input. Format cannot be a direct connection
-		// because it needs to update when the default format changes.
-		/// \todo: make this a direct pass-through once FormatPlug supports it.
-		virtual void hashFormat( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual GafferImage::Format computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const;
-		
 		// Reimplemented to call hashProcessedMetadata()
 		virtual void hashMetadata( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 		// Reimplemented to call computeProcessedMetadata()

--- a/include/GafferImage/Reformat.h
+++ b/include/GafferImage/Reformat.h
@@ -64,7 +64,6 @@ class Reformat : public ImageProcessor
 		const GafferImage::FilterPlug *filterPlug() const;
 
 		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
-		virtual bool enabled() const;
 
 	protected :
 
@@ -81,10 +80,10 @@ class Reformat : public ImageProcessor
 		/// This process is repeated once for the vertical and horizontal passes and the final result is written into the output buffer.
 		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const;
 
-		// Computes the output scale factor from the input and output formats.
-		Imath::V2d scale() const;
-
 	private :
+
+		// Computes the output scale factor from the input and output formats.
+		Imath::V2d scale( const Format &inFormat, const Format &outFormat ) const;
 
 		static size_t g_firstPlugIndex;
 

--- a/include/GafferOSL/OSLImage.h
+++ b/include/GafferOSL/OSLImage.h
@@ -72,12 +72,6 @@ class OSLImage : public GafferImage::ImageProcessor
 		virtual Imath::Box2i computeDataWindow( const Gaffer::Context *context, const GafferImage::ImagePlug *parent ) const;
 		virtual IECore::ConstCompoundObjectPtr computeMetadata( const Gaffer::Context *context, const GafferImage::ImagePlug *parent ) const;
 
-		// Reimplemented to assign directly from the input. Format cannot be a direct connection
-		// because it needs to update when the default format changes.
-		/// \todo: make this a direct pass-through once FormatPlug supports it.
-		virtual void hashFormat( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual GafferImage::Format computeFormat( const Gaffer::Context *context, const GafferImage::ImagePlug *parent ) const;
-		
 		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 		virtual void hashChannelNames( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 		virtual void hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;

--- a/python/GafferImageTest/FormatTest.py
+++ b/python/GafferImageTest/FormatTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2012-2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2012-2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -114,14 +114,16 @@ class FormatTest( unittest.TestCase ) :
 		s = Gaffer.ScriptNode()
 		s.addChild( n )
 
-		h1 = n["out"]["format"].hash()
+		with s.context() :
+			h1 = n["out"]["format"].hash()
 
 		# Change the default format.
 		GafferImage.Format.registerFormat( self.__testFormatValue(), self.__testFormatName() )
 		GafferImage.Format.setDefaultFormat( s, self.__testFormatValue() )
 
 		# Check that the hash has changed.
-		h2 = n["out"]["format"].hash()
+		with s.context() :
+			h2 = n["out"]["format"].hash()
 
 		# we want to assert h1 != h2, but we get a more useful failure message this way
 		if h1 == h2 :

--- a/python/GafferImageTest/ImageWriterTest.py
+++ b/python/GafferImageTest/ImageWriterTest.py
@@ -229,9 +229,8 @@ class ImageWriterTest( unittest.TestCase ) :
 			w["in"].setInput( c["out"] )
 			w["fileName"].setValue( testFile )
 
-			# Execute
-			with Gaffer.Context() :
-				w.execute()
+			w.execute()
+			
 			self.failUnless( os.path.exists( testFile ) )
 			i = IECore.Reader.create( testFile ).read()
 			i.blindData().clear()

--- a/src/GafferImage/ChannelDataProcessor.cpp
+++ b/src/GafferImage/ChannelDataProcessor.cpp
@@ -59,6 +59,7 @@ ChannelDataProcessor::ChannelDataProcessor( const std::string &name )
 	);
 	
 	// We don't ever want to change these, so we make pass-through connections.
+	outPlug()->formatPlug()->setInput( inPlug()->formatPlug() );
 	outPlug()->dataWindowPlug()->setInput( inPlug()->dataWindowPlug() );
 	outPlug()->metadataPlug()->setInput( inPlug()->metadataPlug() );
 	outPlug()->channelNamesPlug()->setInput( inPlug()->channelNamesPlug() );
@@ -110,14 +111,4 @@ IECore::ConstFloatVectorDataPtr ChannelDataProcessor::computeChannelData( const 
 	IECore::FloatVectorDataPtr outData = inPlug()->channelData( channelName, tileOrigin )->copy();
 	processChannelData( context, parent, channelName, outData );
 	return outData;
-}
-
-void ChannelDataProcessor::hashFormat( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const
-{
-	h = inPlug()->formatPlug()->hash();
-}
-
-GafferImage::Format ChannelDataProcessor::computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const
-{
-	return inPlug()->formatPlug()->getValue();
 }

--- a/src/GafferImage/ColorProcessor.cpp
+++ b/src/GafferImage/ColorProcessor.cpp
@@ -68,6 +68,7 @@ ColorProcessor::ColorProcessor( const std::string &name )
 	outPlug()->channelDataPlug()->setFlags( Plug::Cacheable, false );
 	
 	// We don't ever want to change the these, so we make pass-through connections.
+	outPlug()->formatPlug()->setInput( inPlug()->formatPlug() );
 	outPlug()->dataWindowPlug()->setInput( inPlug()->dataWindowPlug() );
 	outPlug()->metadataPlug()->setInput( inPlug()->metadataPlug() );
 	outPlug()->channelNamesPlug()->setInput( inPlug()->channelNamesPlug() );
@@ -154,16 +155,6 @@ void ColorProcessor::compute( Gaffer::ValuePlug *output, const Gaffer::Context *
 	}
 
 	ImageProcessor::compute( output, context );
-}
-
-void ColorProcessor::hashFormat( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const
-{
-	h = inPlug()->formatPlug()->hash();
-}
-
-GafferImage::Format ColorProcessor::computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const
-{
-	return inPlug()->formatPlug()->getValue();
 }
 
 void ColorProcessor::hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const

--- a/src/GafferImage/DeleteChannels.cpp
+++ b/src/GafferImage/DeleteChannels.cpp
@@ -64,6 +64,7 @@ DeleteChannels::DeleteChannels( const std::string &name )
 	// Direct pass-through for the things we don't ever change.
 	// This not only simplifies our implementation, but it is also
 	// faster to compute.
+	outPlug()->formatPlug()->setInput( inPlug()->formatPlug() );
 	outPlug()->dataWindowPlug()->setInput( inPlug()->dataWindowPlug() );
 	outPlug()->metadataPlug()->setInput( inPlug()->metadataPlug() );
 	outPlug()->channelDataPlug()->setInput( inPlug()->channelDataPlug() );
@@ -106,16 +107,6 @@ void DeleteChannels::affects( const Gaffer::Plug *input, AffectedPlugsContainer 
 	{
 		outputs.push_back( outPlug()->channelNamesPlug() );
 	}
-}
-
-void DeleteChannels::hashFormat( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const
-{
-	h = inPlug()->formatPlug()->hash();
-}
-
-GafferImage::Format DeleteChannels::computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const
-{
-	return inPlug()->formatPlug()->getValue();
 }
 
 void DeleteChannels::hashChannelNames( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const

--- a/src/GafferImage/FormatData.cpp
+++ b/src/GafferImage/FormatData.cpp
@@ -78,8 +78,7 @@ template<>
 void SimpleDataHolder<GafferImage::Format>::hash( MurmurHash &h ) const
 {
 	GafferImage::Format f = readable();
-	h.append( f.getDisplayWindow().min );
-	h.append( f.getDisplayWindow().max );
+	h.append( f.getDisplayWindow() );
 	h.append( f.getPixelAspect() );
 }
 

--- a/src/GafferImage/ImagePlug.cpp
+++ b/src/GafferImage/ImagePlug.cpp
@@ -341,6 +341,14 @@ IECore::ImagePrimitivePtr ImagePlug::image() const
 		newDataWindow = format.yDownToFormatSpace( dataWindow );
 	}
 
+	// use the default format if we don't have an explicit one.
+	/// \todo: remove this once FormatPlug is handling it for
+	/// us during ExecutableNode::execute (see issue #887).
+	if( format.getDisplayWindow().isEmpty() )
+	{
+		format = Context::current()->get<Format>( Format::defaultFormatContextName, Format() );
+	}
+	
 	ImagePrimitivePtr result = new ImagePrimitive( newDataWindow, format.getDisplayWindow() );
 	
 	ConstCompoundObjectPtr metadata = metadataPlug()->getValue();

--- a/src/GafferImage/ImagePlug.cpp
+++ b/src/GafferImage/ImagePlug.cpp
@@ -85,7 +85,7 @@ class CopyTiles
 				m_tileSize( tileSize )
 		{}
 
-		void operator()( const blocked_range2d<size_t>& r ) const
+		void operator()( const blocked_range3d<size_t>& r ) const
 		{
 			ContextPtr context = new Context( *m_parentContext, Context::Borrowed );
 			Context::Scope scope( context.get() );
@@ -95,10 +95,10 @@ class CopyTiles
 			V2i maxTileOrigin = ImagePlug::tileOrigin( operationWindow.max );
 			size_t imageStride = m_dataWindow.size().x + 1;
 			
-			for( vector<string>::const_iterator it = m_channelNames.begin(), eIt = m_channelNames.end(); it != eIt; it++ )
+			for( size_t channelIndex = r.pages().begin(); channelIndex < r.pages().end(); ++channelIndex )
 			{
-				context->set( ImagePlug::channelNameContextName, *it );
-				float *channelBegin = m_imageChannelData[ it - m_channelNames.begin() ];
+				context->set( ImagePlug::channelNameContextName, m_channelNames[channelIndex] );
+				float *channelBegin = m_imageChannelData[channelIndex];
 				
 				for( int tileOriginY = minTileOrigin.y; tileOriginY <= maxTileOrigin.y; tileOriginY += m_tileSize )
 				{
@@ -359,7 +359,7 @@ IECore::ImagePrimitivePtr ImagePlug::image() const
 		imageChannelData.push_back( &(c[0]) );
 	}
 
-	parallel_for( blocked_range2d<size_t>( 0, dataWindow.size().x+1, tileSize(), 0, dataWindow.size().y+1, tileSize() ),
+	parallel_for( blocked_range3d<size_t>( 0, imageChannelData.size(), 1, 0, dataWindow.size().x+1, tileSize(), 0, dataWindow.size().y+1, tileSize() ),
 		      GafferImage::Detail::CopyTiles( imageChannelData, channelNames, channelDataPlug(), dataWindow, Context::current(), tileSize()) );
 
 	return result;

--- a/src/GafferImage/ImagePlug.cpp
+++ b/src/GafferImage/ImagePlug.cpp
@@ -108,17 +108,16 @@ class CopyTiles
 						
 						Box2i tileBound( V2i( tileOriginX, tileOriginY ), V2i( tileOriginX + m_tileSize - 1, tileOriginY + m_tileSize - 1 ) );
 						Box2i b = boxIntersection( tileBound, operationWindow );
-
+						size_t tileStrideSize = sizeof(float) * ( b.size().x + 1 );
+						
 						ConstFloatVectorDataPtr tileData = m_channelDataPlug->getValue();
+						const float *tileDataBegin = &(tileData->readable()[0]);
 
 						for( int y = b.min.y; y<=b.max.y; y++ )
 						{
-							const float *tilePtr = &(tileData->readable()[0]) + (y - tileOriginY) * m_tileSize + (b.min.x - tileOriginX);
+							const float *tilePtr = tileDataBegin + (y - tileOriginY) * m_tileSize + (b.min.x - tileOriginX);
 							float *channelPtr = channelBegin + ( m_dataWindow.size().y - ( y - m_dataWindow.min.y ) ) * imageStride + (b.min.x - m_dataWindow.min.x);
-							for( int x = b.min.x; x <= b.max.x; x++ )
-							{
-								*channelPtr++ = *tilePtr++;
-							}
+							std::memcpy( channelPtr, tilePtr, tileStrideSize );
 						}
 					}
 				}

--- a/src/GafferImage/Merge.cpp
+++ b/src/GafferImage/Merge.cpp
@@ -78,6 +78,7 @@ Merge::Merge( const std::string &name )
 	);
 
 	// We don't ever want to change these, so we make pass-through connections.
+	outPlug()->formatPlug()->setInput( inPlug()->formatPlug() );
 	outPlug()->metadataPlug()->setInput( inPlug()->metadataPlug() );
 }
 
@@ -121,16 +122,6 @@ bool Merge::enabled() const
 	}
 
 	return ( m_inputs.nConnectedInputs() >= 2 );
-}
-
-void Merge::hashFormat( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const
-{
-	h = inPlug()->formatPlug()->hash();
-}
-
-GafferImage::Format Merge::computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const
-{
-	return inPlug()->formatPlug()->getValue();
 }
 
 void Merge::hashDataWindow( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const

--- a/src/GafferImage/MetadataProcessor.cpp
+++ b/src/GafferImage/MetadataProcessor.cpp
@@ -48,6 +48,7 @@ MetadataProcessor::MetadataProcessor( const std::string &name )
 	:	ImageProcessor( name )
 {
 	// Direct pass-through for the things we don't ever change.
+	outPlug()->formatPlug()->setInput( inPlug()->formatPlug() );
 	outPlug()->dataWindowPlug()->setInput( inPlug()->dataWindowPlug() );
 	outPlug()->channelNamesPlug()->setInput( inPlug()->channelNamesPlug() );
 	outPlug()->channelDataPlug()->setInput( inPlug()->channelDataPlug() );
@@ -65,16 +66,6 @@ void MetadataProcessor::affects( const Gaffer::Plug *input, AffectedPlugsContain
 	{
 		outputs.push_back( outPlug()->metadataPlug() );
 	}
-}
-
-void MetadataProcessor::hashFormat( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const
-{
-	h = inPlug()->formatPlug()->hash();
-}
-
-GafferImage::Format MetadataProcessor::computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const
-{
-	return inPlug()->formatPlug()->getValue();
 }
 
 void MetadataProcessor::hashMetadata( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const

--- a/src/GafferOSL/OSLImage.cpp
+++ b/src/GafferOSL/OSLImage.cpp
@@ -74,6 +74,7 @@ OSLImage::OSLImage( const std::string &name )
 	outPlug()->channelDataPlug()->setFlags( Plug::Cacheable, false );
 	
 	// We don't ever want to change these, so we make pass-through connections.
+	outPlug()->formatPlug()->setInput( inPlug()->formatPlug() );
 	outPlug()->dataWindowPlug()->setInput( inPlug()->dataWindowPlug() );
 	outPlug()->metadataPlug()->setInput( inPlug()->metadataPlug() );
 }
@@ -186,16 +187,6 @@ void OSLImage::compute( Gaffer::ValuePlug *output, const Gaffer::Context *contex
 	}
 
 	ImageProcessor::compute( output, context );
-}
-
-void OSLImage::hashFormat( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const
-{
-	h = inPlug()->formatPlug()->hash();
-}
-
-GafferImage::Format OSLImage::computeFormat( const Gaffer::Context *context, const GafferImage::ImagePlug *parent ) const
-{
-	return inPlug()->formatPlug()->getValue();
 }
 
 void OSLImage::hashDataWindow( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const


### PR DESCRIPTION
This provides some speedups for a recent test @danieldresser has been doing with long chains of Reformat nodes. Removing `Reformat::enabled()` provided the best improvements, and everything else was just things I tried because they've been on our todo list for a while anyways, and I thought they might help (but didn't really). Hopefully it all seems worth keeping in any case...

The only one I'm unsure about is a7274432de242539e313402b53c927901281638f, because the issues I'm referring too suggest that StringPlug has the right approach, but StringPlug is testing `inCompute()`. I'm guessing some sort of `inComputeOrExecute()` could have made the test pass, but as that doesn't exist (or does it?) I've just removed the `inCompute()` bit... let me know if that seems like an issue.