### PR TITLE
Small changes for Box promotion

### DIFF
--- a/include/Gaffer/Box.h
+++ b/include/Gaffer/Box.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2013-2015, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -92,6 +92,7 @@ class Box : public SubGraph
 	private :
 
 		bool validatePromotability( const Plug *descendantPlug, bool throwExceptions, bool childPlug = false ) const;
+		std::string promotedCounterpartName( const Plug *plug ) const;
 		static void copyMetadata( const Plug *from, Plug *to );
 
 };

--- a/python/GafferSceneTest/ShaderAssignmentTest.py
+++ b/python/GafferSceneTest/ShaderAssignmentTest.py
@@ -1,7 +1,7 @@
 ##########################################################################
 #
 #  Copyright (c) 2012, John Haddon. All rights reserved.
-#  Copyright (c) 2012-2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2012-2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -120,7 +120,7 @@ class ShaderAssignmentTest( unittest.TestCase ) :
 		s = Gaffer.ScriptNode()
 		s.execute( ss )
 
-		self.assertTrue( s["Box"]["a"]["shader"].getInput().isSame( s["Box"]["in"] ) )
+		self.assertTrue( s["Box"]["a"]["shader"].getInput().isSame( s["Box"]["shader"] ) )
 
 	def testDisabled( self ) :
 

--- a/python/GafferSceneUITest/ShaderAssignmentUITest.py
+++ b/python/GafferSceneUITest/ShaderAssignmentUITest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2013-2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -62,7 +62,7 @@ class ShaderAssignmentUITest( GafferUITest.TestCase ) :
 		boxGadget = g.nodeGadget( box )
 
 		self.assertEqual( boxGadget.noduleTangent( boxGadget.nodule( box["in"] ) ), IECore.V3f( 0, 1, 0 ) )
-		self.assertEqual( boxGadget.noduleTangent( boxGadget.nodule( box["in1"] ) ), IECore.V3f( -1, 0, 0 ) )
+		self.assertEqual( boxGadget.noduleTangent( boxGadget.nodule( box["shader"] ) ), IECore.V3f( -1, 0, 0 ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/BoxTest.py
+++ b/python/GafferTest/BoxTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2013-2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -304,7 +304,7 @@ class BoxTest( GafferTest.TestCase ) :
 		self.assertFalse( b.plugIsPromoted( s["n2"]["op1"] ) )
 
 		p = b.promotePlug( b["n1"]["op1"] )
-		self.assertEqual( p.getName(), "n1_op1" )
+		self.assertEqual( p.getName(), "op1" )
 		self.assertTrue( p.parent().isSame( b ) )
 		self.assertTrue( b["n1"]["op1"].getInput().isSame( p ) )
 		self.assertTrue( b.plugIsPromoted( b["n1"]["op1"] ) )
@@ -363,8 +363,8 @@ class BoxTest( GafferTest.TestCase ) :
 		s = Gaffer.ScriptNode()
 		s.execute( ss )
 
-		self.assertTrue( isinstance( s["Box"]["n_c"], Gaffer.Color3fPlug ) )
-		self.assertTrue( s["Box"]["n"]["c"].getInput().isSame( s["Box"]["n_c"] ) )
+		self.assertTrue( isinstance( s["Box"]["c"], Gaffer.Color3fPlug ) )
+		self.assertTrue( s["Box"]["n"]["c"].getInput().isSame( s["Box"]["c"] ) )
 
 	def testCantPromoteNonSerialisablePlugs( self ) :
 
@@ -528,15 +528,15 @@ class BoxTest( GafferTest.TestCase ) :
 
 		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["a2"] ] ) )
 
-		self.assertEqual( Gaffer.Metadata.plugValue( b["in"], "description" ), None )
+		self.assertEqual( Gaffer.Metadata.plugValue( b["op1"], "description" ), None )
 
-		Gaffer.Metadata.registerPlugValue( b["in"], "description", "hello" )
-		self.assertEqual( Gaffer.Metadata.plugValue( b["in"], "description" ), "hello" )
+		Gaffer.Metadata.registerPlugValue( b["op1"], "description", "hello" )
+		self.assertEqual( Gaffer.Metadata.plugValue( b["op1"], "description" ), "hello" )
 
 		s2 = Gaffer.ScriptNode()
 		s2.execute( s.serialise() )
 
