### PR TITLE
ImageProcessors with ArrayPlug inputs

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -502,6 +502,7 @@ libraries = {
 		"pythonEnvAppends" : {
 			"LIBS" : [ "GafferImageTest", "GafferImageBindings" ],
 		},
+		"additionalFiles" : glob.glob( "python/GafferImageTest/scripts/*" ),
 	},
 
 	"GafferImageUITest" : {},

--- a/include/Gaffer/ArrayPlug.h
+++ b/include/Gaffer/ArrayPlug.h
@@ -37,7 +37,7 @@
 #ifndef GAFFER_ARRAYPLUG_H
 #define GAFFER_ARRAYPLUG_H
 
-#include "Gaffer/CompoundPlug.h"
+#include "Gaffer/Plug.h"
 #include "Gaffer/Behaviours/InputGenerator.h"
 
 namespace Gaffer
@@ -46,9 +46,9 @@ namespace Gaffer
 /// The ArrayPlug maintains a sequence of identically-typed child
 /// plugs, automatically adding new plugs when all existing plugs
 /// have connections.
-/// \todo Consider using this everywhere in preference to
-/// InputGenerator, and removing the InputGenerator class.
-class ArrayPlug : public CompoundPlug
+/// \todo Use this everywhere in preference to InputGenerator,
+/// and remove the InputGenerator class.
+class ArrayPlug : public Plug
 {
 
 	public :
@@ -71,7 +71,7 @@ class ArrayPlug : public CompoundPlug
 
 		virtual ~ArrayPlug();
 
-		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::ArrayPlug, ArrayPlugTypeId, CompoundPlug );
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::ArrayPlug, ArrayPlugTypeId, Plug );
 
 		virtual bool acceptsChild( const GraphComponent *potentialChild ) const;
 		virtual PlugPtr createCounterpart( const std::string &name, Direction direction ) const;

--- a/include/Gaffer/ArrayPlug.h
+++ b/include/Gaffer/ArrayPlug.h
@@ -74,6 +74,7 @@ class ArrayPlug : public Plug
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::ArrayPlug, ArrayPlugTypeId, Plug );
 
 		virtual bool acceptsChild( const GraphComponent *potentialChild ) const;
+		virtual void setInput( PlugPtr input );
 		virtual PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
 
 		size_t minSize() const;
@@ -81,15 +82,13 @@ class ArrayPlug : public Plug
 
 	private :
 
-		void childAdded();
 		void parentChanged();
+		void inputChanged( Gaffer::Plug *plug );
 
 		size_t m_minSize;
 		size_t m_maxSize;
 
-		typedef Behaviours::InputGenerator<Plug> InputGenerator;
-		typedef boost::shared_ptr<InputGenerator> InputGeneratorPtr;
-		InputGeneratorPtr m_inputGenerator;
+		boost::signals::scoped_connection m_inputChangedConnection;
 
 };
 

--- a/include/Gaffer/BoxPlug.h
+++ b/include/Gaffer/BoxPlug.h
@@ -48,7 +48,7 @@ namespace Gaffer
 {
 
 template<typename T>
-class BoxPlug : public CompoundPlug
+class BoxPlug : public ValuePlug
 {
 
 	public :
@@ -57,7 +57,7 @@ class BoxPlug : public CompoundPlug
 		typedef typename IECore::BoxTraits<T>::BaseType PointType;
 		typedef CompoundNumericPlug<PointType> ChildType;
 
-		IECORE_RUNTIMETYPED_DECLARETEMPLATE( BoxPlug<T>, CompoundPlug );
+		IECORE_RUNTIMETYPED_DECLARETEMPLATE( BoxPlug<T>, ValuePlug );
 
 		BoxPlug(
 			const std::string &name = defaultName<BoxPlug>(),

--- a/include/Gaffer/CompoundDataPlug.h
+++ b/include/Gaffer/CompoundDataPlug.h
@@ -41,7 +41,6 @@
 #include "IECore/CompoundData.h"
 #include "IECore/CompoundObject.h"
 
-#include "Gaffer/CompoundPlug.h"
 #include "Gaffer/TypedPlug.h"
 
 namespace Gaffer
@@ -52,7 +51,7 @@ IE_CORE_FORWARDDECLARE( StringPlug )
 /// This plug provides an easy means of building CompoundData containing
 /// arbitrary keys and values, where each key and value is represented
 /// by an individual child plug.
-class CompoundDataPlug : public Gaffer::CompoundPlug
+class CompoundDataPlug : public Gaffer::ValuePlug
 {
 
 	public :
@@ -64,19 +63,19 @@ class CompoundDataPlug : public Gaffer::CompoundPlug
 		);
 		virtual ~CompoundDataPlug();
 
-		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::CompoundDataPlug, CompoundDataPlugTypeId, Gaffer::CompoundPlug );
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::CompoundDataPlug, CompoundDataPlugTypeId, Gaffer::ValuePlug );
 
 		/// Accepts only children that can generate values for the CompoundData.
 		virtual bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const;
 		virtual PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
 
 		/// The plug type used to represent the data members.
-		class MemberPlug : public CompoundPlug
+		class MemberPlug : public ValuePlug
 		{
 
 			public :
 
-				IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::CompoundDataPlug::MemberPlug, CompoundDataMemberPlugTypeId, Gaffer::CompoundPlug );
+				IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::CompoundDataPlug::MemberPlug, CompoundDataMemberPlugTypeId, Gaffer::ValuePlug );
 
 				MemberPlug( const std::string &name=defaultName<MemberPlug>(), Direction direction=In, unsigned flags=Default );
 
@@ -101,7 +100,7 @@ class CompoundDataPlug : public Gaffer::CompoundPlug
 		typedef Gaffer::FilteredChildIterator<Gaffer::PlugPredicate<Gaffer::Plug::Invalid, MemberPlug> > MemberPlugIterator;
 		IE_CORE_DECLAREPTR( MemberPlug )
 
-		/// Adds a CompoundPlug to represent a CompoundData member with the specified name and default value.
+		/// Adds a plug to represent a CompoundData member with the specified name and default value.
 		/// \todo Consider replacing all these add*Member() methods with convenience constructors on MemberPlug,
 		/// and a simple addChild( new MemberPlug( ... ) ).
 		MemberPlug *addMember( const std::string &name, const IECore::Data *defaultValue, const std::string &plugName = "member1", unsigned plugFlags = Plug::Default | Plug::Dynamic );

--- a/include/Gaffer/CompoundNumericPlug.h
+++ b/include/Gaffer/CompoundNumericPlug.h
@@ -48,7 +48,7 @@ namespace Gaffer
 {
 
 template<typename T>
-class CompoundNumericPlug : public CompoundPlug
+class CompoundNumericPlug : public ValuePlug
 {
 
 	public :
@@ -56,7 +56,7 @@ class CompoundNumericPlug : public CompoundPlug
 		typedef T ValueType;
 		typedef NumericPlug<typename T::BaseType> ChildType;
 
-		IECORE_RUNTIMETYPED_DECLARETEMPLATE( CompoundNumericPlug<T>, CompoundPlug );
+		IECORE_RUNTIMETYPED_DECLARETEMPLATE( CompoundNumericPlug<T>, ValuePlug );
 
 		CompoundNumericPlug(
 			const std::string &name = defaultName<CompoundNumericPlug>(),

--- a/include/Gaffer/CompoundPlug.h
+++ b/include/Gaffer/CompoundPlug.h
@@ -62,10 +62,6 @@ class CompoundPlug : public ValuePlug
 
 		virtual PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
 
-	private :
-
-		void childAddedOrRemoved();
-
 };
 
 IE_CORE_DECLAREPTR( CompoundPlug );

--- a/include/Gaffer/ExecutableNode.h
+++ b/include/Gaffer/ExecutableNode.h
@@ -90,13 +90,33 @@ class ExecutableNode : public Node
 		ExecutableNode( const std::string &name=defaultName<ExecutableNode>() );
 		virtual ~ExecutableNode();
 
+		/// The plug type used to connect ExecutableNodes
+		/// together to define order of execution.
+		class RequirementPlug : public Plug
+		{
+
+			public :
+
+				IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::ExecutableNode::RequirementPlug, ExecutableNodeRequirementPlugTypeId, Gaffer::Plug );
+
+				RequirementPlug( const std::string &name=defaultName<RequirementPlug>(), Direction direction=In, unsigned flags=Default );
+
+				virtual bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const;
+				virtual bool acceptsInput( const Plug *input ) const;
+				virtual PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
+
+		};
+
+		typedef Gaffer::FilteredChildIterator<Gaffer::PlugPredicate<Gaffer::Plug::Invalid, RequirementPlug> > RequirementPlugIterator;
+		IE_CORE_DECLAREPTR( RequirementPlug )
+
 		/// Array of ExecutableNodes which must be executed before this node can execute successfully.
 		ArrayPlug *requirementsPlug();
 		const ArrayPlug *requirementsPlug() const;
 
 		/// Output plug used by other ExecutableNodes to declare this node as a requirement.
-		Plug *requirementPlug();
-		const Plug *requirementPlug() const;
+		RequirementPlug *requirementPlug();
+		const RequirementPlug *requirementPlug() const;
 
 		/// Parent plug used by Dispatchers to expose per-node dispatcher settings.
 		/// See the "ExecutableNode Customization" section of the Gaffer::Dispatcher
@@ -129,12 +149,6 @@ class ExecutableNode : public Node
 		/// Returns true if the node must execute a sequence of frames all at once.
 		/// The default implementation returns false.
 		virtual bool requiresSequenceExecution() const;
-
-	protected :
-
-		/// Implemented to deny inputs to requirementsPlug() which do not come from
-		/// the requirementPlug() of another ExecutableNode.
-		virtual bool acceptsInput( const Plug *plug, const Plug *inputPlug ) const;
 
 	private :
 

--- a/include/Gaffer/SplinePlug.h
+++ b/include/Gaffer/SplinePlug.h
@@ -130,7 +130,6 @@ class SplinePlug : public ValuePlug
 	private :
 
 		size_t endPointMultiplicity( const T &value ) const;
-		void childAddedOrRemoved();
 
 		T m_defaultValue;
 

--- a/include/Gaffer/Transform2DPlug.h
+++ b/include/Gaffer/Transform2DPlug.h
@@ -42,7 +42,7 @@
 namespace Gaffer
 {
 
-class Transform2DPlug : public CompoundPlug
+class Transform2DPlug : public ValuePlug
 {
 
 	public :
@@ -50,7 +50,7 @@ class Transform2DPlug : public CompoundPlug
 		Transform2DPlug( const std::string &name = defaultName<Transform2DPlug>(), Direction direction=In, unsigned flags = Default );
 		virtual ~Transform2DPlug();
 
-		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::Transform2DPlug, Transform2DPlugTypeId, CompoundPlug );
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::Transform2DPlug, Transform2DPlugTypeId, ValuePlug );
 
 		virtual bool acceptsChild( const GraphComponent *potentialChild ) const;
 		virtual PlugPtr createCounterpart( const std::string &name, Direction direction ) const;

--- a/include/Gaffer/TransformPlug.h
+++ b/include/Gaffer/TransformPlug.h
@@ -43,7 +43,7 @@
 namespace Gaffer
 {
 
-class TransformPlug : public CompoundPlug
+class TransformPlug : public ValuePlug
 {
 
 	public :
@@ -51,7 +51,7 @@ class TransformPlug : public CompoundPlug
 		TransformPlug( const std::string &name = defaultName<TransformPlug>(), Direction direction=In, unsigned flags = Default );
 		virtual ~TransformPlug();
 
-		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::TransformPlug, TransformPlugTypeId, CompoundPlug );
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::TransformPlug, TransformPlugTypeId, ValuePlug );
 
 		virtual bool acceptsChild( const GraphComponent *potentialChild ) const;
 		virtual PlugPtr createCounterpart( const std::string &name, Direction direction ) const;

--- a/include/Gaffer/TypeIds.h
+++ b/include/Gaffer/TypeIds.h
@@ -96,7 +96,7 @@ enum TypeId
 	ContextVariablesComputeNodeTypeId = 110049,
 	RandomTypeId = 110050,
 	DependencyNodeTypeId = 110051,
-	ParameterisedHolderDependencyNodeTypeId = 110052, // obsolete - available for reuse
+	ExecutableNodeRequirementPlugTypeId = 110052,
 	BoxTypeId = 110053,
 	InternedStringVectorDataPlugTypeId = 110054,
 	ExecutableNodeTypeId = 110055,

--- a/include/Gaffer/ValuePlug.h
+++ b/include/Gaffer/ValuePlug.h
@@ -173,6 +173,7 @@ class ValuePlug : public Plug
 		class SetValueAction;
 
 		void setValueInternal( IECore::ConstObjectPtr value, bool propagateDirtiness );
+		void childAddedOrRemoved();
 
 		IECore::ConstObjectPtr m_defaultValue;
 		/// For holding the value of input plugs with no input connections.

--- a/include/Gaffer/ValuePlug.h
+++ b/include/Gaffer/ValuePlug.h
@@ -157,13 +157,6 @@ class ValuePlug : public Plug
 		/// if we are inside Node::compute().
 		bool inCompute() const;
 
-		/// Emits the appropriate Node::plugSetSignal() for this plug and all its
-		/// ancestors, then does the same for its output plugs. This is called
-		/// automatically by setObjectValue() where appropriate, and typically shouldn't
-		/// need to be called manually. It is exposed so that CompoundPlug can
-		/// simulate the behaviour of a plug being set when a child is added or removed.
-		void emitPlugSet();
-
 		/// Reimplemented for cache management.
 		virtual void dirty();
 
@@ -174,9 +167,12 @@ class ValuePlug : public Plug
 
 		void setValueInternal( IECore::ConstObjectPtr value, bool propagateDirtiness );
 		void childAddedOrRemoved();
+		// Emits the appropriate Node::plugSetSignal() for this plug and all its
+		// ancestors, then does the same for its output plugs.
+		void emitPlugSet();
 
 		IECore::ConstObjectPtr m_defaultValue;
-		/// For holding the value of input plugs with no input connections.
+		// For holding the value of input plugs with no input connections.
 		IECore::ConstObjectPtr m_staticValue;
 
 };

--- a/include/GafferBindings/ComputeNodeBinding.h
+++ b/include/GafferBindings/ComputeNodeBinding.h
@@ -64,6 +64,18 @@ class ComputeNodeWrapper : public DependencyNodeWrapper<WrappedType>
 		{
 		}
 
