### PR TITLE
Travis : Workaround GitHub API query limit.

### DIFF
--- a/config/travis/installDependencies.py
+++ b/config/travis/installDependencies.py
@@ -1,7 +1,6 @@
 import os
 import re
 import sys
-import json
 import urllib
 
 # figure out where we'll be making the build
@@ -16,12 +15,10 @@ buildDir = "build/gaffer-%d.%d.%d.%d-%s" % ( gafferMilestoneVersion, gafferMajor
 
 # get the prebuilt dependencies package and unpack it into the build directory
 
-releases = json.load( urllib.urlopen( "https://api.github.com/repos/johnhaddon/gafferDependencies/releases" ) )
-release = next( r for r in releases if len( r["assets"] ) )
- 
-asset = next( a for a in release["assets"] if platform in a["name"] )
-sys.stderr.write( "Downloading dependencies \"%s\"" % asset["browser_download_url"] )
-tarFileName, headers = urllib.urlretrieve( asset["browser_download_url"] )
+downloadURL = "https://github.com/johnhaddon/gafferDependencies/releases/download/0.15.0.0/gafferDependencies-0.15.0.0-linux.tar.gz"
+
+sys.stderr.write( "Downloading dependencies \"%s\"" % downloadURL )
+tarFileName, headers = urllib.urlretrieve( downloadURL )
 
 os.makedirs( buildDir )
 os.system( "tar xf %s -C %s --strip-components=1" % ( tarFileName, buildDir ) )


### PR DESCRIPTION
We've been getting our Travis setup failing to launch fairly frequently recently, and it turns out it was the API queries we were making to figure out the latest gafferDependencies release. Unless you authenticate with some credentials, there's a limit of 60 queries per IP address per hour, and it seemed that often that limit is reached by whatever occurred on the Travis VM before our tests launched. One option would be to provide some credentials, but there's not really a good way of keeping those private, so we instead hardcode the path to the dependencies package directly.