-		self.assertEqual( Gaffer.Metadata.plugValue( s2["Box"]["in"], "description" ), "hello" )
+		self.assertEqual( Gaffer.Metadata.plugValue( s2["Box"]["op1"], "description" ), "hello" )
 
 	def testCantPromoteReadOnlyPlug( self ) :
 

--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2013-2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -70,7 +70,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["r"].load( "/tmp/test.grf" )
 
 		self.assertTrue( "n1" in s["r"] )
-		self.assertTrue( s["r"]["out"].getInput().isSame( s["r"]["n1"]["sum"] ) )
+		self.assertTrue( s["r"]["sum"].getInput().isSame( s["r"]["n1"]["sum"] ) )
 
 	def testSerialisation( self ) :
 
@@ -89,11 +89,11 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["r"].load( "/tmp/test.grf" )
 
 		self.assertTrue( "n1" in s["r"] )
-		self.assertTrue( s["r"]["n1"]["op1"].getInput().isSame( s["r"]["n1_op1"] ) )
-		self.assertTrue( s["r"]["out"].getInput().isSame( s["r"]["n1"]["sum"] ) )
+		self.assertTrue( s["r"]["n1"]["op1"].getInput().isSame( s["r"]["op1"] ) )
+		self.assertTrue( s["r"]["sum"].getInput().isSame( s["r"]["n1"]["sum"] ) )
 
-		s["r"]["n1_op1"].setValue( 25 )
-		self.assertEqual( s["r"]["out"].getValue(), 25 )
+		s["r"]["op1"].setValue( 25 )
+		self.assertEqual( s["r"]["sum"].getValue(), 25 )
 
 		ss = s.serialise()
 
@@ -102,14 +102,14 @@ class ReferenceTest( GafferTest.TestCase ) :
 		self.assertTrue( "AddNode" not in ss )
 		# but the values of user plugs should be stored, so
 		# they can override the values from the reference.
-		self.assertTrue( "\"n1_op1\"" in ss )
+		self.assertTrue( "\"op1\"" in ss )
 
 		s2 = Gaffer.ScriptNode()
 		s2.execute( ss )
 
 		self.assertTrue( "n1" in s2["r"] )
-		self.assertTrue( s2["r"]["out"].getInput().isSame( s2["r"]["n1"]["sum"] ) )
-		self.assertEqual( s2["r"]["out"].getValue(), 25 )
+		self.assertTrue( s2["r"]["sum"].getInput().isSame( s2["r"]["n1"]["sum"] ) )
+		self.assertEqual( s2["r"]["sum"].getValue(), 25 )
 
 	def testReload( self ) :
 
@@ -131,17 +131,17 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s2["r"] = Gaffer.Reference()
 		s2["r"].load( "/tmp/test.grf" )
 
-		s2["r"]["in"].setInput( s2["n1"]["sum"] )
-		s2["r"]["n2_op2"].setValue( 1001 )
-		s2["n3"]["op1"].setInput( s2["r"]["out"] )
+		s2["r"]["op1"].setInput( s2["n1"]["sum"] )
+		s2["r"]["op2"].setValue( 1001 )
+		s2["n3"]["op1"].setInput( s2["r"]["sum"] )
 
 		self.assertTrue( "n2" in s2["r"] )
-		self.assertTrue( s2["r"]["n2"]["op1"].getInput().isSame( s2["r"]["in"] ) )
-		self.assertTrue( s2["r"]["n2"]["op2"].getInput().isSame( s2["r"]["n2_op2"] ) )
-		self.assertEqual( s2["r"]["n2_op2"].getValue(), 1001 )
-		self.assertTrue( s2["r"]["out"].getInput().isSame( s2["r"]["n2"]["sum"] ) )
-		self.assertTrue( s2["r"]["in"].getInput().isSame( s2["n1"]["sum"] ) )
-		self.assertTrue( s2["n3"]["op1"].getInput().isSame( s2["r"]["out"] ) )
+		self.assertTrue( s2["r"]["n2"]["op1"].getInput().isSame( s2["r"]["op1"] ) )
+		self.assertTrue( s2["r"]["n2"]["op2"].getInput().isSame( s2["r"]["op2"] ) )
+		self.assertEqual( s2["r"]["op2"].getValue(), 1001 )
+		self.assertTrue( s2["r"]["sum"].getInput().isSame( s2["r"]["n2"]["sum"] ) )
+		self.assertTrue( s2["r"]["op1"].getInput().isSame( s2["n1"]["sum"] ) )
+		self.assertTrue( s2["n3"]["op1"].getInput().isSame( s2["r"]["sum"] ) )
 		originalReferencedNames = s2["r"].keys()
 
 		b["anotherNode"] = GafferTest.AddNode()
