### PR TITLE
Add PremultiplyTest and UnpremultiplyTest imports to GafferImageTest/__init__.py

### DIFF
--- a/python/GafferImageTest/__init__.py
+++ b/python/GafferImageTest/__init__.py
@@ -67,6 +67,8 @@ from CopyImageMetadataTest import CopyImageMetadataTest
 from ImageLoopTest import ImageLoopTest
 from ImageProcessorTest import ImageProcessorTest
 from ShuffleTest import ShuffleTest
+from PremultiplyTest import PremultiplyTest
+from UnpremultiplyTest import UnpremultiplyTest
 
 if __name__ == "__main__":
 	import unittest


### PR DESCRIPTION
I just realised that I never added the tests for Premultiply/Unpremultiply to GafferImageTest/__init__.py, so the tests would never be run unless directly specified.

Here they are