### PR TITLE
Removed Reference::fileNamePlug()

### DIFF
--- a/include/Gaffer/Reference.h
+++ b/include/Gaffer/Reference.h
@@ -54,23 +54,28 @@ class Reference : public SubGraph
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::Reference, ReferenceTypeId, SubGraph );
 
-		/// The plugs that stores the name of the file being
-		/// referenced. This should be considered read-only, and the
-		/// load() method should be used to set it.
-		StringPlug *fileNamePlug();
-		const StringPlug *fileNamePlug() const;
-
 		/// Loads the specified script, which should have been exported
 		/// using Box::exportForReference().
+		/// \undoable.
 		void load( const std::string &fileName );
+		/// Returns the name of the script currently being referenced.
+		const std::string &fileName() const;
+		
+		typedef boost::signal<void ( Reference * )> ReferenceLoadedSignal;
+		/// Emitted when a reference is loaded (or unloaded following an undo).
+		ReferenceLoadedSignal &referenceLoadedSignal();
 
 	private :
 
+		void loadInternal( const std::string &fileName );
 		bool isReferencePlug( const Plug *plug ) const;
 
-		static size_t g_firstPlugIndex;
+		std::string m_fileName;
+		ReferenceLoadedSignal m_referenceLoadedSignal;
 
 };
+
+IE_CORE_DECLAREPTR( Reference )
 
 typedef FilteredChildIterator<TypePredicate<Reference> > ReferenceIterator;
 typedef FilteredRecursiveChildIterator<TypePredicate<Reference> > RecursiveReferenceIterator;

--- a/python/GafferTest/references/version-0.14.0.0.grf
+++ b/python/GafferTest/references/version-0.14.0.0.grf
@@ -1,0 +1,22 @@
+import Gaffer
+import IECore
+
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:majorVersion", 14, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:minorVersion", 0, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:patchVersion", 0, persistent=False )
+
+__children = {}
+
+__children["testPlug"] = Gaffer.FloatPlug( "testPlug", defaultValue = 2.0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, )
+parent.addChild( __children["testPlug"] )
+Gaffer.Metadata.registerPlugValue( parent["user"], "layout:section", IECore.StringData( 'User' ) )
+Gaffer.Metadata.registerPlugValue( __children["testPlug"], "nodule:type", IECore.StringData( '' ) )
+Gaffer.Metadata.registerPlugValue( __children["testPlug"], "layout:section", IECore.StringData( 'Settings' ) )
+Gaffer.Metadata.registerPlugValue( __children["testPlug"], "layout:index", IECore.IntData( 0 ) )
+Gaffer.Metadata.registerNodeValue( parent, "uiEditor:emptySections", IECore.StringVectorData( [  ] ) )
+Gaffer.Metadata.registerNodeValue( parent, "uiEditor:emptySectionIndices", IECore.IntVectorData( [  ] ) )
+
+
+del __children
+

--- a/python/GafferTest/scripts/referenceVersion-0.14.0.0.gfr
+++ b/python/GafferTest/scripts/referenceVersion-0.14.0.0.gfr
@@ -1,0 +1,26 @@
+import Gaffer
+import IECore
+
+__children = {}
+
+parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "projectName", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectName"].addChild( Gaffer.StringPlug( "name", defaultValue = 'project:name', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectName"].addChild( Gaffer.StringPlug( "value", defaultValue = 'default', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "projectRootDirectory", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "name", defaultValue = 'project:rootDirectory', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "value", defaultValue = '$HOME/gaffer/projects/${project:name}', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["Reference"] = Gaffer.Reference( "Reference" )
+parent.addChild( __children["Reference"] )
+__children["Reference"].load( "/tmp/test.grf" )
+__children["Reference"]["fileName"].setValue( '/tmp/test.grf' )
+__children["Reference"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = IECore.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["Reference"]["__uiPosition"].setValue( IECore.V2f( -2.299999, 0.59999752 ) )
+parent["variables"]["projectName"]["name"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
+parent["variables"]["projectRootDirectory"]["name"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
+Gaffer.Metadata.registerNodeValue( __children["Reference"], "uiEditor:emptySections", IECore.StringVectorData( [  ] ) )
+Gaffer.Metadata.registerNodeValue( __children["Reference"], "uiEditor:emptySectionIndices", IECore.IntVectorData( [  ] ) )
+Gaffer.Metadata.registerPlugValue( __children["Reference"]["user"], "layout:section", IECore.StringData( 'User' ) )
+
+
+del __children
+

--- a/python/GafferUI/NodeGraph.py
+++ b/python/GafferUI/NodeGraph.py
@@ -405,21 +405,10 @@ class NodeGraph( GafferUI.EditorWidget ) :
 		# save/restore the current framing so jumping in
 		# and out of Boxes isn't a confusing experience.
 
-		def __framePlug( node, createIfMissing = False ) :
+		Gaffer.Metadata.registerNodeValue( previousRoot, "ui:nodeGraph:framing", self.__currentFrame(), persistent = False )
 
-			plugName = "__nodeGraphFraming%d" % id( self )
-			result = node.getChild( plugName )
-			if result is None and createIfMissing :
-				result = Gaffer.Box2fPlug( plugName, flags = Gaffer.Plug.Flags.Default & ( ~Gaffer.Plug.Flags.Serialisable ) )
-				node.addChild( result )
-
-			return result
-
-		__framePlug( previousRoot, True ).setValue( self.__currentFrame() )
-
-		newFramePlug = __framePlug( self.graphGadget().getRoot() )
-		if newFramePlug is not None :
-			frame = newFramePlug.getValue()
+		frame = Gaffer.Metadata.nodeValue( self.graphGadget().getRoot(), "ui:nodeGraph:framing" )
+		if frame is not None :
 			self.graphGadgetWidget().getViewportGadget().frame(
 				IECore.Box3f( IECore.V3f( frame.min.x, frame.min.y, 0 ), IECore.V3f( frame.max.x, frame.max.y, 0 ) )
 			)


### PR DESCRIPTION
This removes the "fileName" plug from the Reference node, so the namespace is completely free for the end user to make a plug with that name, or with any other. This addresses the bulk of #801 - the only remaining items are where the UI makes an __ prefixed plug. I'm inclined to leave these for now and deal with them as and when we revisit those particular parts of the code - there's plenty of more important stuff to be getting on with. Does that sound OK?