@@ -151,14 +151,14 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s2["r"].load( "/tmp/test.grf" )
 
 		self.assertTrue( "n2" in s2["r"] )
-		self.assertEqual( set( s2["r"].keys() ), set( originalReferencedNames + [ "anotherNode", "anotherNode_op2" ] ) )
-		self.assertTrue( s2["r"]["n2"]["op1"].getInput().isSame( s2["r"]["in"] ) )
-		self.assertTrue( s2["r"]["n2"]["op2"].getInput().isSame( s2["r"]["n2_op2"] ) )
-		self.assertEqual( s2["r"]["n2_op2"].getValue(), 1001 )
-		self.assertTrue( s2["r"]["anotherNode"]["op2"].getInput().isSame( s2["r"]["anotherNode_op2"] ) )
-		self.assertTrue( s2["r"]["out"].getInput().isSame( s2["r"]["n2"]["sum"] ) )
-		self.assertTrue( s2["r"]["in"].getInput().isSame( s2["n1"]["sum"] ) )
-		self.assertTrue( s2["n3"]["op1"].getInput().isSame( s2["r"]["out"] ) )
+		self.assertEqual( set( s2["r"].keys() ), set( originalReferencedNames + [ "anotherNode", "op3" ] ) )
+		self.assertTrue( s2["r"]["n2"]["op1"].getInput().isSame( s2["r"]["op1"] ) )
+		self.assertTrue( s2["r"]["n2"]["op2"].getInput().isSame( s2["r"]["op2"] ) )
+		self.assertEqual( s2["r"]["op2"].getValue(), 1001 )
+		self.assertTrue( s2["r"]["anotherNode"]["op2"].getInput().isSame( s2["r"]["op3"] ) )
+		self.assertTrue( s2["r"]["sum"].getInput().isSame( s2["r"]["n2"]["sum"] ) )
+		self.assertTrue( s2["r"]["op1"].getInput().isSame( s2["n1"]["sum"] ) )
+		self.assertTrue( s2["n3"]["op1"].getInput().isSame( s2["r"]["sum"] ) )
 
 	def testReloadDoesntRemoveCustomPlugs( self ) :
 
@@ -202,12 +202,12 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s2["r"].load( "/tmp/test.grf" )
 		s2["a"] = GafferTest.AddNode()
 
-		s2["r"]["n2_op2"].setValue( 123 )
-		s2["r"]["in"].setInput( s2["a"]["sum"] )
+		s2["r"]["op2"].setValue( 123 )
+		s2["r"]["op1"].setInput( s2["a"]["sum"] )
 
 		self.assertTrue( "n2" in s2["r"] )
-		self.assertTrue( "out" in s2["r"] )
-		self.assertTrue( s2["r"]["in"].getInput().isSame( s2["a"]["sum"] ) )
+		self.assertTrue( "sum" in s2["r"] )
+		self.assertTrue( s2["r"]["op1"].getInput().isSame( s2["a"]["sum"] ) )
 
 		s2["fileName"].setValue( "/tmp/test.gfr" )
 		s2.save()
@@ -218,8 +218,8 @@ class ReferenceTest( GafferTest.TestCase ) :
 
 		self.assertEqual( s3["r"].keys(), s2["r"].keys() )
 		self.assertEqual( s3["r"]["user"].keys(), s2["r"]["user"].keys() )
-		self.assertEqual( s3["r"]["n2_op2"].getValue(), 123 )
-		self.assertTrue( s3["r"]["in"].getInput().isSame( s3["a"]["sum"] ) )
+		self.assertEqual( s3["r"]["op2"].getValue(), 123 )
+		self.assertTrue( s3["r"]["op1"].getInput().isSame( s3["a"]["sum"] ) )
 
 	def testReferenceExportCustomPlugsFromBoxes( self ) :
 
@@ -439,7 +439,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		
 		# load onto reference:
 		s["r"].load( "/tmp/test.grf" )
-		self.assertEqual( s["r"].correspondingInput( s["r"]["n_sum"] ), None )
+		self.assertEqual( s["r"].correspondingInput( s["r"]["sum"] ), None )
 		self.assertEqual( s["r"].enabledPlug(), None )
 		
 		# Wire it up to support enabledPlug() and correspondingInput()
