### PR TITLE
ImageWriter : Allow reading of images generated after dispatch.

### DIFF
--- a/src/GafferImage/ImageWriter.cpp
+++ b/src/GafferImage/ImageWriter.cpp
@@ -308,7 +308,6 @@ IECore::MurmurHash ImageWriter::hash( const Context *context ) const
 	h.append( fileNamePlug()->hash() );
 	h.append( writeModePlug()->hash() );
 	h.append( channelsPlug()->hash() );
-	h.append( inPlug()->imageHash() );
 	return h;
 }
 


### PR DESCRIPTION
As described in the comments, this is a pretty common use case, and we don't want a user to have to do anything special to enable it. Although not including the image hash is technically incorrect, we assume that when writing different images with the same ImageWriter instance (whether from different frames, or via a Wedge or TaskContextVariables node), the filename will be varied to capture each different image into a different file, and this will mean our hash is unique per image too.

There may be a use case we haven't thought of where this will cause problems. The only alternative solutions I can think of are :

- Have the user set some sort of "ignore errors" plug on the ImageReader or some sort of "don't hash the image" plug on the ImageWriter. But we want to avoid user intervention for this common case.
- Have the ImageWriter put some sort of "don't worry about missing files" variable in the context when calling `ImagePlug::imageHash()` and have the ImageReader act on that appropriately.

It seems that the latter might be our best solution, but for now we are going with the simplest approach until proven insufficient.