### PR TITLE
Activator expressions are now attached to the parent of the plug

### DIFF
--- a/python/GafferRenderManUI/RenderManShaderUI.py
+++ b/python/GafferRenderManUI/RenderManShaderUI.py
@@ -333,7 +333,9 @@ def __nodeColor( node ) :
 
 	return None
 
-def __nodeActivators( node ) :
+def __parameterActivators( parent ) :
+
+	node = parent.node()
 
 	class ExpressionVariables :
 
@@ -413,7 +415,7 @@ Gaffer.Metadata.registerNodeValue( GafferRenderMan.RenderManShader, "nodeGadget:
 
 for nodeType in( GafferRenderMan.RenderManShader, GafferRenderMan.RenderManLight ) :
 
-	Gaffer.Metadata.registerNodeValue( nodeType, "layout:activators", __nodeActivators )
+	Gaffer.Metadata.registerPlugValue( nodeType, "parameters", "layout:activators", __parameterActivators )
 	Gaffer.Metadata.registerPlugDescription( nodeType, "parameters.*", __plugDescription )
 	Gaffer.Metadata.registerPlugValue( nodeType, "parameters.*", "label", __plugLabel )
 	Gaffer.Metadata.registerPlugValue( nodeType, "parameters.*", "divider", __plugDivider )

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -61,13 +61,13 @@ QtGui = GafferUI._qtImport( "QtGui" )
 #     string to be used as a summary for the section.
 #   - layout:section:sectionName:collapsed" boolean indicating whether or
 #     not a section should be collapsed initially.
+#   - "layout:activator:activatorName" a dynamic boolean metadata entry to control
+#     the activation of plugs within the layout
+#   - "layout:activators" a dynamic metadata entry returning a CompoundData of booleans
+#     for several named activators.
 #
 # Per-node metadata support :
 #
-#	- "layout:activator:activatorName" a dynamic boolean metadata entry to control
-#     the activation of plugs within the layout
-#	- "layout:activators" a dynamic metadata entry returning a CompoundData of booleans
-#     for several named activators.
 #
 # ## Custom widgets
 #
@@ -295,7 +295,7 @@ class PlugLayout( GafferUI.Widget ) :
 		if self.getReadOnly() :
 			return
 
-		activators = Gaffer.Metadata.nodeValue( self.__node(), "layout:activators" ) or {}
+		activators = self.__metadataValue( self.__parent, "layout:activators" ) or {}
 		activators = { k : v.value for k, v in activators.items() } # convert CompoundData of BoolData to dict of booleans
 
 		def active( activatorName ) :
@@ -304,7 +304,7 @@ class PlugLayout( GafferUI.Widget ) :
 			if activatorName :
 				result = activators.get( activatorName )
 				if result is None :
-					result = Gaffer.Metadata.nodeValue( self.__node(), "layout:activator:" + activatorName )
+					result = self.__metadataValue( self.__parent, "layout:activator:" + activatorName )
 					result = result if result is not None else False
 					activators[activatorName] = result
 


### PR DESCRIPTION
The parent may be either a node, or a compound plug, rather than always being on the node.

I was a bit nervous about these changes, since I don't really understand this system ( I still haven't spotted where the activator function is actually called ).  But the changes seem straightforward, and after a small tweak to the shader metadata stuff, everything seems to be working.  I tested all uses of activators I could find in Gaffer:  Wedge, Sphere, AttributeVisualiser, and 3delight shaders.

It nicely does the job for my use case in IERendering.  So unless you've thought of some other case, I guess this may be good to go.  We probably need to search for any other IE projects that might be using activators.