@@ -449,7 +449,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		
 		# reload reference and test:
 		s["r"].load( "/tmp/test.grf" )
-		self.assertEqual( s["r"].correspondingInput( s["r"]["n_sum"] ), None )
+		self.assertEqual( s["r"].correspondingInput( s["r"]["sum"] ), None )
 		self.assertEqual( s["r"].enabledPlug(), None )
 		
 		# add an enabled plug:
@@ -458,7 +458,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		
 		# reload reference and test that's now visible via enabledPlug():
 		s["r"].load( "/tmp/test.grf" )
-		self.assertEqual( s["r"].correspondingInput( s["r"]["n_sum"] ), None )
+		self.assertEqual( s["r"].correspondingInput( s["r"]["sum"] ), None )
 		self.assertTrue( s["r"].enabledPlug().isSame( s["r"]["enabled"] ) )
 		
 		# hook up the enabled plug inside the box:
@@ -468,15 +468,15 @@ class ReferenceTest( GafferTest.TestCase ) :
 		# reload reference and test that's now visible via enabledPlug():
 		s["r"].load( "/tmp/test.grf" )
 		self.assertTrue( s["r"].enabledPlug().isSame( s["r"]["enabled"] ) )
-		self.assertTrue( s["r"].correspondingInput( s["r"]["n_sum"] ).isSame( s["r"]["n_op1"] ) )
+		self.assertTrue( s["r"].correspondingInput( s["r"]["sum"] ).isSame( s["r"]["op1"] ) )
 		
 		
 		# Connect it into a network, delete it, and check that we get nice auto-reconnect behaviour
 		s["a"] = GafferTest.AddNode()
-		s["r"]["n_op1"].setInput( s["a"]["sum"] )
+		s["r"]["op1"].setInput( s["a"]["sum"] )
 
 		s["c"] = GafferTest.AddNode()
-		s["c"]["op1"].setInput( s["r"]["n_sum"] )
+		s["c"]["op1"].setInput( s["r"]["sum"] )
 
 		s.deleteNodes( filter = Gaffer.StandardSet( [ s["r"] ] ) )
 

--- a/python/GafferUITest/BoxUITest.py
+++ b/python/GafferUITest/BoxUITest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2013-2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -72,8 +72,8 @@ class BoxUITest( GafferUITest.TestCase ) :
 
 		boxGadget = g.nodeGadget( box )
 
-		self.assertEqual( boxGadget.noduleTangent( boxGadget.nodule( box["in"] ) ), IECore.V3f( -1, 0, 0 ) )
-		self.assertEqual( boxGadget.noduleTangent( boxGadget.nodule( box["out"] ) ), IECore.V3f( 1, 0, 0 ) )
+		self.assertEqual( boxGadget.noduleTangent( boxGadget.nodule( box["op1"] ) ), IECore.V3f( -1, 0, 0 ) )
+		self.assertEqual( boxGadget.noduleTangent( boxGadget.nodule( box["sum"] ) ), IECore.V3f( 1, 0, 0 ) )
 
 		# Now test that a copy/paste of the box maintains the tangents in the copy.
 
@@ -85,8 +85,8 @@ class BoxUITest( GafferUITest.TestCase ) :
 		box2 = s2[box.getName()]
 		boxGadget2 = g2.nodeGadget( box2 )
 
-		self.assertEqual( boxGadget2.noduleTangent( boxGadget2.nodule( box2["in"] ) ), IECore.V3f( -1, 0, 0 ) )
-		self.assertEqual( boxGadget2.noduleTangent( boxGadget2.nodule( box2["out"] ) ), IECore.V3f( 1, 0, 0 ) )
+		self.assertEqual( boxGadget2.noduleTangent( boxGadget2.nodule( box2["op1"] ) ), IECore.V3f( -1, 0, 0 ) )
+		self.assertEqual( boxGadget2.noduleTangent( boxGadget2.nodule( box2["sum"] ) ), IECore.V3f( 1, 0, 0 ) )
 
 	def testNodulePositionsForPromotedPlugs( self ) :
 	

