### PR TITLE
PlugLayout : Activators drive enabled-ness rather than read-only-ness.

### DIFF
--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -141,11 +141,8 @@ class PlugLayout( GafferUI.Widget ) :
  			return
 
  		self.__readOnly = readOnly
-		if self.__readOnly :
-			for widget in self.__widgets.values() :
-				self.__applyReadOnly( widget, self.__readOnly )
-		else :
-			self.__updateActivations()
+		for widget in self.__widgets.values() :
+			self.__applyReadOnly( widget, self.__readOnly )
 
 	def getContext( self ) :
 
@@ -308,9 +305,6 @@ class PlugLayout( GafferUI.Widget ) :
 
 	def __updateActivations( self ) :
 
-		if self.getReadOnly() :
-			return
-
 		with self.getContext() :
 			# Must scope the context when getting activators, because they are typically
 			# computed from the plug values, and may therefore trigger a compute.
@@ -332,8 +326,8 @@ class PlugLayout( GafferUI.Widget ) :
 			return result
 
 		for item, widget in self.__widgets.items() :
-			self.__applyReadOnly( widget, not active( self.__itemMetadataValue( item, "activator" ) ) )
 			if widget is not None :
+				widget.setEnabled( active( self.__itemMetadataValue( item, "activator" ) ) )
 				widget.setVisible( active( self.__itemMetadataValue( item, "visibilityActivator" ) ) )
 
 	def __updateSummariesWalk( self, section ) :

--- a/python/GafferUITest/PlugLayoutTest.py
+++ b/python/GafferUITest/PlugLayoutTest.py
@@ -262,10 +262,10 @@ class PlugLayoutTest( GafferUITest.TestCase ) :
 		s["e"]["expression"].setValue( 'parent["n"]["b"] = context["bVariable"]' )
 
 		l = GafferUI.PlugLayout( s["n"] )
-		self.assertEqual( l.plugValueWidget( s["n"]["s"], lazy = False ).getReadOnly(), True )
+		self.assertEqual( l.plugValueWidget( s["n"]["s"], lazy = False ).enabled(), False )
 
 		p["value"].setValue( True )
-		self.assertEqual( l.plugValueWidget( s["n"]["s"], lazy = False ).getReadOnly(), False )
+		self.assertEqual( l.plugValueWidget( s["n"]["s"], lazy = False ).enabled(), True )
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
Whether a plug (or UI) is read-only or not is orthogonal to whether or not the plug is relevant given the current values of other plugs. Since activators were intended to model the latter concept, it makes more sense to use the enabled state of the widget to implement their effect.