### PR TITLE
SubGraph binding : Support subclassing in Python.

### DIFF
--- a/python/GafferTest/SubGraphTest.py
+++ b/python/GafferTest/SubGraphTest.py
@@ -1,0 +1,75 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferTest
+
+class SubGraphTest( GafferTest.TestCase ) :
+
+	def testDerivingInPython( self ) :
+
+		class MySubGraph( Gaffer.SubGraph ) :
+
+			def __init__( self, name = "MySubGraph" ) :
+
+				Gaffer.SubGraph.__init__( self, name )
+
+		IECore.registerRunTimeTyped( MySubGraph )
+
+		Gaffer.Metadata.registerNode(
+
+			MySubGraph,
+
+			"description",
+			"""
+			If you're retrieving this, the subclassing has worked.
+			""",
+
+		)
+
+		n = MySubGraph()
+		self.assertEqual(
+			Gaffer.Metadata.nodeValue( n, "description" ),
+			"If you're retrieving this, the subclassing has worked."
+		)
+
+if __name__ == "__main__":
+	unittest.main()
+

--- a/python/GafferTest/__init__.py
+++ b/python/GafferTest/__init__.py
@@ -135,6 +135,7 @@ from MatchPatternPathFilterTest import MatchPatternPathFilterTest
 from LoopTest import LoopTest
 from WedgeTest import WedgeTest
 from TaskContextVariablesTest import TaskContextVariablesTest
+from SubGraphTest import SubGraphTest
 
 if __name__ == "__main__":
 	import unittest

--- a/src/GafferBindings/SubGraphBinding.cpp
+++ b/src/GafferBindings/SubGraphBinding.cpp
@@ -49,7 +49,8 @@ namespace GafferBindings
 
 void bindSubGraph()
 {
-	DependencyNodeClass<SubGraph>();
+	typedef DependencyNodeWrapper<SubGraph> Wrapper;
+	DependencyNodeClass<SubGraph, Wrapper>();
 }
 
 } // namespace GafferBindings


### PR DESCRIPTION
It seems this will be necessary for #25 when we come to it, and it's also something that @danieldresser can make use of immediately.