--- a/src/Gaffer/Box.cpp
+++ b/src/Gaffer/Box.cpp
@@ -414,7 +414,7 @@ BoxPtr Box::create( Node *parent, const Set *childNodes )
 					PlugMap::const_iterator mapIt = plugMap.find( input );
 					if( mapIt == plugMap.end() )
 					{
-						PlugPtr intermediateInput = plug->createCounterpart( "in", Plug::In );
+						PlugPtr intermediateInput = plug->createCounterpart( result->promotedCounterpartName( plug ), Plug::In );
 						// we want intermediate inputs to appear on the same side of the node as the
 						// equivalent internal plug, so we copy the relevant metadata over.
 						copyMetadata( plug, intermediateInput.get() );
@@ -444,7 +444,7 @@ BoxPtr Box::create( Node *parent, const Set *childNodes )
 							PlugMap::const_iterator mapIt = plugMap.find( plug );
 							if( mapIt == plugMap.end() )
 							{
-								PlugPtr intermediateOutput = plug->createCounterpart( "out", Plug::Out );
+								PlugPtr intermediateOutput = plug->createCounterpart( result->promotedCounterpartName( plug ), Plug::Out );
 								copyMetadata( plug, intermediateOutput.get() );
 								intermediateOutput->setFlags( Plug::Dynamic, true );
 								result->addChild( intermediateOutput );
@@ -470,7 +470,7 @@ BoxPtr Box::create( Node *parent, const Set *childNodes )
 
 std::string Box::promotedCounterpartName( const Plug *plug ) const
 {
-	std::string result = plug->relativeName( this );
+	std::string result = plug->relativeName( plug->node() );
 	boost::replace_all( result, ".", "_" );
 	return result;
 }

--- a/src/Gaffer/Box.cpp
+++ b/src/Gaffer/Box.cpp
@@ -69,10 +69,7 @@ Plug *Box::promotePlug( Plug *descendantPlug )
 {
 	validatePromotability( descendantPlug, /* throwExceptions = */ true );
 
-	std::string externalPlugName = descendantPlug->relativeName( this );
-	boost::replace_all( externalPlugName, ".", "_" );
-
-	PlugPtr externalPlug = descendantPlug->createCounterpart( externalPlugName, descendantPlug->direction() );
+	PlugPtr externalPlug = descendantPlug->createCounterpart( promotedCounterpartName( descendantPlug ), descendantPlug->direction() );
 	externalPlug->setFlags( Plug::Dynamic, true );
 	// flags are not automatically propagated to the children of compound plugs,
 	// so we need to do that ourselves.
@@ -468,6 +465,13 @@ BoxPtr Box::create( Node *parent, const Set *childNodes )
 		result->addChild( childNode );
 	}
 
+	return result;
+}
+
+std::string Box::promotedCounterpartName( const Plug *plug ) const
+{
+	std::string result = plug->relativeName( this );
+	boost::replace_all( result, ".", "_" );
 	return result;
 }
 

--- a/src/Gaffer/Box.cpp
+++ b/src/Gaffer/Box.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2013-2015, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -480,6 +480,8 @@ void Box::copyMetadata( const Plug *from, Plug *to )
 	/// know all valid names.
 	Metadata::registerPlugValue( to, "nodeGadget:nodulePosition", Metadata::plugValue<IECore::Data>( from, "nodeGadget:nodulePosition" ) );
 	Metadata::registerPlugValue( to, "nodule:type", Metadata::plugValue<IECore::Data>( from, "nodule:type" ) );
+	Metadata::registerPlugValue( to, "nodule:color", Metadata::plugValue<IECore::Data>( from, "nodule:color" ) );
+	Metadata::registerPlugValue( to, "connectionGadget:color", Metadata::plugValue<IECore::Data>( from, "connectionGadget:color" ) );
 	Metadata::registerPlugValue( to, "compoundNodule:orientation", Metadata::plugValue<IECore::Data>( from, "compoundNodule:orientation" ) );
 	Metadata::registerPlugValue( to, "compoundNodule:spacing", Metadata::plugValue<IECore::Data>( from, "compoundNodule:spacing" ) );
 	Metadata::registerPlugValue( to, "compoundNodule:direction", Metadata::plugValue<IECore::Data>( from, "compoundNodule:direction" ) );


### PR DESCRIPTION
This addresses a couple smaller issues I've been having when promoting plugs to boxes:

- Box promotion now transfers nodule and connection color metadata. 
- `Box::create` and `Box::promotePlug` now name promoted plugs the same way.
 - Promoted plug names are now relative to the node they came from.

The last one may be more controversial I suppose, but hopefully my explanation in the commit message is fairly convincing.