+		template<typename Arg1, typename Arg2>
+		ComputeNodeWrapper( PyObject *self, Arg1 arg1, Arg2 arg2 )
+			:	DependencyNodeWrapper<WrappedType>( self, arg1, arg2 )
+		{
+		}
+
+		template<typename Arg1, typename Arg2, typename Arg3>
+		ComputeNodeWrapper( PyObject *self, Arg1 arg1, Arg2 arg2, Arg3 arg3 )
+			:	DependencyNodeWrapper<WrappedType>( self, arg1, arg2, arg3 )
+		{
+		}
+
 		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 		{
 			WrappedType::hash( output, context, h );

--- a/include/GafferBindings/DependencyNodeBinding.h
+++ b/include/GafferBindings/DependencyNodeBinding.h
@@ -74,6 +74,18 @@ class DependencyNodeWrapper : public NodeWrapper<WrappedType>
 		{
 		}
 
+		template<typename Arg1, typename Arg2>
+		DependencyNodeWrapper( PyObject *self, Arg1 arg1, Arg2 arg2 )
+			:	NodeWrapper<WrappedType>( self, arg1, arg2 )
+		{
+		}
+
+		template<typename Arg1, typename Arg2, typename Arg3>
+		DependencyNodeWrapper( PyObject *self, Arg1 arg1, Arg2 arg2, Arg3 arg3 )
+			:	NodeWrapper<WrappedType>( self, arg1, arg2, arg3 )
+		{
+		}
+
 		virtual void affects( const Gaffer::Plug *input, Gaffer::DependencyNode::AffectedPlugsContainer &outputs ) const
 		{
 			if( this->isSubclassed() )

--- a/include/GafferBindings/NodeBinding.h
+++ b/include/GafferBindings/NodeBinding.h
@@ -74,6 +74,18 @@ class NodeWrapper : public GraphComponentWrapper<T>
 		{
 		}
 
+		template<typename Arg1, typename Arg2>
+		NodeWrapper( PyObject *self, Arg1 arg1, Arg2 arg2 )
+			:	GraphComponentWrapper<WrappedType>( self, arg1, arg2 )
+		{
+		}
+
+		template<typename Arg1, typename Arg2, typename Arg3>
+		NodeWrapper( PyObject *self, Arg1 arg1, Arg2 arg2, Arg3 arg3 )
+			:	GraphComponentWrapper<WrappedType>( self, arg1, arg2, arg3 )
+		{
+		}
+
 		virtual bool isInstanceOf( IECore::TypeId typeId ) const
 		{
 			// Optimise for common queries we know should fail.

--- a/include/GafferBindings/NodeBinding.h
+++ b/include/GafferBindings/NodeBinding.h
@@ -92,6 +92,7 @@ class NodeWrapper : public GraphComponentWrapper<T>
 			if(
 				typeId == (IECore::TypeId)Gaffer::ScriptNodeTypeId ||
 				typeId == (IECore::TypeId)Gaffer::PlugTypeId ||
+				typeId == (IECore::TypeId)Gaffer::ValuePlugTypeId ||
 				typeId == (IECore::TypeId)Gaffer::CompoundPlugTypeId
 			)
 			{

--- a/include/GafferImage/ImageProcessor.h
+++ b/include/GafferImage/ImageProcessor.h
@@ -40,24 +40,46 @@
 
 #include "GafferImage/ImageNode.h"
 
+namespace Gaffer
+{
+
+IE_CORE_FORWARDDECLARE( ArrayPlug )
+
+} // namespace Gaffer
+
 namespace GafferImage
 {
 
-/// The ImageProcessor class provides a base class for nodes which will take an image input
-/// and modify it in some way.
+/// A base class for nodes which will take a number of input images and
+/// process them in some way to generate an output image.
 class ImageProcessor : public ImageNode
 {
 
 	public :
 
+		/// Constructs with a single input ImagePlug named "in". Use inPlug()
+		/// to access this plug.
 		ImageProcessor( const std::string &name=defaultName<ImageProcessor>() );
+
+		/// Constructs with an ArrayPlug called "in". Use inPlug() as a
+		/// convenience for accessing the first child in the array, and use
+		/// inPlugs() to access the array itself.
+		ImageProcessor( const std::string &name, size_t minInputs, size_t maxInputs = Imath::limits<size_t>::max() );
 		virtual ~ImageProcessor();
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::ImageProcessor, ImageProcessorTypeId, ImageNode );
 
-		/// Images enter the node through inPlug() and are output in processed form on ImageNode::outPlug()
+		/// Returns the primary image input. For nodes with multiple inputs
+		/// this will be the first child of the inPlugs() array. For nodes
+		/// with a single input, it will be a plug parented directly to the
+		/// node.
 		ImagePlug *inPlug();
 		const ImagePlug *inPlug() const;
+
+		/// For nodes with multiple inputs, returns the ArrayPlug which
+		/// hosts them. For single input nodes, returns NULL;
+		Gaffer::ArrayPlug *inPlugs();
+		const Gaffer::ArrayPlug *inPlugs() const;
 
 		virtual Gaffer::Plug *correspondingInput( const Gaffer::Plug *output );
 		virtual const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const;

--- a/include/GafferImage/Merge.h
+++ b/include/GafferImage/Merge.h
@@ -37,7 +37,7 @@
 #ifndef GAFFERIMAGE_MERGE_H
 #define GAFFERIMAGE_MERGE_H
 
-#include "Gaffer/Behaviours/InputGenerator.h"
+#include "Gaffer/NumericPlug.h"
 
 #include "GafferImage/ImageProcessor.h"
 
@@ -47,14 +47,10 @@ namespace GafferImage
 /// A node for Merging two or more images. Merge will use the displayWindow and metadata from the first input;
 /// expand the dataWindow to the union of all dataWindows from the connected inputs; create a union of
 /// channelNames from all the connected inputs, and will merge the channelData according to the operation mode.
-/// \todo Ideally ImageProcessor will be capable of having multiple inputs via an ArrayPlug called "in", at
-/// which point we can remove this custom InputGenerator behaviour.
 class Merge : public ImageProcessor
 {
 
 	public :
-
-		typedef std::vector<Gaffer::Behaviours::InputGenerator<GafferImage::ImagePlug>::PlugClassPtr> ImagePlugList;
 
 		Merge( const std::string &name=defaultName<Merge>() );
 		virtual ~Merge();
@@ -113,9 +109,6 @@ class Merge : public ImageProcessor
 		virtual IECore::ConstStringVectorDataPtr computeChannelNames( const Gaffer::Context *context, const ImagePlug *parent ) const;
 		/// Implemented to call doMergeOperation according to operationPlug()
 		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const;
-
-		// A helper class that manages our ImagePlug inputs.
-		Gaffer::Behaviours::InputGenerator<ImagePlug> m_inputs;
 
 	private :
 

--- a/include/GafferScene/Light.h
+++ b/include/GafferScene/Light.h
@@ -54,8 +54,8 @@ class Light : public ObjectSource
 		Light( const std::string &name=defaultName<Light>() );
 		virtual ~Light();
 
-		Gaffer::CompoundPlug *parametersPlug();
-		const Gaffer::CompoundPlug *parametersPlug() const;
+		Gaffer::Plug *parametersPlug();
+		const Gaffer::Plug *parametersPlug() const;
 
 		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
 

--- a/include/GafferScene/Outputs.h
+++ b/include/GafferScene/Outputs.h
@@ -55,12 +55,12 @@ class Outputs : public GlobalsProcessor
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Outputs, OutputsTypeId, GlobalsProcessor );
 
-		Gaffer::CompoundPlug *outputsPlug();
-		const Gaffer::CompoundPlug *outputsPlug() const;
+		Gaffer::ValuePlug *outputsPlug();
+		const Gaffer::ValuePlug *outputsPlug() const;
 
 		/// Add an output previously registered with registerOutput().
-		Gaffer::CompoundPlug *addOutput( const std::string &name );
-		Gaffer::CompoundPlug *addOutput( const std::string &name, const IECore::Display *output );
+		Gaffer::ValuePlug *addOutput( const std::string &name );
+		Gaffer::ValuePlug *addOutput( const std::string &name, const IECore::Display *output );
 
 		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
 

--- a/include/GafferScene/Shader.h
+++ b/include/GafferScene/Shader.h
@@ -51,7 +51,6 @@ namespace Gaffer
 {
 
 IE_CORE_FORWARDDECLARE( StringPlug )
-IE_CORE_FORWARDDECLARE( CompoundPlug )
 
 } // namespace Gaffer
 

--- a/include/GafferSceneUI/SceneView.h
+++ b/include/GafferSceneUI/SceneView.h
@@ -77,14 +77,14 @@ class SceneView : public GafferUI::View3D
 		Gaffer::IntPlug *minimumExpansionDepthPlug();
 		const Gaffer::IntPlug *minimumExpansionDepthPlug() const;
 
-		Gaffer::CompoundPlug *lookThroughPlug();
-		const Gaffer::CompoundPlug *lookThroughPlug() const;
+		Gaffer::ValuePlug *lookThroughPlug();
+		const Gaffer::ValuePlug *lookThroughPlug() const;
 
-		Gaffer::CompoundPlug *gridPlug();
-		const Gaffer::CompoundPlug *gridPlug() const;
+		Gaffer::ValuePlug *gridPlug();
+		const Gaffer::ValuePlug *gridPlug() const;
 
-		Gaffer::CompoundPlug *gnomonPlug();
-		const Gaffer::CompoundPlug *gnomonPlug() const;
+		Gaffer::ValuePlug *gnomonPlug();
+		const Gaffer::ValuePlug *gnomonPlug() const;
 
 		void expandSelection( size_t depth = 1 );
 		void collapseSelection();

--- a/include/GafferUI/CompoundNodule.h
+++ b/include/GafferUI/CompoundNodule.h
@@ -41,13 +41,6 @@
 #include "GafferUI/Nodule.h"
 #include "GafferUI/LinearContainer.h"
 
-namespace Gaffer
-{
-
-IE_CORE_FORWARDDECLARE( CompoundPlug )
-
-} // namespace Gaffer
-
 namespace GafferUI
 {
 
@@ -78,7 +71,7 @@ class CompoundNodule : public Nodule
 
 		virtual bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const;
 
-		/// Returns a Nodule for a child of the CompoundPlug being represented.
+		/// Returns a Nodule for a child of the plug being represented.
 		Nodule *nodule( const Gaffer::Plug *plug );
 		const Nodule *nodule( const Gaffer::Plug *plug ) const;
 

--- a/python/GafferCortexTest/ParameterisedHolderTest.py
+++ b/python/GafferCortexTest/ParameterisedHolderTest.py
@@ -285,7 +285,7 @@ class ParameterisedHolderTest( GafferTest.TestCase ) :
 		ph = GafferCortex.ParameterisedHolderNode()
 		ph.setParameterised( p )
 
-		self.failUnless( isinstance( ph["parameters"]["b"], Gaffer.CompoundPlug ) )
+		self.failUnless( isinstance( ph["parameters"]["b"], Gaffer.Box3iPlug ) )
 		self.failUnless( isinstance( ph["parameters"]["b"]["min"], Gaffer.V3iPlug ) )
 		self.failUnless( isinstance( ph["parameters"]["b"]["max"], Gaffer.V3iPlug ) )
 

--- a/python/GafferImageTest/ImageProcessorTest.py
+++ b/python/GafferImageTest/ImageProcessorTest.py
@@ -92,5 +92,34 @@ class ImageProcessorTest( GafferTest.TestCase ) :
 			"Deletes the alpha channel.",
 		)
 
+	def testNumberOfInputs( self ) :
+
+		n = GafferImage.ImageProcessor()
+		self.assertTrue( isinstance( n["in"], GafferImage.ImagePlug ) )
+
+		n = GafferImage.ImageProcessor( minInputs = 2, maxInputs = 2 )
+		self.assertTrue( isinstance( n["in"], Gaffer.ArrayPlug ) )
+		self.assertEqual( len( n["in"] ), 2 )
+		self.assertTrue( isinstance( n["in"][0], GafferImage.ImagePlug ) )
+		self.assertTrue( isinstance( n["in"][1], GafferImage.ImagePlug ) )
+		self.assertEqual( n["in"].minSize(), 2 )
+		self.assertEqual( n["in"].maxSize(), 2 )
+
+		n = GafferImage.ImageProcessor( minInputs = 2, maxInputs = 1000 )
+		self.assertTrue( isinstance( n["in"], Gaffer.ArrayPlug ) )
+		self.assertTrue( isinstance( n["in"][0], GafferImage.ImagePlug ) )
+		self.assertTrue( isinstance( n["in"][1], GafferImage.ImagePlug ) )
+		self.assertEqual( len( n["in"] ), 2 )
+		self.assertEqual( n["in"].minSize(), 2 )
+		self.assertEqual( n["in"].maxSize(), 1000 )
+
+		n = GafferImage.ImageProcessor( minInputs = 2 )
+		self.assertTrue( isinstance( n["in"], Gaffer.ArrayPlug ) )
+		self.assertTrue( isinstance( n["in"][0], GafferImage.ImagePlug ) )
+		self.assertTrue( isinstance( n["in"][1], GafferImage.ImagePlug ) )
+		self.assertEqual( len( n["in"] ), 2 )
+		self.assertEqual( n["in"].minSize(), 2 )
+		self.assertEqual( n["in"].maxSize(), Gaffer.ArrayPlug().maxSize() )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageTest/MergeTest.py
+++ b/python/GafferImageTest/MergeTest.py
@@ -39,6 +39,7 @@ import unittest
 
 import IECore
 
+import Gaffer
 import GafferTest
 import GafferImage
 
@@ -240,6 +241,17 @@ class MergeTest( GafferTest.TestCase ) :
 		
 		self.assertEqual( m["out"]["format"].getValue(), d["out"]["format"].getValue() )
 		self.assertEqual( m["out"]["metadata"].getValue(), d["out"]["metadata"].getValue() )
+
+	def testFileCompatibilityWithVersion0_15( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( os.path.dirname( __file__ ) + "/scripts/mergeVersion-0.15.0.0.gfr" )
+		s.load()
+
+		self.assertTrue( s["m"]["in"][0].getInput().isSame( s["c1"]["out"] ) )
+		self.assertTrue( s["m"]["in"][1].getInput().isSame( s["c2"]["out"] ) )
+
+		self.assertEqual( s["m"]["out"].channelData( "R", IECore.V2i( 0 ) )[0], 0.75 )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageTest/MergeTest.py
+++ b/python/GafferImageTest/MergeTest.py
@@ -64,16 +64,17 @@ class MergeTest( GafferTest.TestCase ) :
 		##########################################
 		# Test to see if the hash changes.
 		##########################################
+
 		merge = GafferImage.Merge()
 		merge["operation"].setValue( GafferImage.Merge.Operation.Over )
 
-		merge["in"].setInput(r1["out"])
-		merge["in1"].setInput(r2["out"])
+		merge["in"][0].setInput( r1["out"] )
+		merge["in"][1].setInput( r2["out"] )
 		h1 = merge["out"].image().hash()
 
 		# Switch the inputs.
-		merge["in1"].setInput(r1["out"])
-		merge["in"].setInput(r2["out"])
+		merge["in"][1].setInput( r1["out"] )
+		merge["in"][0].setInput( r2["out"] )
 		h2 = merge["out"].image().hash()
 
 		self.assertNotEqual( h1, h2 )
@@ -83,20 +84,21 @@ class MergeTest( GafferTest.TestCase ) :
 		# when the output should be the same but the
 		# input plugs used are not.
 		##########################################
+
 		merge = GafferImage.Merge()
 		merge["operation"].setValue( GafferImage.Merge.Operation.Over )
 
 		expectedHash = h1
 
 		# Connect up a load of inputs ...
-		merge["in"].setInput(r1["out"])
-		merge["in1"].setInput(r1["out"])
-		merge["in2"].setInput(r1["out"])
-		merge["in3"].setInput(r2["out"])
+		merge["in"][0].setInput( r1["out"] )
+		merge["in"][1].setInput( r1["out"] )
+		merge["in"][2].setInput( r1["out"] )
+		merge["in"][3].setInput( r2["out"] )
 
 		# but then disconnect two so that the result should still be the same...
-		merge["in1"].setInput( None )
-		merge["in2"].setInput( None )
+		merge["in"][1].setInput( None )
+		merge["in"][2].setInput( None )
 		h1 = merge["out"].image().hash()
 
 		self.assertEqual( h1, expectedHash )
@@ -110,11 +112,12 @@ class MergeTest( GafferTest.TestCase ) :
 		# Test to see if the input has is always passed
 		# through if only the first input is connected.
 		##########################################
+
 		merge = GafferImage.Merge()
 		merge["operation"].setValue( GafferImage.Merge.Operation.Over )
 
 		expectedHash = r1["out"].image().hash()
-		merge["in"].setInput(r1["out"])
+		merge["in"][0].setInput( r1["out"] )
 		h1 = merge["out"].image().hash()
 
 		self.assertEqual( h1, expectedHash )
@@ -122,14 +125,15 @@ class MergeTest( GafferTest.TestCase ) :
 		##########################################
 		# Test that if we disable the node the hash gets passed through.
 		##########################################
+		
 		merge["enabled"].setValue(False)
 		h1 = merge["out"].image().hash()
 
 		self.assertEqual( h1, expectedHash )
 
-
 	# Overlay a red, green and blue tile of different data window sizes and check the data window is expanded on the result and looks as we expect.
 	def testOverRGBA( self ) :
+		
 		r = GafferImage.ImageReader()
 		r["fileName"].setValue( self.rPath )
 
@@ -141,9 +145,9 @@ class MergeTest( GafferTest.TestCase ) :
 
 		merge = GafferImage.Merge()
 		merge["operation"].setValue( GafferImage.Merge.Operation.Over )
-		merge["in"].setInput(r["out"])
-		merge["in1"].setInput(g["out"])
-		merge["in2"].setInput(b["out"])
+		merge["in"][0].setInput( r["out"] )
+		merge["in"][1].setInput( g["out"] )
+		merge["in"][2].setInput( b["out"] )
 
 		mergeResult = merge["out"].image()
 		expected = IECore.Reader.create( self.rgbPath ).read()
@@ -167,10 +171,10 @@ class MergeTest( GafferTest.TestCase ) :
 
 		merge = GafferImage.Merge()
 		merge["operation"].setValue( GafferImage.Merge.Operation.Over )
-		merge["in"].setInput(c["out"])
-		merge["in1"].setInput(r["out"])
-		merge["in2"].setInput(g["out"])
-		merge["in3"].setInput(b["out"])
+		merge["in"][0].setInput( c["out"] )
+		merge["in"][1].setInput( r["out"] )
+		merge["in"][2].setInput( g["out"] )
+		merge["in"][3].setInput( b["out"] )
 
 		mergeResult = merge["out"].image()
 		expected = IECore.Reader.create( self.checkerRGBPath ).read()
@@ -183,28 +187,30 @@ class MergeTest( GafferTest.TestCase ) :
 		c2 = GafferImage.Constant()
 
 		m = GafferImage.Merge()
-		m["in"].setInput( c1["out"] )
-		m["in1"].setInput( c2["out"] )
+		m["in"][0].setInput( c1["out"] )
+		m["in"][1].setInput( c2["out"] )
 
 		cs = GafferTest.CapturingSlot( m.plugDirtiedSignal() )
 
 		c1["color"]["r"].setValue( 0.1 )
 
-		self.assertEqual( len( cs ), 4 )
-		self.assertTrue( cs[0][0].isSame( m["in"]["channelData"] ) )
-		self.assertTrue( cs[1][0].isSame( m["in"] ) )
-		self.assertTrue( cs[2][0].isSame( m["out"]["channelData"] ) )
-		self.assertTrue( cs[3][0].isSame( m["out"] ) )
+		self.assertEqual( len( cs ), 5 )
+		self.assertTrue( cs[0][0].isSame( m["in"][0]["channelData"] ) )
+		self.assertTrue( cs[1][0].isSame( m["in"][0] ) )
+		self.assertTrue( cs[2][0].isSame( m["in"] ) )
+		self.assertTrue( cs[3][0].isSame( m["out"]["channelData"] ) )
+		self.assertTrue( cs[4][0].isSame( m["out"] ) )
 
 		del cs[:]
 
 		c2["color"]["g"].setValue( 0.2 )
 
-		self.assertEqual( len( cs ), 4 )
-		self.assertTrue( cs[0][0].isSame( m["in1"]["channelData"] ) )
-		self.assertTrue( cs[1][0].isSame( m["in1"] ) )
-		self.assertTrue( cs[2][0].isSame( m["out"]["channelData"] ) )
-		self.assertTrue( cs[3][0].isSame( m["out"] ) )
+		self.assertEqual( len( cs ), 5 )
+		self.assertTrue( cs[0][0].isSame( m["in"][1]["channelData"] ) )
+		self.assertTrue( cs[1][0].isSame( m["in"][1] ) )
+		self.assertTrue( cs[2][0].isSame( m["in"] ) )
+		self.assertTrue( cs[3][0].isSame( m["out"]["channelData"] ) )
+		self.assertTrue( cs[4][0].isSame( m["out"] ) )
 
 	def testEnabledAffects( self ) :
 
@@ -224,8 +230,8 @@ class MergeTest( GafferTest.TestCase ) :
 		d["in"].setInput( f["out"] )
 		
 		m = GafferImage.Merge()
-		m["in"].setInput( c["out"] )
-		m["in1"].setInput( d["out"] )
+		m["in"][0].setInput( c["out"] )
+		m["in"][1].setInput( d["out"] )
 
 		self.assertEqual( m["out"]["format"].hash(), c["out"]["format"].hash() )
 		self.assertEqual( m["out"]["metadata"].hash(), c["out"]["metadata"].hash() )
@@ -233,8 +239,8 @@ class MergeTest( GafferTest.TestCase ) :
 		self.assertEqual( m["out"]["format"].getValue(), c["out"]["format"].getValue() )
 		self.assertEqual( m["out"]["metadata"].getValue(), c["out"]["metadata"].getValue() )
 		
-		m["in"].setInput( d["out"] )
-		m["in1"].setInput( c["out"] )
+		m["in"][0].setInput( d["out"] )
+		m["in"][1].setInput( c["out"] )
 		
 		self.assertEqual( m["out"]["format"].hash(), d["out"]["format"].hash() )
 		self.assertEqual( m["out"]["metadata"].hash(), d["out"]["metadata"].hash() )

--- a/python/GafferImageTest/scripts/mergeVersion-0.15.0.0.gfr
+++ b/python/GafferImageTest/scripts/mergeVersion-0.15.0.0.gfr
@@ -1,0 +1,25 @@
+import Gaffer
+import GafferImage
+import IECore
+
+__children = {}
+
+__children["defaultFormat"] = GafferImage.FormatPlug( "defaultFormat", defaultValue = GafferImage.Format(), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, )
+parent.addChild( __children["defaultFormat"] )
+GafferImage.Format.registerFormat( GafferImage.Format( IECore.Box2i( IECore.V2i( 0, 0 ), IECore.V2i( 1919, 1079 ) ), 1.000 ), "HD 1080p 1920x1080 1" )
+__children["defaultFormat"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 0, 0 ), IECore.V2i( 1919, 1079 ) ), 1.000 ) )
+__children["c1"] = GafferImage.Constant( "c1" )
+parent.addChild( __children["c1"] )
+__children["c1"]["color"].setValue( IECore.Color4f( 0.5, 0, 0, 1 ) )
+__children["c2"] = GafferImage.Constant( "c2" )
+parent.addChild( __children["c2"] )
+__children["c2"]["color"].setValue( IECore.Color4f( 0.25, 0, 0, 1 ) )
+__children["m"] = GafferImage.Merge( "m" )
+parent.addChild( __children["m"] )
+__children["m"].addChild( GafferImage.ImagePlug( "in2", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["m"]["in"].setInput( __children["c1"]["out"] )
+__children["m"]["in1"].setInput( __children["c2"]["out"] )
+
+
+del __children
+

--- a/python/GafferImageUI/ImageProcessorUI.py
+++ b/python/GafferImageUI/ImageProcessorUI.py
@@ -52,10 +52,11 @@ Gaffer.Metadata.registerNode(
 
 		"in" : [
 
-			"description",
-			"""
-			The input image.
-			""",
+			"description", lambda plug : "The input image" + ( "s" if isinstance( plug, Gaffer.ArrayPlug ) else "" ),
+
+			"plugValueWidget:type", "",
+			"nodule:type", lambda plug : "GafferUI::CompoundNodule" if isinstance( plug, Gaffer.ArrayPlug ) else "GafferUI::StandardNodule",
+			"compoundNodule:spacing", 2.0,
 
 		],
 

--- a/python/GafferRenderManTest/RenderManShaderTest.py
+++ b/python/GafferRenderManTest/RenderManShaderTest.py
@@ -461,7 +461,7 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		self.assertEqual( n["parameters"].keys(), [ "dynamicShaderArray", "fixedShaderArray" ] )
 
-		self.assertTrue( isinstance( n["parameters"]["fixedShaderArray"], Gaffer.CompoundPlug ) )
+		self.assertTrue( isinstance( n["parameters"]["fixedShaderArray"], Gaffer.ArrayPlug ) )
 
 		self.assertEqual( len( n["parameters"]["fixedShaderArray"] ), 4 )
 		self.assertTrue( isinstance( n["parameters"]["fixedShaderArray"]["fixedShaderArray0"], Gaffer.Plug ) )

--- a/python/GafferTest/ArrayPlugTest.py
+++ b/python/GafferTest/ArrayPlugTest.py
@@ -367,6 +367,12 @@ class ArrayPlugTest( GafferTest.TestCase ) :
 		self.assertEqual( len( n["a"] ), 3 )
 		assertInput( n["b"], n["a"] )
 
+	def testOnlyOneChildType( self ) :
+
+		p = Gaffer.ArrayPlug( element = Gaffer.IntPlug() )
+		self.assertTrue( p.acceptsChild( Gaffer.IntPlug() ) )
+		self.assertFalse( p.acceptsChild( Gaffer.FloatPlug() ) )
+
 	def tearDown( self ) :
 
 		# some bugs in the InputGenerator only showed themselves when

--- a/python/GafferTest/ArrayPlugTest.py
+++ b/python/GafferTest/ArrayPlugTest.py
@@ -337,6 +337,36 @@ class ArrayPlugTest( GafferTest.TestCase ) :
 		self.assertEqual( len( n["a"] ), 2 )
 		self.assertTrue( isinstance( n["a"][1], PythonElement ) )
 
+	def testTopLevelConnection( self ) :
+
+		n = Gaffer.Node()
+
+		n["a"] = Gaffer.ArrayPlug( element = Gaffer.IntPlug() )
+		n["b"] = Gaffer.ArrayPlug( element = Gaffer.IntPlug() )
+		n["b"].setInput( n["a"] )
+
+		def assertInput( plug, input ) :
+
+			self.assertEqual( len( plug ), len( input ) )
+			for i in range( 0, len( plug ) ) :
+				self.assertTrue( plug[i].getInput().isSame( input[i] ) )
+
+		assertInput( n["b"], n["a"] )
+
+		a = GafferTest.AddNode()
+
+		n["a"][0].setInput( a["sum"] )
+		self.assertEqual( len( n["a"] ), 2 )
+		assertInput( n["b"], n["a"] )
+
+		n["a"][1].setInput( a["sum"] )
+		self.assertEqual( len( n["a"] ), 3 )
+		assertInput( n["b"], n["a"] )
+
+		n["a"][0].setInput( None )
+		self.assertEqual( len( n["a"] ), 3 )
+		assertInput( n["b"], n["a"] )
+
 	def tearDown( self ) :
 
 		# some bugs in the InputGenerator only showed themselves when

--- a/python/GafferTest/BoxPlugTest.py
+++ b/python/GafferTest/BoxPlugTest.py
@@ -46,11 +46,11 @@ class BoxPlugTest( GafferTest.TestCase ) :
 	def testRunTimeTyped( self ) :
 
 		p = Gaffer.Box3fPlug()
-		self.failUnless( p.isInstanceOf( Gaffer.CompoundPlug.staticTypeId() ) )
+		self.failUnless( p.isInstanceOf( Gaffer.ValuePlug.staticTypeId() ) )
 		self.failUnless( p.isInstanceOf( Gaffer.Plug.staticTypeId() ) )
 
 		t = p.typeId()
-		self.assertEqual( IECore.RunTimeTyped.baseTypeId( t ), Gaffer.CompoundPlug.staticTypeId() )
+		self.assertEqual( IECore.RunTimeTyped.baseTypeId( t ), Gaffer.ValuePlug.staticTypeId() )
 
 	def testCreateCounterpart( self ) :
 

--- a/python/GafferTest/BoxTest.py
+++ b/python/GafferTest/BoxTest.py
@@ -366,6 +366,33 @@ class BoxTest( GafferTest.TestCase ) :
 		self.assertTrue( isinstance( s["Box"]["c"], Gaffer.Color3fPlug ) )
 		self.assertTrue( s["Box"]["n"]["c"].getInput().isSame( s["Box"]["c"] ) )
 
+	def testPromoteNonDynamicColorPlugAndSerialise( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["b"] = Gaffer.Box()
+		s["b"]["n"] = Gaffer.Random()
+
+		p = s["b"].promotePlug( s["b"]["n"]["baseColor"] )
+		p.setValue( IECore.Color3f( 1, 2, 3 ) )
+		p.setName( "c" )
+
+		self.assertTrue( isinstance( s["b"]["c"], Gaffer.Color3fPlug ) )
+		self.assertTrue( s["b"]["n"]["baseColor"].getInput().isSame( s["b"]["c"] ) )
+		self.assertTrue( s["b"]["n"]["baseColor"]["r"].getInput().isSame( s["b"]["c"]["r"] ) )
+		self.assertTrue( s["b"]["n"]["baseColor"]["g"].getInput().isSame( s["b"]["c"]["g"] ) )
+		self.assertTrue( s["b"]["n"]["baseColor"]["b"].getInput().isSame( s["b"]["c"]["b"] ) )
+		self.assertEqual( s["b"]["c"].getValue(), IECore.Color3f( 1, 2, 3 ) )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		self.assertTrue( isinstance( s2["b"]["c"], Gaffer.Color3fPlug ) )
+		self.assertTrue( s2["b"]["n"]["baseColor"].getInput().isSame( s2["b"]["c"] ) )
+		self.assertTrue( s2["b"]["n"]["baseColor"]["r"].getInput().isSame( s2["b"]["c"]["r"] ) )
+		self.assertTrue( s2["b"]["n"]["baseColor"]["g"].getInput().isSame( s2["b"]["c"]["g"] ) )
+		self.assertTrue( s2["b"]["n"]["baseColor"]["b"].getInput().isSame( s2["b"]["c"]["b"] ) )
+		self.assertEqual( s2["b"]["c"].getValue(), IECore.Color3f( 1, 2, 3 ) )
+
 	def testCantPromoteNonSerialisablePlugs( self ) :
 
 		s = Gaffer.ScriptNode()
@@ -824,6 +851,91 @@ class BoxTest( GafferTest.TestCase ) :
 		self.assertTrue( "n" in s["b2"] )
 		self.assertEqual( Gaffer.Metadata.nodeValue( s["b2"], "description" ), None )
 		self.assertEqual( Gaffer.Metadata.nodeValue( s["b2"], "nodeGadget:color" ), None )
+
+	def testPromoteDynamicBoxPlugAndSerialise( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["b"] = Gaffer.Box()
+		s["b"]["n"] = Gaffer.Node()
+		s["b"]["n"]["p"] = Gaffer.Box2iPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		p = s["b"].promotePlug( s["b"]["n"]["p"] )
+		p.setValue( IECore.Box2i( IECore.V2i( 1, 2 ), IECore.V2i( 3, 4 ) ) )
+		p.setName( "c" )
+
+		self.assertTrue( isinstance( s["b"]["c"], Gaffer.Box2iPlug ) )
+		self.assertTrue( s["b"]["n"]["p"].getInput().isSame( s["b"]["c"] ) )
+		self.assertTrue( s["b"]["n"]["p"]["min"].getInput().isSame( s["b"]["c"]["min"] ) )
+		self.assertTrue( s["b"]["n"]["p"]["max"].getInput().isSame( s["b"]["c"]["max"] ) )
+		self.assertEqual( s["b"]["c"].getValue(), IECore.Box2i( IECore.V2i( 1, 2 ), IECore.V2i( 3, 4 ) ) )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		self.assertTrue( isinstance( s2["b"]["c"], Gaffer.Box2iPlug ) )
+		self.assertTrue( s2["b"]["n"]["p"].getInput().isSame( s2["b"]["c"] ) )
+		self.assertTrue( s2["b"]["n"]["p"]["min"].getInput().isSame( s2["b"]["c"]["min"] ) )
+		self.assertTrue( s2["b"]["n"]["p"]["max"].getInput().isSame( s2["b"]["c"]["max"] ) )
+		self.assertEqual( s2["b"]["c"].getValue(), IECore.Box2i( IECore.V2i( 1, 2 ), IECore.V2i( 3, 4 ) ) )
+
+	def testPromoteStaticPlugsWithChildren( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["b"] = Gaffer.Box()
+		s["b"]["n"] = GafferTest.CompoundPlugNode()
+		s["b"]["n"]["valuePlug"]["i"].setValue( 10 )
+
+		p = s["b"].promotePlug( s["b"]["n"]["valuePlug"] )
+		p.setName( "p" )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		self.assertEqual( s2["b"]["n"]["valuePlug"]["i"].getValue(), 10 )
+		self.assertTrue( s2["b"]["n"]["valuePlug"]["i"].getInput().isSame( s2["b"]["p"]["i"] ) )
+
+	def testPromoteDynamicPlugsWithChildren( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["b"] = Gaffer.Box()
+		s["b"]["n"] = Gaffer.Node()
+
+		s["b"]["n"]["user"]["p"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["b"]["n"]["user"]["p"]["p"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["b"]["n"]["user"]["p"]["p"]["i"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		s["b"]["n"]["user"]["v"] = Gaffer.ValuePlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["b"]["n"]["user"]["v"]["v"] = Gaffer.ValuePlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["b"]["n"]["user"]["v"]["v"]["i"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		p = s["b"].promotePlug( s["b"]["n"]["user"]["p"] )
+		p.setName( "p" )
+		p["p"]["i"].setValue( 10 )
+
+		v = s["b"].promotePlug( s["b"]["n"]["user"]["v"] )
+		v.setName( "v" )
+		v["v"]["i"].setValue( 20 )
+
+		def assertValid( script ) :
+
+			self.assertEqual( script["b"]["n"]["user"]["p"]["p"]["i"].getValue(), 10 )
+			self.assertTrue( script["b"]["n"]["user"]["p"]["p"]["i"].getInput().isSame( script["b"]["p"]["p"]["i"] ) )
+			self.assertTrue( script["b"]["n"]["user"]["p"]["p"].getInput().isSame( script["b"]["p"]["p"] ) )
+			self.assertTrue( script["b"]["n"]["user"]["p"].getInput().isSame( script["b"]["p"] ) )
+
+			self.assertEqual( script["b"]["n"]["user"]["v"]["v"]["i"].getValue(), 20 )
+			self.assertTrue( script["b"]["n"]["user"]["v"]["v"]["i"].getInput().isSame( script["b"]["v"]["v"]["i"] ) )
+			self.assertTrue( script["b"]["n"]["user"]["v"]["v"].getInput().isSame( script["b"]["v"]["v"] ) )
+			self.assertTrue( script["b"]["n"]["user"]["v"].getInput().isSame( script["b"]["v"] ) )
+
+		assertValid( s )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		assertValid( s2 )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/BoxTest.py
+++ b/python/GafferTest/BoxTest.py
@@ -937,5 +937,29 @@ class BoxTest( GafferTest.TestCase ) :
 
 		assertValid( s2 )
 
+	def testPromoteArrayPlug( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["a"] = GafferTest.AddNode()
+
+		s["b"] = Gaffer.Box()
+		s["b"]["n"] = GafferTest.ArrayPlugNode()
+
+		p = s["b"].promotePlug( s["b"]["n"]["in"] )
+		p.setName( "p" )
+
+		s["b"]["p"][0].setInput( s["a"]["sum"] )
+		s["b"]["p"][1].setInput( s["a"]["sum"] )
+
+		self.assertEqual( len( s["b"]["n"]["in"] ), 3 )
+		self.assertTrue( s["b"]["n"]["in"].getInput().isSame( s["b"]["p"] ) )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		self.assertEqual( len( s2["b"]["n"]["in"] ), 3 )
+		self.assertTrue( s2["b"]["n"]["in"].getInput().isSame( s2["b"]["p"] ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/CompoundDataPlugTest.py
+++ b/python/GafferTest/CompoundDataPlugTest.py
@@ -49,7 +49,7 @@ class CompoundDataPlugTest( GafferTest.TestCase ) :
 		p = Gaffer.CompoundDataPlug()
 
 		m1 = p.addMember( "a", IECore.IntData( 10 ) )
-		self.failUnless( isinstance( m1, Gaffer.CompoundPlug ) )
+		self.failUnless( isinstance( m1, Gaffer.ValuePlug ) )
 		self.assertEqual( m1.getName(), "member1" )
 		self.assertEqual( m1["name"].getValue(), "a" )
 		self.assertEqual( m1["value"].getValue(), 10 )
@@ -65,7 +65,7 @@ class CompoundDataPlugTest( GafferTest.TestCase ) :
 		self.assertEqual( n, "b" )
 
 		m2 = p.addMember( "c", IECore.FloatData( .5 ) )
-		self.failUnless( isinstance( m2, Gaffer.CompoundPlug ) )
+		self.failUnless( isinstance( m2, Gaffer.ValuePlug ) )
 		self.assertEqual( m2.getName(), "member2" )
 		self.assertEqual( m2["name"].getValue(), "c" )
 		self.assertEqual( m2["value"].getValue(), .5 )
@@ -76,7 +76,7 @@ class CompoundDataPlugTest( GafferTest.TestCase ) :
 		self.assertEqual( n, "c" )
 
 		m3 = p.addOptionalMember( "o", IECore.StringData( "--" ), plugName = "m", enabled = True )
-		self.failUnless( isinstance( m3, Gaffer.CompoundPlug ) )
+		self.failUnless( isinstance( m3, Gaffer.ValuePlug ) )
 		self.assertEqual( m3.getName(), "m" )
 		self.assertEqual( m3["name"].getValue(), "o" )
 		self.assertEqual( m3["value"].getValue(), "--" )
@@ -97,35 +97,35 @@ class CompoundDataPlugTest( GafferTest.TestCase ) :
 		p = Gaffer.CompoundDataPlug()
 
 		m1 = p.addMember( "a", IECore.FloatVectorData( [ 1, 2, 3 ] ) )
-		self.failUnless( isinstance( m1, Gaffer.CompoundPlug ) )
+		self.failUnless( isinstance( m1, Gaffer.ValuePlug ) )
 
 		d, n = p.memberDataAndName( m1 )
 		self.assertEqual( d, IECore.FloatVectorData( [ 1, 2, 3 ] ) )
 		self.assertEqual( n, "a" )
 
 		m2 = p.addMember( "b", IECore.IntVectorData( [ 1, 2, 3 ] ) )
-		self.failUnless( isinstance( m2, Gaffer.CompoundPlug ) )
+		self.failUnless( isinstance( m2, Gaffer.ValuePlug ) )
 
 		d, n = p.memberDataAndName( m2 )
 		self.assertEqual( d, IECore.IntVectorData( [ 1, 2, 3 ] ) )
 		self.assertEqual( n, "b" )
 
 		m3 = p.addMember( "c", IECore.StringVectorData( [ "1", "2", "3" ] ) )
-		self.failUnless( isinstance( m3, Gaffer.CompoundPlug ) )
+		self.failUnless( isinstance( m3, Gaffer.ValuePlug ) )
 
 		d, n = p.memberDataAndName( m3 )
 		self.assertEqual( d, IECore.StringVectorData( [ "1", "2", "3" ] ) )
 		self.assertEqual( n, "c" )
 
 		m4 = p.addMember( "d", IECore.V3fVectorData( [ IECore.V3f( x ) for x in range( 1, 5 ) ] ) )
-		self.failUnless( isinstance( m4, Gaffer.CompoundPlug ) )
+		self.failUnless( isinstance( m4, Gaffer.ValuePlug ) )
 
 		d, n = p.memberDataAndName( m4 )
 		self.assertEqual( d, IECore.V3fVectorData( [ IECore.V3f( x ) for x in range( 1, 5 ) ] ) )
 		self.assertEqual( n, "d" )
 
 		m5 = p.addMember( "e", IECore.Color3fVectorData( [ IECore.Color3f( x ) for x in range( 1, 5 ) ] ) )
-		self.failUnless( isinstance( m5, Gaffer.CompoundPlug ) )
+		self.failUnless( isinstance( m5, Gaffer.ValuePlug ) )
 
 		d, n = p.memberDataAndName( m5 )
 		self.assertEqual( d, IECore.Color3fVectorData( [ IECore.Color3f( x ) for x in range( 1, 5 ) ] ) )
@@ -136,14 +136,14 @@ class CompoundDataPlugTest( GafferTest.TestCase ) :
 		p = Gaffer.CompoundDataPlug()
 
 		m1 = p.addMember( "a", IECore.V3fData( IECore.V3f( 1, 2, 3 ) ) )
-		self.failUnless( isinstance( m1, Gaffer.CompoundPlug ) )
+		self.failUnless( isinstance( m1, Gaffer.ValuePlug ) )
 
 		d, n = p.memberDataAndName( m1 )
 		self.assertEqual( d, IECore.V3fData( IECore.V3f( 1, 2, 3 ) ) )
 		self.assertEqual( n, "a" )
 
 		m2 = p.addMember( "b", IECore.V2fData( IECore.V2f( 1, 2 ) ) )
-		self.failUnless( isinstance( m2, Gaffer.CompoundPlug ) )
+		self.failUnless( isinstance( m2, Gaffer.ValuePlug ) )
 
 		d, n = p.memberDataAndName( m2 )
 		self.assertEqual( d, IECore.V2fData( IECore.V2f( 1, 2 ) ) )

--- a/python/GafferTest/CompoundNumericPlugTest.py
+++ b/python/GafferTest/CompoundNumericPlugTest.py
@@ -198,11 +198,11 @@ class CompoundNumericPlugTest( GafferTest.TestCase ) :
 	def testRunTimeTyped( self ) :
 
 		p = Gaffer.Color3fPlug()
-		self.failUnless( p.isInstanceOf( Gaffer.CompoundPlug.staticTypeId() ) )
+		self.failUnless( p.isInstanceOf( Gaffer.ValuePlug.staticTypeId() ) )
 		self.failUnless( p.isInstanceOf( Gaffer.Plug.staticTypeId() ) )
 
 		t = p.typeId()
-		self.assertEqual( IECore.RunTimeTyped.baseTypeId( t ), Gaffer.CompoundPlug.staticTypeId() )
+		self.assertEqual( IECore.RunTimeTyped.baseTypeId( t ), Gaffer.ValuePlug.staticTypeId() )
 
 	def testSetToDefault( self ) :
 

--- a/python/GafferTest/CompoundNumericPlugTest.py
+++ b/python/GafferTest/CompoundNumericPlugTest.py
@@ -355,6 +355,12 @@ class CompoundNumericPlugTest( GafferTest.TestCase ) :
 		ss = s.serialise( filter = Gaffer.StandardSet( [ s["n"] ] ) )
 		self.assertEqual( ss.count( "setValue" ), 1 )
 
+		s["n"]["p"]["z"].setInput( s["n"]["p"]["y"] )
+
+		ss = s.serialise( filter = Gaffer.StandardSet( [ s["n"] ] ) )
+		self.assertEqual( ss.count( "setValue" ), 2 )
+		self.assertEqual( ss.count( "setInput" ), 1 )
+
 	def testUndoMerging( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/python/GafferTest/CompoundPlugNode.py
+++ b/python/GafferTest/CompoundPlugNode.py
@@ -63,6 +63,10 @@ class CompoundPlugNode( Gaffer.DependencyNode ) :
 		# for CompoundPlugTest.testSerialisationOfDynamicPlugsOnNondynamicParent().
 		self.addChild( Gaffer.CompoundPlug( name = "nonDynamicParent" ) )
 
+		# For BoxTest.testPromoteStaticPlugsWithChildren
+		self["valuePlug"] = Gaffer.ValuePlug()
+		self["valuePlug"]["i"] = Gaffer.IntPlug()
+
 	def affects( self, inputPlug ) :
 
 		outputs = Gaffer.DependencyNode.affects( self, inputPlug )

--- a/python/GafferTest/DispatcherTest.py
+++ b/python/GafferTest/DispatcherTest.py
@@ -764,24 +764,6 @@ class DispatcherTest( GafferTest.TestCase ) :
 		expectedText = "n1 on 2;n1 on 4;n1 on 6;n3 on 2;n3 on 4;n3 on 6;"
 		self.assertEqual( text, expectedText )
 
-		# connecting it to a non-executable doesn't do anything either
-
-		s["b"]["n5"] = Gaffer.Node()
-		s["b"]["n5"]["requirement"] = Gaffer.Plug( direction = Gaffer.Plug.Direction.Out )
-		s["b"]["out2"].setInput( s["b"]["n5"]["requirement"] )
-
-		os.remove( fileName )
-		self.assertEqual( os.path.isfile( fileName ), False )
-		dispatcher.dispatch( [ s["b"] ] )
-		shutil.rmtree( dispatcher.jobDirectory() )
-		self.assertEqual( os.path.isfile( fileName ), True )
-		with file( fileName, "r" ) as f :
-			text = f.read()
-
-		# all frames of n1, followed by the n3 sequence
-		expectedText = "n1 on 2;n1 on 4;n1 on 6;n3 on 2;n3 on 4;n3 on 6;"
-		self.assertEqual( text, expectedText )
-
 		# multiple promoted requirements will dispatch
 
 		s["b"]["out3"] = s["b"]["n2"]['requirement'].createCounterpart( "out3", Gaffer.Plug.Direction.Out )

--- a/python/GafferTest/ExecutableNodeTest.py
+++ b/python/GafferTest/ExecutableNodeTest.py
@@ -354,6 +354,12 @@ class ExecutableNodeTest( GafferTest.TestCase ) :
 
 		self.assertTrue( s["r"]["e"]["requirements"][0].source().isSame( s["e"]["requirement"] ) )
 
+	def testLoadPromotedRequirementsFromVersion0_15( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( os.path.dirname( __file__ ) + "/scripts/promotedRequirementsVersion-0.15.0.0.gfr" )
+		s.load()
+
 	def tearDown( self ) :
 
 		GafferTest.TestCase.tearDown( self )

--- a/python/GafferTest/Transform2DPlugTest.py
+++ b/python/GafferTest/Transform2DPlugTest.py
@@ -114,8 +114,8 @@ class Transform2DPlugTest( GafferTest.TestCase ) :
 	def testRunTimeTyped( self ) :
 
 		p = Gaffer.Transform2DPlug()
-		self.failIf( p.typeId() == Gaffer.CompoundPlug.staticTypeId() )
-		self.failUnless( p.isInstanceOf( Gaffer.CompoundPlug.staticTypeId() ) )
+		self.failIf( p.typeId() == Gaffer.ValuePlug.staticTypeId() )
+		self.failUnless( p.isInstanceOf( Gaffer.ValuePlug.staticTypeId() ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/TransformPlugTest.py
+++ b/python/GafferTest/TransformPlugTest.py
@@ -101,8 +101,8 @@ class TransformPlugTest( GafferTest.TestCase ) :
 	def testRunTimeTyped( self ) :
 
 		p = Gaffer.TransformPlug()
-		self.failIf( p.typeId() == Gaffer.CompoundPlug.staticTypeId() )
-		self.failUnless( p.isInstanceOf( Gaffer.CompoundPlug.staticTypeId() ) )
+		self.failIf( p.typeId() == Gaffer.ValuePlug.staticTypeId() )
+		self.failUnless( p.isInstanceOf( Gaffer.ValuePlug.staticTypeId() ) )
 
 	def testPivot( self ) :
 

--- a/python/GafferTest/ValuePlugTest.py
+++ b/python/GafferTest/ValuePlugTest.py
@@ -271,6 +271,19 @@ class ValuePlugTest( GafferTest.TestCase ) :
 		self.assertEqual( n.numHashCalls, numHashCalls )
 		self.assertTrue( a3.isSame( a1 ) )
 
+	def testSerialisationOfChildValues( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["n"] = Gaffer.Node()
+		s["n"]["user"]["v"] = Gaffer.ValuePlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["n"]["user"]["v"]["i"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["n"]["user"]["v"]["i"].setValue( 10 )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		self.assertEqual( s2["n"]["user"]["v"]["i"].getValue(), 10 )
+
 	def setUp( self ) :
 
 		self.__originalCacheMemoryLimit = Gaffer.ValuePlug.getCacheMemoryLimit()

--- a/python/GafferTest/scripts/promotedRequirementsVersion-0.15.0.0.gfr
+++ b/python/GafferTest/scripts/promotedRequirementsVersion-0.15.0.0.gfr
@@ -1,0 +1,27 @@
+import Gaffer
+import IECore
+
+__children = {}
+
+__children["b"] = Gaffer.Box( "b" )
+parent.addChild( __children["b"] )
+__children["b"].addChild( Gaffer.TaskList( "n" ) )
+__children["b"]["n"]["requirements"].addChild( Gaffer.Plug( "requirement1", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["b"].addChild( Gaffer.Plug( "n_requirements_requirement0", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["b"].addChild( Gaffer.Plug( "n_requirement", direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["b"]["n"]["requirements"]["requirement0"].setInput( __children["b"]["n_requirements_requirement0"] )
+Gaffer.Metadata.registerPlugValue( __children["b"]["n_requirements_requirement0"], "nodeGadget:nodulePosition", None )
+Gaffer.Metadata.registerPlugValue( __children["b"]["n_requirements_requirement0"], "nodule:type", None )
+Gaffer.Metadata.registerPlugValue( __children["b"]["n_requirements_requirement0"], "compoundNodule:orientation", None )
+Gaffer.Metadata.registerPlugValue( __children["b"]["n_requirements_requirement0"], "compoundNodule:spacing", None )
+Gaffer.Metadata.registerPlugValue( __children["b"]["n_requirements_requirement0"], "compoundNodule:direction", None )
+__children["b"]["n_requirement"].setInput( __children["b"]["n"]["requirement"] )
+Gaffer.Metadata.registerPlugValue( __children["b"]["n_requirement"], "nodeGadget:nodulePosition", None )
+Gaffer.Metadata.registerPlugValue( __children["b"]["n_requirement"], "nodule:type", None )
+Gaffer.Metadata.registerPlugValue( __children["b"]["n_requirement"], "compoundNodule:orientation", None )
+Gaffer.Metadata.registerPlugValue( __children["b"]["n_requirement"], "compoundNodule:spacing", None )
+Gaffer.Metadata.registerPlugValue( __children["b"]["n_requirement"], "compoundNodule:direction", None )
+
+
+del __children
+

--- a/src/Gaffer/ArrayPlug.cpp
+++ b/src/Gaffer/ArrayPlug.cpp
@@ -45,7 +45,7 @@ using namespace boost;
 IE_CORE_DEFINERUNTIMETYPED( ArrayPlug )
 
 ArrayPlug::ArrayPlug( const std::string &name, Direction direction, PlugPtr element, size_t minSize, size_t maxSize, unsigned flags )
-	:	CompoundPlug( name, direction, flags ), m_minSize( minSize ), m_maxSize( maxSize )
+	:	Plug( name, direction, flags ), m_minSize( minSize ), m_maxSize( maxSize )
 {
 	if( direction == Plug::Out )
 	{
@@ -76,7 +76,7 @@ ArrayPlug::~ArrayPlug()
 
 bool ArrayPlug::acceptsChild( const GraphComponent *potentialChild ) const
 {
-	if( !CompoundPlug::acceptsChild( potentialChild ) )
+	if( !Plug::acceptsChild( potentialChild ) )
 	{
 		return false;
 	}

--- a/src/Gaffer/ArrayPlug.cpp
+++ b/src/Gaffer/ArrayPlug.cpp
@@ -85,7 +85,20 @@ bool ArrayPlug::acceptsChild( const GraphComponent *potentialChild ) const
 		return false;
 	}
 
-	return children().size() == 0 || potentialChild->typeId() == children()[0]->typeId();
+	if( children().size() == 0 || potentialChild->typeId() == children()[0]->typeId() )
+	{
+		return true;
+	}
+
+	// Ideally we'd just return false here right away, but we need this
+	// hack to provide backwards compatibility with old ExecutableNodes,
+	// which used to use generic Plugs as children and now use RequirementPlugs.
+	if( children()[0]->isInstanceOf( (IECore::TypeId)ExecutableNodeRequirementPlugTypeId ) && potentialChild->typeId() == (IECore::TypeId)PlugTypeId )
+	{
+		return true;
+	}
+
+	return false;
 }
 
 void ArrayPlug::setInput( PlugPtr input )

--- a/src/Gaffer/Box.cpp
+++ b/src/Gaffer/Box.cpp
@@ -76,9 +76,12 @@ Plug *Box::promotePlug( Plug *descendantPlug )
 	// so we need to do that ourselves. We don't want to propagate them to the
 	// children of plug types which create the children themselves during
 	// construction though, hence the typeId checks for the base classes
-	// which add no children during construction.
-	const Gaffer::TypeId compoundTypes[] = { PlugTypeId, ValuePlugTypeId, CompoundPlugTypeId };
-	const Gaffer::TypeId *compoundTypesEnd = compoundTypes + 3;
+	// which add no children during construction. I'm not sure this approach is
+	// necessarily the best - the alternative would be to set everything dynamic
+	// unconditionally and then implement Serialiser::childNeedsConstruction()
+	// for types like CompoundNumericPlug that create children in their constructors.
+	const Gaffer::TypeId compoundTypes[] = { PlugTypeId, ValuePlugTypeId, CompoundPlugTypeId, ArrayPlugTypeId };
+	const Gaffer::TypeId *compoundTypesEnd = compoundTypes + 4;
 	if( find( compoundTypes, compoundTypesEnd, externalPlug->typeId() ) != compoundTypesEnd )
 	{
 		for( RecursivePlugIterator it( externalPlug.get() ); it != it.end(); ++it )

--- a/src/Gaffer/BoxPlug.cpp
+++ b/src/Gaffer/BoxPlug.cpp
@@ -49,7 +49,7 @@ BoxPlug<T>::BoxPlug(
 	T defaultValue,
 	unsigned flags
 )
-	:	CompoundPlug( name, direction, flags )
+	:	ValuePlug( name, direction, flags )
 {
 	const unsigned childFlags = flags & ~Dynamic;
 	addChild(
@@ -82,7 +82,7 @@ BoxPlug<T>::BoxPlug(
 	const PointType &maxValue,
 	unsigned flags
 )
-	:	CompoundPlug( name, direction, flags )
+	:	ValuePlug( name, direction, flags )
 {
 	const unsigned childFlags = flags & ~Dynamic;
 	addChild(

--- a/src/Gaffer/CompoundDataPlug.cpp
+++ b/src/Gaffer/CompoundDataPlug.cpp
@@ -57,7 +57,7 @@ using namespace Gaffer;
 IE_CORE_DEFINERUNTIMETYPED( CompoundDataPlug::MemberPlug );
 
 CompoundDataPlug::MemberPlug::MemberPlug( const std::string &name, Direction direction, unsigned flags )
-	:	CompoundPlug( name, direction, flags )
+	:	ValuePlug( name, direction, flags )
 {
 }
 
@@ -83,7 +83,7 @@ const BoolPlug *CompoundDataPlug::MemberPlug::enabledPlug() const
 
 bool CompoundDataPlug::MemberPlug::acceptsChild( const Gaffer::GraphComponent *potentialChild ) const
 {
-	if( !CompoundPlug::acceptsChild( potentialChild ) )
+	if( !ValuePlug::acceptsChild( potentialChild ) )
 	{
 		return false;
 	}
@@ -133,7 +133,7 @@ PlugPtr CompoundDataPlug::MemberPlug::createCounterpart( const std::string &name
 IE_CORE_DEFINERUNTIMETYPED( CompoundDataPlug )
 
 CompoundDataPlug::CompoundDataPlug( const std::string &name, Direction direction, unsigned flags )
-	:	CompoundPlug( name, direction, flags )
+	:	ValuePlug( name, direction, flags )
 {
 }
 
@@ -143,7 +143,7 @@ CompoundDataPlug::~CompoundDataPlug()
 
 bool CompoundDataPlug::acceptsChild( const GraphComponent *potentialChild ) const
 {
-	if( !CompoundPlug::acceptsChild( potentialChild ) )
+	if( !ValuePlug::acceptsChild( potentialChild ) )
 	{
 		return false;
 	}

--- a/src/Gaffer/CompoundNumericPlug.cpp
+++ b/src/Gaffer/CompoundNumericPlug.cpp
@@ -51,7 +51,7 @@ CompoundNumericPlug<T>::CompoundNumericPlug(
 	T maxValue,
 	unsigned flags
 )
-	:	CompoundPlug( name, direction, flags )
+	:	ValuePlug( name, direction, flags )
 {
 	const char **n = childNames();
 	unsigned childFlags = flags & ~Dynamic;

--- a/src/Gaffer/CompoundPlug.cpp
+++ b/src/Gaffer/CompoundPlug.cpp
@@ -53,8 +53,6 @@ IE_CORE_DEFINERUNTIMETYPED( CompoundPlug )
 CompoundPlug::CompoundPlug( const std::string &name, Direction direction, unsigned flags )
 	:	ValuePlug( name, direction, flags )
 {
-	childAddedSignal().connect( boost::bind( &CompoundPlug::childAddedOrRemoved, this ) );
-	childRemovedSignal().connect( boost::bind( &CompoundPlug::childAddedOrRemoved, this ) );
 }
 
 CompoundPlug::~CompoundPlug()
@@ -69,14 +67,4 @@ PlugPtr CompoundPlug::createCounterpart( const std::string &name, Direction dire
 		result->addChild( (*it)->createCounterpart( (*it)->getName(), direction ) );
 	}
 	return result;
-}
-
-void CompoundPlug::childAddedOrRemoved()
-{
-	// addition or removal of a child to a compound is considered to
-	// change its value, so we emit the appropriate signal. this is
-	// mostly of use for the SplinePlug, as points are added by adding
-	// plugs and removed by removing them.
-	/// \todo Do we really need this?
-	emitPlugSet();
 }

--- a/src/Gaffer/ComputeNode.cpp
+++ b/src/Gaffer/ComputeNode.cpp
@@ -37,7 +37,6 @@
 
 #include "Gaffer/ComputeNode.h"
 #include "Gaffer/ValuePlug.h"
-#include "Gaffer/CompoundPlug.h"
 
 using namespace Gaffer;
 

--- a/src/Gaffer/Dispatcher.cpp
+++ b/src/Gaffer/Dispatcher.cpp
@@ -40,7 +40,6 @@
 #include "IECore/MessageHandler.h"
 
 #include "Gaffer/Box.h"
-#include "Gaffer/CompoundPlug.h"
 #include "Gaffer/Context.h"
 #include "Gaffer/Dispatcher.h"
 #include "Gaffer/ScriptNode.h"

--- a/src/Gaffer/ExecutableNode.cpp
+++ b/src/Gaffer/ExecutableNode.cpp
@@ -111,7 +111,25 @@ bool ExecutableNode::RequirementPlug::acceptsInput( const Plug *input ) const
 		return true;
 	}
 
-	return input->isInstanceOf( staticTypeId() );
+	if( input->isInstanceOf( staticTypeId() ) )
+	{
+		return true;
+	}
+
+	// Ideally we'd return false right now, but we must
+	// provide backwards compatibility with old scripts
+	// where the requirement plugs were just represented
+	// as standard Plugs, and may have been promoted to
+	// Boxes and Dots in that form.
+	if( input->typeId() == Plug::staticTypeId() )
+	{
+		const Plug *sourcePlug = input->source<Plug>();
+		const Node *sourceNode = sourcePlug->node();
+		return runTimeCast<const SubGraph>( sourceNode ) || runTimeCast<const Dot>( sourceNode );
+	}
+
+	return false;
+
 }
 
 PlugPtr ExecutableNode::RequirementPlug::createCounterpart( const std::string &name, Direction direction ) const

--- a/src/Gaffer/ExecutableNode.cpp
+++ b/src/Gaffer/ExecutableNode.cpp
@@ -84,6 +84,42 @@ bool ExecutableNode::Task::operator < ( const Task &rhs ) const
 }
 
 //////////////////////////////////////////////////////////////////////////
+// RequirementPlug implementation.
+//////////////////////////////////////////////////////////////////////////
+
+IE_CORE_DEFINERUNTIMETYPED( ExecutableNode::RequirementPlug );
+
+ExecutableNode::RequirementPlug::RequirementPlug( const std::string &name, Direction direction, unsigned flags )
+	:	Plug( name, direction, flags )
+{
+}
+
+bool ExecutableNode::RequirementPlug::acceptsChild( const Gaffer::GraphComponent *potentialChild ) const
+{
+	return false;
+}
+
+bool ExecutableNode::RequirementPlug::acceptsInput( const Plug *input ) const
+{
+	if( !Plug::acceptsInput( input ) )
+	{
+		return false;
+	}
+
+	if( !input )
+	{
+		return true;
+	}
+
+	return input->isInstanceOf( staticTypeId() );
+}
+
+PlugPtr ExecutableNode::RequirementPlug::createCounterpart( const std::string &name, Direction direction ) const
+{
+	return new RequirementPlug( name, direction, getFlags() );
+}
+
+//////////////////////////////////////////////////////////////////////////
 // ExecutableNode implementation
 //////////////////////////////////////////////////////////////////////////
 
@@ -95,8 +131,8 @@ ExecutableNode::ExecutableNode( const std::string &name )
 	:	Node( name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
-	addChild( new ArrayPlug( "requirements", Plug::In, new Plug( "requirement0" ) ) );
-	addChild( new Plug( "requirement", Plug::Out ) );
+	addChild( new ArrayPlug( "requirements", Plug::In, new RequirementPlug( "requirement0" ) ) );
+	addChild( new RequirementPlug( "requirement", Plug::Out ) );
 
 	PlugPtr dispatcherPlug = new Plug( "dispatcher", Plug::In );
 	addChild( dispatcherPlug );
@@ -118,14 +154,14 @@ const ArrayPlug *ExecutableNode::requirementsPlug() const
 	return getChild<ArrayPlug>( g_firstPlugIndex );
 }
 
-Plug *ExecutableNode::requirementPlug()
+ExecutableNode::RequirementPlug *ExecutableNode::requirementPlug()
 {
-	return getChild<Plug>( g_firstPlugIndex + 1 );
+	return getChild<RequirementPlug>( g_firstPlugIndex + 1 );
 }
 
-const Plug *ExecutableNode::requirementPlug() const
+const ExecutableNode::RequirementPlug *ExecutableNode::requirementPlug() const
 {
-	return getChild<Plug>( g_firstPlugIndex + 1 );
+	return getChild<RequirementPlug>( g_firstPlugIndex + 1 );
 }
 
 Plug *ExecutableNode::dispatcherPlug()
@@ -182,30 +218,3 @@ bool ExecutableNode::requiresSequenceExecution() const
 {
 	return false;
 }
-
-bool ExecutableNode::acceptsInput( const Plug *plug, const Plug *inputPlug ) const
-{
-	if( !Node::acceptsInput( plug, inputPlug ) )
-	{
-		return false;
-	}
-
-	if( plug->parent<ArrayPlug>() == requirementsPlug() )
-	{
-		const Plug *sourcePlug = inputPlug->source<Plug>();
-		const Node *sourceNode = sourcePlug->node();
-		if ( const ExecutableNode *executable = runTimeCast<const ExecutableNode>( sourceNode ) )
-		{
-			return sourcePlug == executable->requirementPlug();
-		}
-
-		// we only really want to accept connections from ExecutableNodes, because we can't require
-		// anything else, but we also accept the unconnected inputs and outputs of subgraphs, so you
-		// can wrap ExecutableNodes in boxes prior to connecting the other side. likewise, we accept
-		// connections from dots.
-		return runTimeCast<const SubGraph>( sourceNode ) || runTimeCast<const Dot>( sourceNode );
-	}
-
-	return true;
-}
-

--- a/src/Gaffer/ScriptNode.cpp
+++ b/src/Gaffer/ScriptNode.cpp
@@ -49,7 +49,6 @@
 #include "Gaffer/Action.h"
 #include "Gaffer/ApplicationRoot.h"
 #include "Gaffer/Context.h"
-#include "Gaffer/CompoundPlug.h"
 #include "Gaffer/StandardSet.h"
 #include "Gaffer/DependencyNode.h"
 #include "Gaffer/CompoundDataPlug.h"
@@ -206,7 +205,7 @@ ScriptNode::ScriptNode( const std::string &name )
 	addChild( new StringPlug( "fileName", Plug::In, "", Plug::Default & ~Plug::Serialisable ) );
 	addChild( new BoolPlug( "unsavedChanges", Plug::In, false, Plug::Default & ~Plug::Serialisable ) );
 
-	CompoundPlugPtr frameRangePlug = new CompoundPlug( "frameRange", Plug::In );
+	ValuePlugPtr frameRangePlug = new ValuePlug( "frameRange", Plug::In );
 	IntPlugPtr frameStartPlug = new IntPlug( "start", Plug::In, 1 );
 	IntPlugPtr frameEndPlug = new IntPlug( "end", Plug::In, 100 );
 	frameRangePlug->addChild( frameStartPlug );
@@ -602,22 +601,22 @@ const CompoundDataPlug *ScriptNode::variablesPlug() const
 
 IntPlug *ScriptNode::frameStartPlug()
 {
-	return getChild<CompoundPlug>( g_firstPlugIndex + 2 )->getChild<IntPlug>( 0 );
+	return getChild<ValuePlug>( g_firstPlugIndex + 2 )->getChild<IntPlug>( 0 );
 }
 
 const IntPlug *ScriptNode::frameStartPlug() const
 {
-	return getChild<CompoundPlug>( g_firstPlugIndex + 2 )->getChild<IntPlug>( 0 );
+	return getChild<ValuePlug>( g_firstPlugIndex + 2 )->getChild<IntPlug>( 0 );
 }
 
 IntPlug *ScriptNode::frameEndPlug()
 {
-	return getChild<CompoundPlug>( g_firstPlugIndex + 2 )->getChild<IntPlug>( 1 );
+	return getChild<ValuePlug>( g_firstPlugIndex + 2 )->getChild<IntPlug>( 1 );
 }
 
 const IntPlug *ScriptNode::frameEndPlug() const
 {
-	return getChild<CompoundPlug>( g_firstPlugIndex + 2 )->getChild<IntPlug>( 1 );
+	return getChild<ValuePlug>( g_firstPlugIndex + 2 )->getChild<IntPlug>( 1 );
 }
 
 void ScriptNode::plugSet( Plug *plug )

--- a/src/Gaffer/SplinePlug.cpp
+++ b/src/Gaffer/SplinePlug.cpp
@@ -58,9 +58,6 @@ SplinePlug<T>::SplinePlug( const std::string &name, Direction direction, const T
 	addChild( new IntPlug( "endPointMultiplicity", direction, endPointMultiplicity( defaultValue ), 1 ) );
 
 	setValue( defaultValue );
-
-	childAddedSignal().connect( boost::bind( &SplinePlug::childAddedOrRemoved, this ) );
-	childRemovedSignal().connect( boost::bind( &SplinePlug::childAddedOrRemoved, this ) );
 }
 
 template<typename T>
@@ -384,13 +381,6 @@ size_t SplinePlug<T>::endPointMultiplicity( const T &value ) const
 	{
 		return 1;
 	}
-}
-
-template<typename T>
-void SplinePlug<T>::childAddedOrRemoved()
-{
-	// adding or removing points sets our value.
-	emitPlugSet();
 }
 
 namespace Gaffer

--- a/src/Gaffer/Transform2DPlug.cpp
+++ b/src/Gaffer/Transform2DPlug.cpp
@@ -46,7 +46,7 @@ IE_CORE_DEFINERUNTIMETYPED( Transform2DPlug );
 size_t Transform2DPlug::g_firstPlugIndex = 0;
 
 Transform2DPlug::Transform2DPlug( const std::string &name, Direction direction, unsigned flags )
-	:	CompoundPlug( name, direction, flags )
+	:	ValuePlug( name, direction, flags )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 

--- a/src/Gaffer/TransformPlug.cpp
+++ b/src/Gaffer/TransformPlug.cpp
@@ -47,7 +47,7 @@ IE_CORE_DEFINERUNTIMETYPED( TransformPlug );
 size_t TransformPlug::g_firstPlugIndex = 0;
 
 TransformPlug::TransformPlug( const std::string &name, Direction direction, unsigned flags )
-	:	CompoundPlug( name, direction, flags )
+	:	ValuePlug( name, direction, flags )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 

--- a/src/GafferAppleseed/AppleseedLight.cpp
+++ b/src/GafferAppleseed/AppleseedLight.cpp
@@ -97,7 +97,10 @@ void AppleseedLight::loadShader( const std::string &shaderName )
 
 void AppleseedLight::hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	parametersPlug()->hash( h );
+	for( ValuePlugIterator it( parametersPlug() ); it != it.end(); ++it )
+	{
+		(*it)->hash( h );
+	}
 	getChild<StringPlug>( "__model" )->hash( h );
 }
 

--- a/src/GafferArnold/ArnoldLight.cpp
+++ b/src/GafferArnold/ArnoldLight.cpp
@@ -82,7 +82,10 @@ void ArnoldLight::loadShader( const std::string &shaderName )
 
 void ArnoldLight::hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	parametersPlug()->hash( h );
+	for( ValuePlugIterator it( parametersPlug() ); it != it.end(); ++it )
+	{
+		(*it)->hash( h );
+	}
 	getChild<StringPlug>( "__shaderName" )->hash( h );
 }
 

--- a/src/GafferBindings/ApplicationRootBinding.cpp
+++ b/src/GafferBindings/ApplicationRootBinding.cpp
@@ -46,7 +46,6 @@
 #include "IECorePython/Wrapper.h"
 
 #include "Gaffer/ApplicationRoot.h"
-#include "Gaffer/CompoundPlug.h"
 #include "Gaffer/Preferences.h"
 
 #include "GafferBindings/ApplicationRootBinding.h"

--- a/src/GafferBindings/ArrayPlugBinding.cpp
+++ b/src/GafferBindings/ArrayPlugBinding.cpp
@@ -40,7 +40,7 @@
 #include "IECorePython/RunTimeTypedBinding.h"
 
 #include "Gaffer/ArrayPlug.h"
-#include "GafferBindings/CompoundPlugBinding.h"
+#include "GafferBindings/PlugBinding.h"
 #include "GafferBindings/ArrayPlugBinding.h"
 
 using namespace boost::python;
@@ -83,7 +83,7 @@ static std::string repr( const ArrayPlug *plug )
 	return maskedRepr( plug, Plug::All );
 }
 
-class ArrayPlugSerialiser : public CompoundPlugSerialiser
+class ArrayPlugSerialiser : public PlugSerialiser
 {
 
 	public :

--- a/src/GafferBindings/CompoundDataPlugBinding.cpp
+++ b/src/GafferBindings/CompoundDataPlugBinding.cpp
@@ -41,7 +41,7 @@
 
 #include "Gaffer/CompoundDataPlug.h"
 
-#include "GafferBindings/CompoundPlugBinding.h"
+#include "GafferBindings/ValuePlugBinding.h"
 #include "GafferBindings/CompoundDataPlugBinding.h"
 
 using namespace boost::python;
@@ -124,7 +124,7 @@ static void fillCompoundObject( const CompoundDataPlug &p, IECore::CompoundObjec
 	p.fillCompoundObject( o->members() );
 }
 
-class MemberPlugSerialiser : public CompoundPlugSerialiser
+class MemberPlugSerialiser : public ValuePlugSerialiser
 {
 
 	public :

--- a/src/GafferBindings/CompoundNumericPlugBinding.cpp
+++ b/src/GafferBindings/CompoundNumericPlugBinding.cpp
@@ -43,8 +43,8 @@
 
 #include "Gaffer/CompoundNumericPlug.h"
 
+#include "GafferBindings/ValuePlugBinding.h"
 #include "GafferBindings/CompoundNumericPlugBinding.h"
-#include "GafferBindings/CompoundPlugBinding.h"
 
 using namespace boost::python;
 using namespace GafferBindings;
@@ -60,7 +60,7 @@ std::string compoundNumericPlugRepr( const T *plug )
 }
 
 template<typename T>
-class CompoundNumericPlugSerialiser : public CompoundPlugSerialiser
+class CompoundNumericPlugSerialiser : public ValuePlugSerialiser
 {
 
 	protected :

--- a/src/GafferBindings/DispatcherBinding.cpp
+++ b/src/GafferBindings/DispatcherBinding.cpp
@@ -40,7 +40,6 @@
 
 #include "Gaffer/Context.h"
 #include "Gaffer/Dispatcher.h"
-#include "Gaffer/CompoundPlug.h"
 #include "Gaffer/ScriptNode.h"
 
 #include "GafferBindings/DispatcherBinding.h"

--- a/src/GafferBindings/ExecutableNodeBinding.cpp
+++ b/src/GafferBindings/ExecutableNodeBinding.cpp
@@ -48,13 +48,16 @@ using namespace IECorePython;
 using namespace GafferBindings;
 using namespace Gaffer;
 
-static unsigned long taskHash( const ExecutableNode::Task &t )
+namespace
+{
+
+unsigned long taskHash( const ExecutableNode::Task &t )
 {
 	const IECore::MurmurHash h = t.hash();
 	return tbb::tbb_hasher( h.toString() );
 }
 
-static ContextPtr taskContext( const ExecutableNode::Task &t, bool copy = true )
+ContextPtr taskContext( const ExecutableNode::Task &t, bool copy = true )
 {
 	if ( ConstContextPtr context = t.context() )
 	{
@@ -69,7 +72,7 @@ static ContextPtr taskContext( const ExecutableNode::Task &t, bool copy = true )
 	return 0;
 }
 
-static ExecutableNodePtr taskNode( const ExecutableNode::Task &t )
+ExecutableNodePtr taskNode( const ExecutableNode::Task &t )
 {
 	if ( ConstExecutableNodePtr node = t.node() )
 	{
@@ -78,6 +81,8 @@ static ExecutableNodePtr taskNode( const ExecutableNode::Task &t )
 
 	return 0;
 }
+
+} // namespace
 
 void GafferBindings::bindExecutableNode()
 {

--- a/src/GafferBindings/ExecutableNodeBinding.cpp
+++ b/src/GafferBindings/ExecutableNodeBinding.cpp
@@ -41,6 +41,7 @@
 #include "Gaffer/ExecutableNode.h"
 
 #include "GafferBindings/ExecutableNodeBinding.h"
+#include "GafferBindings/PlugBinding.h"
 
 using namespace boost::python;
 using namespace IECore;
@@ -98,4 +99,19 @@ void GafferBindings::bindExecutableNode()
 		.def("__eq__", &ExecutableNode::Task::operator== )
 		.def("__hash__", &taskHash )
 	;
+
+	PlugClass<ExecutableNode::RequirementPlug>()
+		.def( init<const char *, Plug::Direction, unsigned>(
+				(
+					boost::python::arg_( "name" )=GraphComponent::defaultName<ExecutableNode::RequirementPlug>(),
+					boost::python::arg_( "direction" )=Plug::In,
+					boost::python::arg_( "flags" )=Plug::Default
+				)
+			)
+		)
+		// Adjusting the name so that it correctly reflects
+		// the nesting, and can be used by the PlugSerialiser.
+		.attr( "__name__" ) = "ExecutableNode.RequirementPlug"
+	;
+
 }

--- a/src/GafferBindings/ValuePlugBinding.cpp
+++ b/src/GafferBindings/ValuePlugBinding.cpp
@@ -175,54 +175,52 @@ std::string ValuePlugSerialiser::constructor( const Gaffer::GraphComponent *grap
 std::string ValuePlugSerialiser::postConstructor( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const
 {
 	const ValuePlug *plug = static_cast<const ValuePlug *>( graphComponent );
-	if( valueNeedsSerialisation( plug, serialisation ) )
+	if( !valueNeedsSerialisation( plug, serialisation ) )
 	{
-		object pythonPlug( ValuePlugPtr( const_cast<ValuePlug *>( plug ) ) );
-		if( PyObject_HasAttrString( pythonPlug.ptr(), "getValue" ) )
-		{
-			object pythonValue = pythonPlug.attr( "getValue" )();
+		return "";
+	}
+
+	object pythonPlug( ValuePlugPtr( const_cast<ValuePlug *>( plug ) ) );
+	object pythonValue = pythonPlug.attr( "getValue" )();
 			
-			bool omitDefaultValue = true;
-			if( const Reference *reference = IECore::runTimeCast<const Reference>( plug->node() ) )
-			{
-				// Prior to version 0.9.0.0, `.grf` files created with `Box::exportForReference()`
-				// could contain setValue() calls for promoted plugs like this one. When such
-				// files have been loaded on a Reference node, we must always serialise the plug values
-				// from the Reference node, lest they should get clobbered by the setValue() calls
-				// in the `.grf` file.
-				int milestoneVersion = 0;
-				int majorVersion = 0;
-				if( IECore::ConstIntDataPtr v = Metadata::nodeValue<IECore::IntData>( reference, "serialiser:milestoneVersion" ) )
-				{
-					milestoneVersion = v->readable();
-				}
-				if( IECore::ConstIntDataPtr v = Metadata::nodeValue<IECore::IntData>( reference, "serialiser:majorVersion" ) )
-				{
-					majorVersion = v->readable();
-				}
-				omitDefaultValue = milestoneVersion > 0 || majorVersion > 8;
-				/// \todo Consider whether or not we might like to have a plug flag
-				/// to control this behaviour, so that ValuePlugSerialiser doesn't
-				/// need explicit knowledge of Reference Nodes. On the one hand, reducing
-				/// coupling between this and the Reference node seems good, but on the other,
-				/// it'd be nice to keep the plug flags as simple as possible, and we don't have
-				/// another worthwhile use case.
-			}
+	bool omitDefaultValue = true;
+	if( const Reference *reference = IECore::runTimeCast<const Reference>( plug->node() ) )
+	{
+		// Prior to version 0.9.0.0, `.grf` files created with `Box::exportForReference()`
+		// could contain setValue() calls for promoted plugs like this one. When such
+		// files have been loaded on a Reference node, we must always serialise the plug values
+		// from the Reference node, lest they should get clobbered by the setValue() calls
+		// in the `.grf` file.
+		int milestoneVersion = 0;
+		int majorVersion = 0;
+		if( IECore::ConstIntDataPtr v = Metadata::nodeValue<IECore::IntData>( reference, "serialiser:milestoneVersion" ) )
+		{
+			milestoneVersion = v->readable();
+		}
+		if( IECore::ConstIntDataPtr v = Metadata::nodeValue<IECore::IntData>( reference, "serialiser:majorVersion" ) )
+		{
+			majorVersion = v->readable();
+		}
+		omitDefaultValue = milestoneVersion > 0 || majorVersion > 8;
+		/// \todo Consider whether or not we might like to have a plug flag
+		/// to control this behaviour, so that ValuePlugSerialiser doesn't
+		/// need explicit knowledge of Reference Nodes. On the one hand, reducing
+		/// coupling between this and the Reference node seems good, but on the other,
+		/// it'd be nice to keep the plug flags as simple as possible, and we don't have
+		/// another worthwhile use case.
+	}
 
-			if( omitDefaultValue && PyObject_HasAttrString( pythonPlug.ptr(), "defaultValue" ) )
-			{
-				object pythonDefaultValue = pythonPlug.attr( "defaultValue" )();
-				if( pythonValue == pythonDefaultValue )
-				{
-					return "";
-				}
-			}
-
-			std::string value = extract<std::string>( pythonValue.attr( "__repr__" )() );
-			return identifier + ".setValue( " + value + " )\n";
+	if( omitDefaultValue && PyObject_HasAttrString( pythonPlug.ptr(), "defaultValue" ) )
+	{
+		object pythonDefaultValue = pythonPlug.attr( "defaultValue" )();
+		if( pythonValue == pythonDefaultValue )
+		{
+			return "";
 		}
 	}
-	return "";
+
+	std::string value = extract<std::string>( pythonValue.attr( "__repr__" )() );
+	return identifier + ".setValue( " + value + " )\n";
 }
 
 bool ValuePlugSerialiser::valueNeedsSerialisation( const Gaffer::ValuePlug *plug, const Serialisation &serialisation ) const
@@ -240,6 +238,12 @@ bool ValuePlugSerialiser::valueNeedsSerialisation( const Gaffer::ValuePlug *plug
 	{
 		// There's no point in serialising the value if we're
 		// turning it into the default value anyway.
+		return false;
+	}
+
+	object pythonPlug( ValuePlugPtr( const_cast<ValuePlug *>( plug ) ) );
+	if( !PyObject_HasAttrString( pythonPlug.ptr(), "getValue" ) )
+	{
 		return false;
 	}
 

--- a/src/GafferImage/ImageProcessor.cpp
+++ b/src/GafferImage/ImageProcessor.cpp
@@ -36,6 +36,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "Gaffer/Context.h"
+#include "Gaffer/ArrayPlug.h"
 
 #include "GafferImage/ImageProcessor.h"
 
@@ -53,18 +54,53 @@ ImageProcessor::ImageProcessor( const std::string &name )
 	addChild( new ImagePlug( "in", Gaffer::Plug::In ) );
 }
 
+ImageProcessor::ImageProcessor( const std::string &name, size_t minInputs, size_t maxInputs )
+	:	ImageNode( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+	addChild(
+		new ArrayPlug( "in", Gaffer::Plug::In, new ImagePlug( "in0" ), minInputs, maxInputs )
+	);
+}
+
 ImageProcessor::~ImageProcessor()
 {
 }
 
 ImagePlug *ImageProcessor::inPlug()
 {
-	return getChild<ImagePlug>( g_firstPlugIndex );
+	GraphComponent *p = getChild<GraphComponent>( g_firstPlugIndex );
+	if( ImagePlug *i = IECore::runTimeCast<ImagePlug>( p ) )
+	{
+		return i;
+	}
+	else
+	{
+		return static_cast<ArrayPlug *>( p )->getChild<ImagePlug>( 0 );
+	}
 }
 
 const ImagePlug *ImageProcessor::inPlug() const
 {
-	return getChild<ImagePlug>( g_firstPlugIndex );
+	const GraphComponent *p = getChild<GraphComponent>( g_firstPlugIndex );
+	if( const ImagePlug *i = IECore::runTimeCast<const ImagePlug>( p ) )
+	{
+		return i;
+	}
+	else
+	{
+		return static_cast<const ArrayPlug *>( p )->getChild<ImagePlug>( 0 );
+	}
+}
+
+Gaffer::ArrayPlug *ImageProcessor::inPlugs()
+{
+	return getChild<Gaffer::ArrayPlug>( g_firstPlugIndex );
+}
+
+const Gaffer::ArrayPlug *ImageProcessor::inPlugs() const
+{
+	return getChild<Gaffer::ArrayPlug>( g_firstPlugIndex );
 }
 
 Plug *ImageProcessor::correspondingInput( const Plug *output )

--- a/src/GafferImageBindings/ImageProcessorBinding.cpp
+++ b/src/GafferImageBindings/ImageProcessorBinding.cpp
@@ -42,6 +42,8 @@
 
 #include "GafferImageBindings/ImageProcessorBinding.h"
 
+using namespace boost::python;
+using namespace Gaffer;
 using namespace GafferBindings;
 using namespace GafferImage;
 
@@ -49,6 +51,15 @@ void GafferImageBindings::bindImageProcessor()
 {
 
 	typedef ComputeNodeWrapper<ImageProcessor> Wrapper;
-	GafferBindings::DependencyNodeClass<ImageProcessor, Wrapper>();
+	GafferBindings::DependencyNodeClass<ImageProcessor, Wrapper>()
+		.def( init<const std::string &, size_t, size_t>(
+				(
+					arg( "name" ) = GraphComponent::defaultName<ImageProcessor>(),
+					arg( "minInputs" ),
+					arg( "maxInputs" ) = Imath::limits<size_t>::max()
+				)
+			)
+		)
+	;
 
 }

--- a/src/GafferModule/GafferModule.cpp
+++ b/src/GafferModule/GafferModule.cpp
@@ -144,8 +144,8 @@ BOOST_PYTHON_MODULE( _Gaffer )
 	bindNode();
 	bindDependencyNode();
 	bindComputeNode();
-	bindExecutableNode();
 	bindPlug();
+	bindExecutableNode();
 	bindValuePlug();
 	bindNumericPlug();
 	bindTypedPlug();

--- a/src/GafferRenderMan/RenderManLight.cpp
+++ b/src/GafferRenderMan/RenderManLight.cpp
@@ -67,7 +67,10 @@ void RenderManLight::loadShader( const std::string &shaderName )
 
 void RenderManLight::hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	parametersPlug()->hash( h );
+	for( ValuePlugIterator it( parametersPlug() ); it != it.end(); ++it )
+	{
+		(*it)->hash( h );
+	}
 	getChild<StringPlug>( "__shaderName" )->hash( h );
 }
 

--- a/src/GafferScene/Light.cpp
+++ b/src/GafferScene/Light.cpp
@@ -52,21 +52,21 @@ Light::Light( const std::string &name )
 	:	ObjectSource( name, "light" )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
-	addChild( new CompoundPlug( "parameters" ) );
+	addChild( new Plug( "parameters" ) );
 }
 
 Light::~Light()
 {
 }
 
-Gaffer::CompoundPlug *Light::parametersPlug()
+Gaffer::Plug *Light::parametersPlug()
 {
-	return getChild<CompoundPlug>( g_firstPlugIndex );
+	return getChild<Plug>( g_firstPlugIndex );
 }
 
-const Gaffer::CompoundPlug *Light::parametersPlug() const
+const Gaffer::Plug *Light::parametersPlug() const
 {
-	return getChild<CompoundPlug>( g_firstPlugIndex );
+	return getChild<Plug>( g_firstPlugIndex );
 }
 
 void Light::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const

--- a/src/GafferScene/Outputs.cpp
+++ b/src/GafferScene/Outputs.cpp
@@ -89,24 +89,24 @@ Outputs::Outputs( const std::string &name )
 	:	GlobalsProcessor( name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
-	addChild( new CompoundPlug( "outputs" ) );
+	addChild( new ValuePlug( "outputs" ) );
 }
 
 Outputs::~Outputs()
 {
 }
 
-Gaffer::CompoundPlug *Outputs::outputsPlug()
+Gaffer::ValuePlug *Outputs::outputsPlug()
 {
-	return getChild<CompoundPlug>( g_firstPlugIndex );
+	return getChild<ValuePlug>( g_firstPlugIndex );
 }
 
-const Gaffer::CompoundPlug *Outputs::outputsPlug() const
+const Gaffer::ValuePlug *Outputs::outputsPlug() const
 {
-	return getChild<CompoundPlug>( g_firstPlugIndex );
+	return getChild<ValuePlug>( g_firstPlugIndex );
 }
 
-Gaffer::CompoundPlug *Outputs::addOutput( const std::string &name )
+Gaffer::ValuePlug *Outputs::addOutput( const std::string &name )
 {
 	OutputMap::nth_index<0>::type &index = outputMap().get<0>();
 	OutputMap::const_iterator it = index.find( name );
@@ -117,9 +117,9 @@ Gaffer::CompoundPlug *Outputs::addOutput( const std::string &name )
 	return addOutput( it->first, it->second.get() );
 }
 
-Gaffer::CompoundPlug *Outputs::addOutput( const std::string &name, const IECore::Display *output )
+Gaffer::ValuePlug *Outputs::addOutput( const std::string &name, const IECore::Display *output )
 {
-	CompoundPlugPtr outputPlug = new CompoundPlug( "output1" );
+	ValuePlugPtr outputPlug = new ValuePlug( "output1" );
 	outputPlug->setFlags( Plug::Dynamic, true );
 
 	StringPlugPtr namePlug = new StringPlug( "name" );
@@ -173,7 +173,7 @@ void Outputs::hashProcessedGlobals( const Gaffer::Context *context, IECore::Murm
 
 IECore::ConstCompoundObjectPtr Outputs::computeProcessedGlobals( const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputGlobals ) const
 {
-	const CompoundPlug *dsp = outputsPlug();
+	const ValuePlug *dsp = outputsPlug();
 	if( !dsp->children().size() )
 	{
 		return inputGlobals;
@@ -187,9 +187,9 @@ IECore::ConstCompoundObjectPtr Outputs::computeProcessedGlobals( const Gaffer::C
 	result->members() = inputGlobals->members();
 
 	// add our outputs to the result
-	for( InputCompoundPlugIterator it( dsp ); it != it.end(); it++ )
+	for( InputValuePlugIterator it( dsp ); it != it.end(); it++ )
 	{
-		const CompoundPlug *outputPlug = it->get();
+		const ValuePlug *outputPlug = it->get();
 		if( outputPlug->getChild<BoolPlug>( "active" )->getValue() )
 		{
 			// backwards compatibility with old plug layout

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -182,7 +182,7 @@ void Shader::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs
 		const Plug *out = outPlug();
 		if( out )
 		{
-			if( out->isInstanceOf( CompoundPlug::staticTypeId() ) )
+			if( out->children().size() )
 			{
 				for( RecursivePlugIterator it( out ); it != it.end(); it++ )
 				{

--- a/src/GafferSceneBindings/OutputsBinding.cpp
+++ b/src/GafferSceneBindings/OutputsBinding.cpp
@@ -46,19 +46,10 @@
 
 using namespace std;
 using namespace boost::python;
+using namespace IECorePython;
 using namespace Gaffer;
 using namespace GafferBindings;
 using namespace GafferScene;
-
-static Gaffer::CompoundPlugPtr addOutputWrapper1( Outputs &outputs, const std::string &name )
-{
-	return outputs.addOutput( name );
-}
-
-static Gaffer::CompoundPlugPtr addOutputWrapper2( Outputs &outputs, const std::string &name, const IECore::Display *d )
-{
-	return outputs.addOutput( name, d );
-}
 
 static tuple registeredOutputsWrapper()
 {
@@ -75,8 +66,8 @@ static tuple registeredOutputsWrapper()
 void GafferSceneBindings::bindOutputs()
 {
 	DependencyNodeClass<Outputs>()
-		.def( "addOutput", &addOutputWrapper1 )
-		.def( "addOutput", &addOutputWrapper2 )
+		.def( "addOutput", (ValuePlug *(Outputs::*)( const std::string & ))&Outputs::addOutput, return_value_policy<CastToIntrusivePtr>() )
+		.def( "addOutput", (ValuePlug *(Outputs::*)( const std::string &, const IECore::Display * ))&Outputs::addOutput, return_value_policy<CastToIntrusivePtr>() )
 		.def( "registerOutput", &Outputs::registerOutput ).staticmethod( "registerOutput" )
 		.def( "registeredOutputs", &registeredOutputsWrapper ).staticmethod( "registeredOutputs" )
 	;

--- a/src/GafferSceneTest/TestLight.cpp
+++ b/src/GafferSceneTest/TestLight.cpp
@@ -55,7 +55,10 @@ TestLight::~TestLight()
 
 void TestLight::hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	parametersPlug()->hash( h );
+	for( ValuePlugIterator it( parametersPlug() ); it != it.end(); ++it )
+	{
+		(*it)->hash( h );
+	}
 }
 
 IECore::LightPtr TestLight::computeLight( const Gaffer::Context *context ) const

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -973,8 +973,8 @@ SceneView::SceneView( const std::string &name )
 	// add a node for hiding things
 
 	StandardAttributesPtr hide = new StandardAttributes( "hide" );
-	hide->attributesPlug()->getChild<CompoundPlug>( "visibility" )->getChild<BoolPlug>( "enabled" )->setValue( true );
-	hide->attributesPlug()->getChild<CompoundPlug>( "visibility" )->getChild<BoolPlug>( "value" )->setValue( false );
+	hide->attributesPlug()->getChild<ValuePlug>( "visibility" )->getChild<BoolPlug>( "enabled" )->setValue( true );
+	hide->attributesPlug()->getChild<ValuePlug>( "visibility" )->getChild<BoolPlug>( "value" )->setValue( false );
 
 	preprocessor->addChild( hide );
 	hide->inPlug()->setInput( preprocessorInput );

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -199,7 +199,7 @@ class SceneView::Grid
 		{
 			m_node->transformPlug()->rotatePlug()->setValue( V3f( 90, 0, 0 ) );
 
-			CompoundPlugPtr plug = new CompoundPlug( "grid" );
+			ValuePlugPtr plug = new ValuePlug( "grid" );
 			view->addChild( plug );
 
 			plug->addChild( new BoolPlug( "visible", Plug::In, true ) );
@@ -223,14 +223,14 @@ class SceneView::Grid
 			update();
 		}
 
-		Gaffer::CompoundPlug *plug()
+		Gaffer::ValuePlug *plug()
 		{
-			return m_view->getChild<Gaffer::CompoundPlug>( "grid" );
+			return m_view->getChild<Gaffer::ValuePlug>( "grid" );
 		}
 
-		const Gaffer::CompoundPlug *plug() const
+		const Gaffer::ValuePlug *plug() const
 		{
-			return m_view->getChild<Gaffer::CompoundPlug>( "grid" );
+			return m_view->getChild<Gaffer::ValuePlug>( "grid" );
 		}
 
 		Gadget *gadget()
@@ -406,7 +406,7 @@ class SceneView::Gnomon
 		Gnomon( SceneView *view )
 			:	m_view( view ), m_gadget( new GnomonGadget() )
 		{
-			CompoundPlugPtr plug = new CompoundPlug( "gnomon" );
+			ValuePlugPtr plug = new ValuePlug( "gnomon" );
 			view->addChild( plug );
 
 			plug->addChild( new BoolPlug( "visible", Plug::In, true ) );
@@ -433,14 +433,14 @@ class SceneView::Gnomon
 			update();
 		}
 
-		Gaffer::CompoundPlug *plug()
+		Gaffer::ValuePlug *plug()
 		{
-			return m_view->getChild<Gaffer::CompoundPlug>( "gnomon" );
+			return m_view->getChild<Gaffer::ValuePlug>( "gnomon" );
 		}
 
-		const Gaffer::CompoundPlug *plug() const
+		const Gaffer::ValuePlug *plug() const
 		{
-			return m_view->getChild<Gaffer::CompoundPlug>( "gnomon" );
+			return m_view->getChild<Gaffer::ValuePlug>( "gnomon" );
 		}
 
 		Gadget *gadget()
@@ -650,7 +650,7 @@ class SceneView::LookThrough
 
 			// Set up our plugs
 
-			CompoundPlugPtr lookThrough = new CompoundPlug( "lookThrough", Plug::In, Plug::Default & ~Plug::AcceptsInputs );
+			ValuePlugPtr lookThrough = new ValuePlug( "lookThrough", Plug::In, Plug::Default & ~Plug::AcceptsInputs );
 			lookThrough->addChild( new BoolPlug( "enabled", Plug::In, false, Plug::Default & ~Plug::AcceptsInputs ) );
 			lookThrough->addChild( new StringPlug( "camera", Plug::In, "", Plug::Default & ~Plug::AcceptsInputs ) );
 			view->addChild( lookThrough );
@@ -689,14 +689,14 @@ class SceneView::LookThrough
 
 		}
 
-		Gaffer::CompoundPlug *plug()
+		Gaffer::ValuePlug *plug()
 		{
-			return m_view->getChild<Gaffer::CompoundPlug>( "lookThrough" );
+			return m_view->getChild<Gaffer::ValuePlug>( "lookThrough" );
 		}
 
-		const Gaffer::CompoundPlug *plug() const
+		const Gaffer::ValuePlug *plug() const
 		{
-			return m_view->getChild<Gaffer::CompoundPlug>( "lookThrough" );
+			return m_view->getChild<Gaffer::ValuePlug>( "lookThrough" );
 		}
 
 		const Imath::Box2f &resolutionGate() const
@@ -1016,32 +1016,32 @@ const Gaffer::IntPlug *SceneView::minimumExpansionDepthPlug() const
 	return getChild<IntPlug>( g_firstPlugIndex );
 }
 
-Gaffer::CompoundPlug *SceneView::lookThroughPlug()
+Gaffer::ValuePlug *SceneView::lookThroughPlug()
 {
 	return m_lookThrough->plug();
 }
 
-const Gaffer::CompoundPlug *SceneView::lookThroughPlug() const
+const Gaffer::ValuePlug *SceneView::lookThroughPlug() const
 {
 	return m_lookThrough->plug();
 }
 
-Gaffer::CompoundPlug *SceneView::gridPlug()
+Gaffer::ValuePlug *SceneView::gridPlug()
 {
 	return m_grid->plug();
 }
 
-const Gaffer::CompoundPlug *SceneView::gridPlug() const
+const Gaffer::ValuePlug *SceneView::gridPlug() const
 {
 	return m_grid->plug();
 }
 
-Gaffer::CompoundPlug *SceneView::gnomonPlug()
+Gaffer::ValuePlug *SceneView::gnomonPlug()
 {
 	return m_gnomon->plug();
 }
 
-const Gaffer::CompoundPlug *SceneView::gnomonPlug() const
+const Gaffer::ValuePlug *SceneView::gnomonPlug() const
 {
 	return m_gnomon->plug();
 }

--- a/src/GafferUI/CompoundNodule.cpp
+++ b/src/GafferUI/CompoundNodule.cpp
@@ -40,7 +40,6 @@
 
 #include "IECore/SimpleTypedData.h"
 
-#include "Gaffer/CompoundPlug.h"
 #include "Gaffer/PlugIterator.h"
 #include "Gaffer/Metadata.h"
 

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -46,7 +46,6 @@
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/NumericPlug.h"
 #include "Gaffer/TypedPlug.h"
-#include "Gaffer/CompoundPlug.h"
 #include "Gaffer/StandardSet.h"
 #include "Gaffer/CompoundNumericPlug.h"
 #include "Gaffer/RecursiveChildIterator.h"
@@ -1488,10 +1487,7 @@ void GraphGadget::addConnectionGadgets( Gaffer::GraphComponent *plugParent )
 			}
 		}
 
-		if( (*pIt)->isInstanceOf( Gaffer::CompoundPlug::staticTypeId() ) )
-		{
-			addConnectionGadgets( pIt->get() );
-		}
+		addConnectionGadgets( pIt->get() );
 	}
 
 }
@@ -1570,10 +1566,7 @@ void GraphGadget::removeConnectionGadgets( const Gaffer::GraphComponent *plugPar
 			}
 		}
 
-		if( (*pIt)->isInstanceOf( Gaffer::CompoundPlug::staticTypeId() ) )
-		{
-			removeConnectionGadgets( pIt->get() );
-		}
+		removeConnectionGadgets( pIt->get() );
 	}
 
 }

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -43,7 +43,6 @@
 #include "IECoreGL/Selector.h"
 
 #include "Gaffer/TypedObjectPlug.h"
-#include "Gaffer/CompoundPlug.h"
 #include "Gaffer/StandardSet.h"
 #include "Gaffer/DependencyNode.h"
 #include "Gaffer/Metadata.h"

--- a/src/GafferUI/View3D.cpp
+++ b/src/GafferUI/View3D.cpp
@@ -44,7 +44,6 @@
 
 #include "IECoreGL/Primitive.h"
 
-#include "Gaffer/CompoundPlug.h"
 #include "Gaffer/NumericPlug.h"
 #include "Gaffer/TypedPlug.h"
 
@@ -69,25 +68,25 @@ View3D::View3D( const std::string &name, Gaffer::PlugPtr inPlug )
 
 	// plugs
 
-	CompoundPlugPtr baseState = new CompoundPlug( "baseState" );
+	ValuePlugPtr baseState = new ValuePlug( "baseState" );
 	addChild( baseState );
 
-	CompoundPlugPtr solid = new CompoundPlug( "solid" );
+	ValuePlugPtr solid = new ValuePlug( "solid" );
 	baseState->addChild( solid );
 	solid->addChild( new BoolPlug( "enabled", Plug::In, true ) );
 	solid->addChild( new BoolPlug( "override" ) );
 
-	CompoundPlugPtr wireframe = new CompoundPlug( "wireframe" );
+	ValuePlugPtr wireframe = new ValuePlug( "wireframe" );
 	baseState->addChild( wireframe );
 	wireframe->addChild( new BoolPlug( "enabled" ) );
 	wireframe->addChild( new BoolPlug( "override" ) );
 
-	CompoundPlugPtr points = new CompoundPlug( "points" );
+	ValuePlugPtr points = new ValuePlug( "points" );
 	baseState->addChild( points );
 	points->addChild( new BoolPlug( "enabled" ) );
 	points->addChild( new BoolPlug( "override" ) );
 
-	CompoundPlugPtr bound = new CompoundPlug( "bound" );
+	ValuePlugPtr bound = new ValuePlug( "bound" );
 	baseState->addChild( bound );
 	bound->addChild( new BoolPlug( "enabled" ) );
 	bound->addChild( new BoolPlug( "override" ) );
@@ -136,27 +135,27 @@ void View3D::plugSet( const Gaffer::Plug *plug )
 
 void View3D::updateBaseState()
 {
-	const CompoundPlug *baseState = getChild<CompoundPlug>( "baseState" );
+	const ValuePlug *baseState = getChild<ValuePlug>( "baseState" );
 
-	const CompoundPlug *solid = baseState->getChild<CompoundPlug>( "solid" );
+	const ValuePlug *solid = baseState->getChild<ValuePlug>( "solid" );
 	m_baseState->add(
 		new Primitive::DrawSolid( solid->getChild<BoolPlug>( "enabled" )->getValue() ),
 		solid->getChild<BoolPlug>( "override" )->getValue()
 	);
 
-	const CompoundPlug *wireframe = baseState->getChild<CompoundPlug>( "wireframe" );
+	const ValuePlug *wireframe = baseState->getChild<ValuePlug>( "wireframe" );
 	m_baseState->add(
 		new Primitive::DrawWireframe( wireframe->getChild<BoolPlug>( "enabled" )->getValue() ),
 		wireframe->getChild<BoolPlug>( "override" )->getValue()
 	);
 
-	const CompoundPlug *points = baseState->getChild<CompoundPlug>( "points" );
+	const ValuePlug *points = baseState->getChild<ValuePlug>( "points" );
 	m_baseState->add(
 		new Primitive::DrawPoints( points->getChild<BoolPlug>( "enabled" )->getValue() ),
 		points->getChild<BoolPlug>( "override" )->getValue()
 	);
 
-	const CompoundPlug *bound = baseState->getChild<CompoundPlug>( "bound" );
+	const ValuePlug *bound = baseState->getChild<ValuePlug>( "bound" );
 	m_baseState->add(
 		new Primitive::DrawBound( bound->getChild<BoolPlug>( "enabled" )->getValue() ),
 		bound->getChild<BoolPlug>( "override" )->getValue()

--- a/src/GafferUIBindings/CompoundNoduleBinding.cpp
+++ b/src/GafferUIBindings/CompoundNoduleBinding.cpp
@@ -37,7 +37,7 @@
 
 #include "boost/python.hpp"
 
-#include "Gaffer/CompoundPlug.h"
+#include "Gaffer/Plug.h"
 
 #include "GafferUI/CompoundNodule.h"
 
@@ -51,6 +51,6 @@ using namespace GafferUI;
 void GafferUIBindings::bindCompoundNodule()
 {
 	GadgetClass<CompoundNodule>()
-		.def( init<Gaffer::CompoundPlugPtr, LinearContainer::Orientation, float, LinearContainer::Direction>( ( arg( "plug" ), arg( "orientation" )=LinearContainer::X, arg( "spacing" ) = 0.0f, arg( "direction" )=LinearContainer::InvalidDirection ) ) )
+		.def( init<Gaffer::PlugPtr, LinearContainer::Orientation, float, LinearContainer::Direction>( ( arg( "plug" ), arg( "orientation" )=LinearContainer::X, arg( "spacing" ) = 0.0f, arg( "direction" )=LinearContainer::InvalidDirection ) ) )
 	;
 }

--- a/startup/Gaffer/inputGeneratorCompatibility.py
+++ b/startup/Gaffer/inputGeneratorCompatibility.py
@@ -1,0 +1,96 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import re
+
+import Gaffer
+
+# Backwards compatibility for nodes which have migrated from using
+# an InputGenerator into using an ArrayPlug instead. This is requested
+# on a per-node basis by setting an "enableInputGeneratorCompatibility"
+# attribute to True. See startup/GafferImage/inputGeneratorCompatibility.py for
+# an example.
+
+def __nodeGetItem( self, key ) :
+
+	if getattr( self, "enableInputGeneratorCompatibility", False ) :
+		if key == "in" :
+			# We now have an ArrayPlug where we used to have an ImagePlug.
+			# Enable the required compatibility methods.
+			result = Gaffer.Node.__originalGetItem( self, key )
+			result.enableInputGeneratorCompatibility = True
+			return result
+
+		m = re.match( "^in([0-9]+)$", key )
+		if m :
+			# These were originally plugs parented directly to the node,
+			# and are now children of the array plug.
+			return Gaffer.Node.__originalGetItem( self, "in" )[int( m.group( 1 ) )]
+		
+	return Gaffer.Node.__originalGetItem( self, key )
+
+def __arrayPlugSetInput( self, input ) :
+
+	if getattr( self, "enableInputGeneratorCompatibility", False ) :
+		if len( self ) and isinstance( input, self[0].__class__ ) :
+			self[0].setInput( input )
+			return
+
+	Gaffer.ArrayPlug.__originalSetInput( self, input )
+
+def __arrayPlugGetItem( self, key ) :
+
+	if getattr( self, "enableInputGeneratorCompatibility", False ) :
+		try :
+			return Gaffer.ArrayPlug.__originalGetItem( self, key )
+		except KeyError :
+			try :
+				return Gaffer.ArrayPlug.__originalGetItem( self, 0 )[key]
+			except :
+				raise e
+
+	return Gaffer.ArrayPlug.__originalGetItem( self, key )
+
+if not hasattr( Gaffer.Node, "__originalGetItem" ) :
+
+	Gaffer.Node.__originalGetItem = Gaffer.Node.__getitem__
+	Gaffer.Node.__getitem__ = __nodeGetItem
+
+	Gaffer.ArrayPlug.__originalSetInput = Gaffer.ArrayPlug.setInput
+	Gaffer.ArrayPlug.setInput = __arrayPlugSetInput
+
+	Gaffer.ArrayPlug.__originalGetItem = Gaffer.ArrayPlug.__getitem__
+	Gaffer.ArrayPlug.__getitem__ = __arrayPlugGetItem

--- a/startup/GafferImage/inputGeneratorCompatibility.py
+++ b/startup/GafferImage/inputGeneratorCompatibility.py
@@ -1,0 +1,44 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import GafferImage
+
+# Backwards compatibility for old nodes which originally
+# used InputGenerators and now use ArrayPlugs instead.
+# See startup/Gaffer/inputGeneratorCompatibility.py for
+# details of how this works.
+
+GafferImage.Merge.enableInputGeneratorCompatibility = True


### PR DESCRIPTION
The way we've been dealing with ImageProcessors with multiple inputs (Merge and ImageSwitch) up till now has been frankly a bit weird. The node inherits an input ImagePlug called "in" from it's ImageProcessor base class, and then uses an InputGenerator internally to add on extra "in1", "in2" etc plugs on demand. This makes for an awkward API, where there's no decent way of accessing inputs by index, or asking for the next input, or even of saying "is this considered an input?". The implementation of InputGenerator is also awkward to say the least.

This pull request fixes all that while maintaining a good degree of backwards compatibility :

- A new `ImageProcessor( name, minInputs, maxInputs )` constructor allows a derived class to say they want an ArrayPlug of inputs rather than just a single ImagePlug.
- Array inputs are accessed with `node->inPlugs()->getChild<ImagePlug>( index )` in C++, and `node["in"][index]` in Python.
- Nodes which still want only one input remain exactly as before with no code changes, continuing to access the input with `node->inPlug()` in C++ and `node["in"]` in Python.
- A compatibility config file provides the necessary mappings for old files to be loaded in the new version.

I'm pretty pleased with the way this has turned out - the new API feels right, and it's actually required pretty minimal changes to put together. I'm putting this up for review after implementing it only for the Merge node, and marked it as revisionRequired, in case anyone feels differently. Assuming all is well, I'll then implement this for the Group and Switch nodes, consign InputGenerators to history, and update the pull request ready for a merge.

Note that this builds on top of the ArrayPlug improvements from the existing pull request #1424 - only the last 6 commits are unique to this branch.