### PR TITLE
Crop node

### DIFF
--- a/include/GafferImage/Crop.h
+++ b/include/GafferImage/Crop.h
@@ -38,16 +38,12 @@
 #ifndef GAFFERIMAGE_CROP_H
 #define GAFFERIMAGE_CROP_H
 
-#include "GafferImage/ImageProcessor.h"
 #include "Gaffer/BoxPlug.h"
+#include "GafferImage/ImageProcessor.h"
 
 namespace GafferImage
 {
 
-
-/// Reformats the input image to a new resolution using a resampling filter.
-/// \todo: Add support for changing the pixelAspect of the image.
-/// \todo Reimplement in terms of a network of simpler atomic operations.
 class Crop : public ImageProcessor
 {
 	public :
@@ -57,7 +53,7 @@ class Crop : public ImageProcessor
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::Crop, CropTypeId, ImageProcessor );
 
-		enum AreaType
+		enum AreaSource
 		{
 			Custom = 0,
 			DataWindow = 1,
@@ -73,8 +69,6 @@ class Crop : public ImageProcessor
 		const Gaffer::BoolPlug *affectDataWindowPlug() const;
 		Gaffer::BoolPlug *affectDisplayWindowPlug();
 		const Gaffer::BoolPlug *affectDisplayWindowPlug() const;
-		Gaffer::AtomicBox2iPlug *cropWindowPlug();
-		const Gaffer::AtomicBox2iPlug *cropWindowPlug() const;
 
 		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
 
@@ -90,6 +84,9 @@ class Crop : public ImageProcessor
 		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
 
 	private :
+
+		Gaffer::AtomicBox2iPlug *cropWindowPlug();
+		const Gaffer::AtomicBox2iPlug *cropWindowPlug() const;
 
 		static size_t g_firstPlugIndex;
 };

--- a/include/GafferImage/Crop.h
+++ b/include/GafferImage/Crop.h
@@ -1,0 +1,101 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2013-2015, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2015, Nvizible Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERIMAGE_CROP_H
+#define GAFFERIMAGE_CROP_H
+
+#include "GafferImage/ImageProcessor.h"
+#include "Gaffer/BoxPlug.h"
+
+namespace GafferImage
+{
+
+
+/// Reformats the input image to a new resolution using a resampling filter.
+/// \todo: Add support for changing the pixelAspect of the image.
+/// \todo Reimplement in terms of a network of simpler atomic operations.
+class Crop : public ImageProcessor
+{
+	public :
+
+		Crop( const std::string &name=defaultName<Crop>() );
+		virtual ~Crop();
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::Crop, CropTypeId, ImageProcessor );
+
+		enum AreaType
+		{
+			Custom = 0,
+			DataWindow = 1,
+			DisplayWindow = 2
+		};
+
+		/// Plug accessors.
+		Gaffer::IntPlug *areaSourcePlug();
+		const Gaffer::IntPlug *areaSourcePlug() const;
+		Gaffer::Box2iPlug *areaPlug();
+		const Gaffer::Box2iPlug *areaPlug() const;
+		Gaffer::BoolPlug *affectDataWindowPlug();
+		const Gaffer::BoolPlug *affectDataWindowPlug() const;
+		Gaffer::BoolPlug *affectDisplayWindowPlug();
+		const Gaffer::BoolPlug *affectDisplayWindowPlug() const;
+		Gaffer::AtomicBox2iPlug *cropWindowPlug();
+		const Gaffer::AtomicBox2iPlug *cropWindowPlug() const;
+
+		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+
+	protected :
+
+		virtual void hashFormat( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		virtual void hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+
+		virtual GafferImage::Format computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const;
+		virtual Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const;
+
+		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+
+	private :
+
+		static size_t g_firstPlugIndex;
+};
+
+IE_CORE_DECLAREPTR( Crop )
+
+} // namespace GafferImage
+
+#endif // GAFFERIMAGE_CROP_H

--- a/include/GafferImage/TypeIds.h
+++ b/include/GafferImage/TypeIds.h
@@ -93,6 +93,7 @@ enum TypeId
 	CopyImageMetadataTypeId = 110797,
 	ImageLoopTypeId = 110798,
 	PremultiplyTypeId = 110799,
+	CropTypeId = 110800,
 
 	LastTypeId = 110849
 };

--- a/include/GafferImageBindings/CropBinding.h
+++ b/include/GafferImageBindings/CropBinding.h
@@ -1,6 +1,7 @@
 //////////////////////////////////////////////////////////////////////////
 //
 //  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2015, Nvizible Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are

--- a/include/GafferImageBindings/CropBinding.h
+++ b/include/GafferImageBindings/CropBinding.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERIMAGEBINDINGS_CROPBINDING_H
+#define GAFFERIMAGEBINDINGS_CROPBINDING_H
+
+namespace GafferImageBindings
+{
+
+void bindCrop();
+
+}; // namespace GafferImageBindings
+
+#endif // GAFFERIMAGEBINDINGS_CROPBINDING_H

--- a/python/GafferImageTest/CropTest.py
+++ b/python/GafferImageTest/CropTest.py
@@ -1,6 +1,7 @@
 ##########################################################################
 #
 #  Copyright (c) 2013-2015, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2015, Nvizible Ltd. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -35,25 +36,12 @@
 ##########################################################################
 
 import unittest
+import os
 
 import IECore
 import Gaffer
-import GafferImage
 import GafferTest
-import os
-
-"""
-Tests:
-
-Channel data passes through
-
-Data Window doesn't affect Display Window
-Display Window doesn't affect Data Window
-Data window intersects
-source = Data Window
-source = Display Window
-source = Custom
-"""
+import GafferImage
 
 class CropTest( unittest.TestCase ) :
 
@@ -64,10 +52,10 @@ class CropTest( unittest.TestCase ) :
 
 		crop = GafferImage.Crop()
 
-		self.assertEqual( crop["areaSource"].getValue(), GafferImage.Crop.AreaType.DisplayWindow )
+		self.assertEqual( crop["areaSource"].getValue(), GafferImage.Crop.AreaSource.Custom )
 		self.assertTrue( crop["area"].getValue().isEmpty() )
 		self.assertEqual( crop["affectDataWindow"].getValue(), True )
-		self.assertEqual( crop["affectDisplayWindow"].getValue(), False )
+		self.assertEqual( crop["affectDisplayWindow"].getValue(), True )
 
 	def testPassThrough( self ) :
 
@@ -76,7 +64,7 @@ class CropTest( unittest.TestCase ) :
 
 		crop = GafferImage.Crop()
 		crop["in"].setInput(i["out"])
-		crop["areaSource"].setValue( GafferImage.Crop.AreaType.Custom )
+		crop["areaSource"].setValue( GafferImage.Crop.AreaSource.Custom )
 		crop["area"].setValue( IECore.Box2i( IECore.V2i( 40 ), IECore.V2i( 50 ) ) )
 		crop["affectDataWindow"].setValue( True )
 		crop["affectDisplayWindow"].setValue( True )
@@ -111,7 +99,7 @@ class CropTest( unittest.TestCase ) :
 
 		crop = GafferImage.Crop()
 		crop["in"].setInput(i["out"])
-		crop["areaSource"].setValue( GafferImage.Crop.AreaType.Custom )
+		crop["areaSource"].setValue( GafferImage.Crop.AreaSource.Custom )
 		crop["area"].setValue( IECore.Box2i( IECore.V2i( 40 ), IECore.V2i( 50 ) ) )
 		crop["affectDataWindow"].setValue( True )
 		crop["affectDisplayWindow"].setValue( False )
@@ -126,7 +114,7 @@ class CropTest( unittest.TestCase ) :
 
 		crop = GafferImage.Crop()
 		crop["in"].setInput(i["out"])
-		crop["areaSource"].setValue( GafferImage.Crop.AreaType.Custom )
+		crop["areaSource"].setValue( GafferImage.Crop.AreaSource.Custom )
 		crop["area"].setValue( IECore.Box2i( IECore.V2i( 40 ), IECore.V2i( 50 ) ) )
 		crop["affectDataWindow"].setValue( False )
 		crop["affectDisplayWindow"].setValue( True )
@@ -141,7 +129,7 @@ class CropTest( unittest.TestCase ) :
 
 		crop = GafferImage.Crop()
 		crop["in"].setInput(i["out"])
-		crop["areaSource"].setValue( GafferImage.Crop.AreaType.Custom )
+		crop["areaSource"].setValue( GafferImage.Crop.AreaSource.Custom )
 		crop["area"].setValue( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 50 ) ) )
 		crop["affectDataWindow"].setValue( True )
 		crop["affectDisplayWindow"].setValue( False )
@@ -155,7 +143,7 @@ class CropTest( unittest.TestCase ) :
 
 		crop = GafferImage.Crop()
 		crop["in"].setInput(i["out"])
-		crop["areaSource"].setValue( GafferImage.Crop.AreaType.DataWindow )
+		crop["areaSource"].setValue( GafferImage.Crop.AreaSource.DataWindow )
 		crop["affectDataWindow"].setValue( False )
 		crop["affectDisplayWindow"].setValue( True )
 
@@ -168,7 +156,7 @@ class CropTest( unittest.TestCase ) :
 
 		crop = GafferImage.Crop()
 		crop["in"].setInput(i["out"])
-		crop["areaSource"].setValue( GafferImage.Crop.AreaType.DisplayWindow )
+		crop["areaSource"].setValue( GafferImage.Crop.AreaSource.DisplayWindow )
 		crop["affectDataWindow"].setValue( True )
 		crop["affectDisplayWindow"].setValue( False )
 

--- a/python/GafferImageTest/CropTest.py
+++ b/python/GafferImageTest/CropTest.py
@@ -1,0 +1,179 @@
+##########################################################################
+#
+#  Copyright (c) 2013-2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+import Gaffer
+import GafferImage
+import GafferTest
+import os
+
+"""
+Tests:
+
+Channel data passes through
+
+Data Window doesn't affect Display Window
+Display Window doesn't affect Data Window
+Data window intersects
+source = Data Window
+source = Display Window
+source = Custom
+"""
+
+class CropTest( unittest.TestCase ) :
+
+	imageFileUndersizeDataWindow = os.path.expandvars( "$GAFFER_ROOT/python/GafferTest/images/blueWithDataWindow.100x100.exr" )
+	imageFileOversizeDataWindow = os.path.expandvars( "$GAFFER_ROOT/python/GafferTest/images/checkerWithNegWindows.200x150.exr" )
+
+	def testDefaultState( self ) :
+
+		crop = GafferImage.Crop()
+
+		self.assertEqual( crop["areaSource"].getValue(), GafferImage.Crop.AreaType.DisplayWindow )
+		self.assertTrue( crop["area"].getValue().isEmpty() )
+		self.assertEqual( crop["affectDataWindow"].getValue(), True )
+		self.assertEqual( crop["affectDisplayWindow"].getValue(), False )
+
+	def testPassThrough( self ) :
+
+		i = GafferImage.ImageReader()
+		i["fileName"].setValue( self.imageFileUndersizeDataWindow )
+
+		crop = GafferImage.Crop()
+		crop["in"].setInput(i["out"])
+		crop["areaSource"].setValue( GafferImage.Crop.AreaType.Custom )
+		crop["area"].setValue( IECore.Box2i( IECore.V2i( 40 ), IECore.V2i( 50 ) ) )
+		crop["affectDataWindow"].setValue( True )
+		crop["affectDisplayWindow"].setValue( True )
+
+		self.assertEqual(i['out'].channelDataHash( "R", IECore.V2i( 0 ) ), crop['out'].channelDataHash( "R", IECore.V2i( 0 ) ) )
+		self.assertEqual(i['out'].channelDataHash( "G", IECore.V2i( 0 ) ), crop['out'].channelDataHash( "G", IECore.V2i( 0 ) ) )
+		self.assertEqual(i['out'].channelDataHash( "B", IECore.V2i( 0 ) ), crop['out'].channelDataHash( "B", IECore.V2i( 0 ) ) )
+
+		self.assertEqual( i["out"]["metadata"].hash(), crop["out"]["metadata"].hash() )
+		self.assertEqual( i["out"]["channelNames"].hash(), crop["out"]["channelNames"].hash() )
+		self.assertNotEqual( i["out"]["format"].hash(), crop["out"]["format"].hash() )
+		self.assertNotEqual( i["out"]["dataWindow"].hash(), crop["out"]["dataWindow"].hash() )
+
+		self.assertEqual( i["out"]["metadata"].getValue(), crop["out"]["metadata"].getValue() )
+		self.assertEqual( i["out"]["channelNames"].getValue(), crop["out"]["channelNames"].getValue() )
+		self.assertNotEqual( i["out"]["format"].getValue(), crop["out"]["format"].getValue() )
+		self.assertNotEqual( i["out"]["dataWindow"].getValue(), crop["out"]["dataWindow"].getValue() )
+
+	def testEnableBehaviour( self ) :
+
+		crop = GafferImage.Crop()
+
+		self.assertTrue( crop.enabledPlug().isSame( crop["enabled"] ) )
+		self.assertTrue( crop.correspondingInput( crop["out"] ).isSame( crop["in"] ) )
+		self.assertEqual( crop.correspondingInput( crop["in"] ), None )
+		self.assertEqual( crop.correspondingInput( crop["enabled"] ), None )
+
+	def testAffectDataWindow( self ) :
+
+		i = GafferImage.ImageReader()
+		i["fileName"].setValue( self.imageFileUndersizeDataWindow )
+
+		crop = GafferImage.Crop()
+		crop["in"].setInput(i["out"])
+		crop["areaSource"].setValue( GafferImage.Crop.AreaType.Custom )
+		crop["area"].setValue( IECore.Box2i( IECore.V2i( 40 ), IECore.V2i( 50 ) ) )
+		crop["affectDataWindow"].setValue( True )
+		crop["affectDisplayWindow"].setValue( False )
+
+		self.assertEqual( crop["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( 40 ), IECore.V2i( 49 ) ) )
+		self.assertEqual( i["out"]["format"].getValue(), crop["out"]["format"].getValue() )
+
+	def testAffectDisplayWindow( self ) :
+
+		i = GafferImage.ImageReader()
+		i["fileName"].setValue( self.imageFileUndersizeDataWindow )
+
+		crop = GafferImage.Crop()
+		crop["in"].setInput(i["out"])
+		crop["areaSource"].setValue( GafferImage.Crop.AreaType.Custom )
+		crop["area"].setValue( IECore.Box2i( IECore.V2i( 40 ), IECore.V2i( 50 ) ) )
+		crop["affectDataWindow"].setValue( False )
+		crop["affectDisplayWindow"].setValue( True )
+
+		self.assertEqual( crop["out"]["format"].getValue().getDisplayWindow(), IECore.Box2i( IECore.V2i( 40 ), IECore.V2i( 49 ) ) )
+		self.assertEqual( i["out"]["dataWindow"].getValue(), crop["out"]["dataWindow"].getValue() )
+
+	def testIntersectDataWindow( self ) :
+
+		i = GafferImage.ImageReader()
+		i["fileName"].setValue( self.imageFileUndersizeDataWindow )
+
+		crop = GafferImage.Crop()
+		crop["in"].setInput(i["out"])
+		crop["areaSource"].setValue( GafferImage.Crop.AreaType.Custom )
+		crop["area"].setValue( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 50 ) ) )
+		crop["affectDataWindow"].setValue( True )
+		crop["affectDisplayWindow"].setValue( False )
+
+		self.assertEqual( crop["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( 30 ), IECore.V2i( 49 ) ) )
+
+	def testDataWindowToDisplayWindow( self ) :
+
+		i = GafferImage.ImageReader()
+		i["fileName"].setValue( self.imageFileUndersizeDataWindow )
+
+		crop = GafferImage.Crop()
+		crop["in"].setInput(i["out"])
+		crop["areaSource"].setValue( GafferImage.Crop.AreaType.DataWindow )
+		crop["affectDataWindow"].setValue( False )
+		crop["affectDisplayWindow"].setValue( True )
+
+		self.assertEqual( i["out"]["dataWindow"].getValue(), crop["out"]["format"].getValue().getDisplayWindow() )
+	
+	def testDisplayWindowToDataWindow( self ) :
+
+		i = GafferImage.ImageReader()
+		i["fileName"].setValue( self.imageFileOversizeDataWindow )
+
+		crop = GafferImage.Crop()
+		crop["in"].setInput(i["out"])
+		crop["areaSource"].setValue( GafferImage.Crop.AreaType.DisplayWindow )
+		crop["affectDataWindow"].setValue( True )
+		crop["affectDisplayWindow"].setValue( False )
+
+		self.assertEqual( i["out"]["format"].getValue().getDisplayWindow(), crop["out"]["dataWindow"].getValue() )
+
+	
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferImageTest/__init__.py
+++ b/python/GafferImageTest/__init__.py
@@ -69,6 +69,7 @@ from ImageProcessorTest import ImageProcessorTest
 from ShuffleTest import ShuffleTest
 from PremultiplyTest import PremultiplyTest
 from UnpremultiplyTest import UnpremultiplyTest
+from CropTest import CropTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferImageUI/CropUI.py
+++ b/python/GafferImageUI/CropUI.py
@@ -1,0 +1,127 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import IECore
+import Gaffer
+import GafferImage
+import GafferUI
+
+## A command suitable for use with NodeMenu.definition().append(), to add a menu
+# item for the creation of a crop node
+def postCreateCrop( node, script, menu ) :
+
+	if node['in'].getInput() :
+		cropFormat = node['in']['format'].getValue()
+	else:
+		cropFormat = script['defaultFormat'].getValue()
+
+	cropArea = cropFormat.getDisplayWindow()
+	cropArea.max += IECore.V2i( 1 )
+
+	node['area'].setValue( cropArea )
+
+
+Gaffer.Metadata.registerNode(
+
+	GafferImage.Crop,
+
+	"description",
+	"""
+	Modifies the Data and/or Display Window, in a way that is
+	either user-defined, or can be driven by the existing Data
+	or Display Window.
+	""",
+
+	"layout:activator:areaSourceIsCustom", lambda node : node["areaSource"].getValue() == GafferImage.Crop.AreaType.Custom,
+
+	plugs = {
+
+		"area" : [
+
+			"description",
+			"""
+			The custom area to set the Data/Display Window to.
+			This plug is only used if 'Area Source' is set to
+			Custom.
+			""",
+
+			"layout:activator", "areaSourceIsCustom",
+
+		],
+
+		"areaSource" : [
+
+			"description",
+			"""
+			Where to source the actual area to use. If this is
+			set to DataWindow, it will use the input's Data Window,
+			if it is set to DisplayWindow, it will use the input's
+			Display Window, and if it is set to Custom, it will use
+			the Area plug.
+			""",
+
+			"preset:DataWindow", GafferImage.Crop.AreaType.DataWindow,
+			"preset:DisplayWindow", GafferImage.Crop.AreaType.DisplayWindow,
+			"preset:Custom", GafferImage.Crop.AreaType.Custom,
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
+		],
+
+		"affectDataWindow" : [
+
+			"description",
+			"""
+			Whether to intersect the defined area with the input Data
+			Window. It will never pad black onto the Data Window, it
+			will only ever reduce the existing Data Window.
+			""",
+
+		],
+
+		"affectDisplayWindow" : [
+
+			"description",
+			"""
+			Whether to assign a new Display Window based on the defined
+			area.
+			""",
+
+		],
+
+	}
+
+)

--- a/python/GafferImageUI/CropUI.py
+++ b/python/GafferImageUI/CropUI.py
@@ -1,6 +1,7 @@
 ##########################################################################
 #
 #  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2015, Nvizible Ltd. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -41,12 +42,12 @@ import GafferUI
 
 ## A command suitable for use with NodeMenu.definition().append(), to add a menu
 # item for the creation of a crop node
-def postCreateCrop( node, script, menu ) :
+def postCreateCrop( node, menu ) :
 
 	if node['in'].getInput() :
 		cropFormat = node['in']['format'].getValue()
 	else:
-		cropFormat = script['defaultFormat'].getValue()
+		cropFormat = node.scriptNode()['defaultFormat'].getValue()
 
 	cropArea = cropFormat.getDisplayWindow()
 	cropArea.max += IECore.V2i( 1 )
@@ -65,7 +66,7 @@ Gaffer.Metadata.registerNode(
 	or Display Window.
 	""",
 
-	"layout:activator:areaSourceIsCustom", lambda node : node["areaSource"].getValue() == GafferImage.Crop.AreaType.Custom,
+	"layout:activator:areaSourceIsCustom", lambda node : node["areaSource"].getValue() == GafferImage.Crop.AreaSource.Custom,
 
 	plugs = {
 
@@ -93,9 +94,9 @@ Gaffer.Metadata.registerNode(
 			the Area plug.
 			""",
 
-			"preset:DataWindow", GafferImage.Crop.AreaType.DataWindow,
-			"preset:DisplayWindow", GafferImage.Crop.AreaType.DisplayWindow,
-			"preset:Custom", GafferImage.Crop.AreaType.Custom,
+			"preset:DataWindow", GafferImage.Crop.AreaSource.DataWindow,
+			"preset:DisplayWindow", GafferImage.Crop.AreaSource.DisplayWindow,
+			"preset:Custom", GafferImage.Crop.AreaSource.Custom,
 
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 

--- a/python/GafferImageUI/__init__.py
+++ b/python/GafferImageUI/__init__.py
@@ -69,5 +69,6 @@ import ImageLoopUI
 import ShuffleUI
 import PremultiplyUI
 import UnpremultiplyUI
+import CropUI
 
 __import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", {}, subdirectory = "GafferImageUI" )

--- a/python/GafferUI/NodeMenu.py
+++ b/python/GafferUI/NodeMenu.py
@@ -86,15 +86,15 @@ class NodeMenu :
 
 	## Utility function to append a menu item to definition.
 	# nodeCreator must be a callable that returns a Gaffer.Node.
-	def append( self, path, nodeCreator, plugValues={}, **kw ) :
+	def append( self, path, nodeCreator, plugValues={}, postCreator=None, **kw ) :
 
-		item = IECore.MenuItemDefinition( command = self.nodeCreatorWrapper( nodeCreator=nodeCreator, plugValues=plugValues ), **kw )
+		item = IECore.MenuItemDefinition( command = self.nodeCreatorWrapper( nodeCreator=nodeCreator, plugValues=plugValues, postCreator=postCreator ), **kw )
 		self.definition().append( path, item )
 
 	## Utility function which takes a callable that creates a node, and returns a new
 	# callable which will add the node to the graph.
 	@staticmethod
-	def nodeCreatorWrapper( nodeCreator, plugValues={} ) :
+	def nodeCreatorWrapper( nodeCreator, plugValues={}, postCreator=None ) :
 
 		def f( menu ) :
 
@@ -145,5 +145,8 @@ class NodeMenu :
 			script.selection().add( node )
 
 			nodeGraph.frame( [ node ], extend = True )
+
+			if postCreator is not None :
+				postCreator( node, script, menu )
 
 		return f

--- a/python/GafferUI/NodeMenu.py
+++ b/python/GafferUI/NodeMenu.py
@@ -147,6 +147,6 @@ class NodeMenu :
 			nodeGraph.frame( [ node ], extend = True )
 
 			if postCreator is not None :
-				postCreator( node, script, menu )
+				postCreator( node, menu )
 
 		return f

--- a/src/GafferImage/Crop.cpp
+++ b/src/GafferImage/Crop.cpp
@@ -1,0 +1,311 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2013-2015, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2013, Luke Goddard. All rights reserved.
+//  Copyright (c) 2015, Nvizible Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of Image Engine Design nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/bind.hpp"
+
+#include "GafferImage/Crop.h"
+#include "GafferImage/Sampler.h"
+
+using namespace Gaffer;
+using namespace IECore;
+using namespace GafferImage;
+
+IE_CORE_DEFINERUNTIMETYPED( Crop );
+
+size_t Crop::g_firstPlugIndex = 0;
+
+Crop::Crop( const std::string &name )
+	:   ImageProcessor( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+	addChild( new IntPlug( "areaSource", Gaffer::Plug::In, Crop::DisplayWindow ) );
+	addChild( new Box2iPlug( "area" ) );
+	addChild( new BoolPlug( "affectDataWindow", Gaffer::Plug::In, true ) );
+	addChild( new BoolPlug( "affectDisplayWindow", Gaffer::Plug::In, false ) );
+
+	addChild( new AtomicBox2iPlug( "__cropWindow", Gaffer::Plug::Out ) );
+
+	// We don't ever want to change these, so we make pass-through connections.
+	outPlug()->metadataPlug()->setInput( inPlug()->metadataPlug() );
+	outPlug()->channelNamesPlug()->setInput( inPlug()->channelNamesPlug() );
+	outPlug()->channelDataPlug()->setInput( inPlug()->channelDataPlug() );
+}
+
+Crop::~Crop()
+{
+}
+
+Gaffer::IntPlug *Crop::areaSourcePlug()
+{
+	return getChild<IntPlug>( g_firstPlugIndex );
+}
+
+const Gaffer::IntPlug *Crop::areaSourcePlug() const
+{
+	return getChild<IntPlug>( g_firstPlugIndex );
+}
+
+Gaffer::Box2iPlug *Crop::areaPlug()
+{
+	return getChild<Box2iPlug>( g_firstPlugIndex+1 );
+}
+
+const Gaffer::Box2iPlug *Crop::areaPlug() const
+{
+	return getChild<Box2iPlug>( g_firstPlugIndex+1 );
+}
+
+Gaffer::BoolPlug *Crop::affectDataWindowPlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex+2 );
+}
+
+const Gaffer::BoolPlug *Crop::affectDataWindowPlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex+2 );
+}
+
+Gaffer::BoolPlug *Crop::affectDisplayWindowPlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex+3 );
+}
+
+const Gaffer::BoolPlug *Crop::affectDisplayWindowPlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex+3 );
+}
+
+Gaffer::AtomicBox2iPlug *Crop::cropWindowPlug()
+{
+	return getChild<AtomicBox2iPlug>( g_firstPlugIndex+4 );
+}
+
+const Gaffer::AtomicBox2iPlug *Crop::cropWindowPlug() const
+{
+	return getChild<AtomicBox2iPlug>( g_firstPlugIndex+4 );
+}
+
+void Crop::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
+{
+	ImageProcessor::affects( input, outputs );
+
+	if ( areaPlug()->isAncestorOf( input ) ||
+	     input == areaSourcePlug() )
+	{
+		outputs.push_back( cropWindowPlug() );
+	}
+	else if ( input == cropWindowPlug() ||
+	          input == affectDataWindowPlug() ||
+	          input == affectDisplayWindowPlug() ||
+	          input == inPlug()->dataWindowPlug() )
+	{
+		outputs.push_back( outPlug()->formatPlug() );
+		outputs.push_back( outPlug()->dataWindowPlug() );
+	}
+}
+
+void Crop::hashFormat( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	bool affectDisplayWindow = affectDisplayWindowPlug()->getValue();
+
+	if ( ! affectDisplayWindow )
+	{
+		// No-op because we are not applying this
+		// crop to the display window
+		h = inPlug()->formatPlug()->hash();
+		return;
+	}
+
+	Format inFormat = inPlug()->formatPlug()->getValue();
+
+	Imath::Box2i cropWindow = cropWindowPlug()->getValue();
+
+	Format newFormat( cropWindow, inFormat.getPixelAspect() );
+
+	if ( inFormat == newFormat )
+	{
+		// No-op because the resulting format will
+		// be identical to the input format
+		h = inPlug()->formatPlug()->hash();
+		return;
+	}
+
+	ImageProcessor::hashFormat( parent, context, h );
+
+	cropWindowPlug()->hash( h );
+}
+
+GafferImage::Format Crop::computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const
+{
+	bool affectDisplayWindow = affectDisplayWindowPlug()->getValue();
+
+	if ( ! affectDisplayWindow )
+	{
+		// No-op because we are not applying this
+		// crop to the display window
+		return inPlug()->formatPlug()->getValue();
+	}
+
+	Format inFormat = inPlug()->formatPlug()->getValue();
+
+	Imath::Box2i cropWindow = cropWindowPlug()->getValue();
+
+	return Format( cropWindow, inFormat.getPixelAspect() );
+}
+
+
+void Crop::hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	bool affectDataWindow = affectDataWindowPlug()->getValue();
+
+	if ( ! affectDataWindow )
+	{
+		// No-op because we are not applying this
+		// crop to the data window
+		h = inPlug()->dataWindowPlug()->hash();
+		return;
+	}
+
+	Imath::Box2i cropWindow = cropWindowPlug()->getValue();
+	Imath::Box2i dataWindow = inPlug()->dataWindowPlug()->getValue();
+
+	if ( dataWindow.min.x >= cropWindow.min.x &&
+		 dataWindow.min.y >= cropWindow.min.y &&
+		 dataWindow.max.x <= cropWindow.max.x &&
+		 dataWindow.max.y <= cropWindow.max.y )
+	{
+		// No-op because the data window is wholly
+		// contained inside the specified area
+		h = inPlug()->dataWindowPlug()->hash();
+		return;
+	}
+
+	ImageProcessor::hashDataWindow( parent, context, h );
+
+	cropWindowPlug()->hash( h );
+}
+
+Imath::Box2i Crop::computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const
+{
+	bool affectDataWindow = affectDataWindowPlug()->getValue();
+
+	if ( ! affectDataWindow )
+	{
+		// No-op because we are not applying this
+		// crop to the data window
+		return inPlug()->dataWindowPlug()->getValue();
+	}
+
+	Imath::Box2i cropWindow = cropWindowPlug()->getValue();
+	Imath::Box2i dataWindow = inPlug()->dataWindowPlug()->getValue();
+
+	return Imath::Box2i( Imath::V2i( std::max( dataWindow.min.x, cropWindow.min.x ),
+									 std::max( dataWindow.min.y, cropWindow.min.y ) ),
+						 Imath::V2i( std::min( dataWindow.max.x, cropWindow.max.x ),
+									 std::min( dataWindow.max.y, cropWindow.max.y ) ) );
+}
+
+void Crop::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	if ( output == cropWindowPlug() )
+	{
+		int areaSource = areaSourcePlug()->getValue();
+
+		switch ( areaSource )
+		{
+			case DataWindow:
+			{
+				inPlug()->dataWindowPlug()->hash( h );
+				break;
+			}
+			case DisplayWindow:
+			{
+				inPlug()->formatPlug()->hash( h );
+				break;
+			}
+			default:
+			{
+				areaPlug()->hash( h );
+				break;
+			}
+		}
+	}
+	else
+	{
+		ImageProcessor::hash( output, context, h );
+	}
+}
+
+void Crop::compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const
+{
+	if ( output == cropWindowPlug() )
+	{
+		int areaSource = areaSourcePlug()->getValue();
+		Imath::Box2i cropWindow;
+
+		switch ( areaSource )
+		{
+			case DataWindow:
+			{
+				cropWindow = inPlug()->dataWindowPlug()->getValue();
+				break;
+			}
+			case DisplayWindow:
+			{
+				cropWindow = inPlug()->formatPlug()->getValue().getDisplayWindow();
+				break;
+			}
+			default:
+			{
+				cropWindow = areaPlug()->getValue();
+				// Because we are treating the areaPlug as exclusive, but the
+				// cropWindow is inclusive, need to subtract 1 from the max
+				// values.
+				cropWindow.max -= Imath::V2i( 1 );
+				break;
+			}
+		}
+
+		static_cast<Gaffer::AtomicBox2iPlug *>( output )->setValue( cropWindow );
+	}
+	else
+	{
+		ImageProcessor::compute( output, context );
+	}
+}
+

--- a/src/GafferImageBindings/CropBinding.cpp
+++ b/src/GafferImageBindings/CropBinding.cpp
@@ -1,6 +1,7 @@
 //////////////////////////////////////////////////////////////////////////
 //
 //  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2015, Nvizible Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,7 +36,6 @@
 #include "boost/python.hpp"
 
 #include "GafferBindings/DependencyNodeBinding.h"
-// #include "IECorePython/RunTimeTypedBinding.h"
 
 #include "GafferImage/Crop.h"
 #include "GafferImageBindings/CropBinding.h"
@@ -52,7 +52,7 @@ void bindCrop()
 
 	scope s = GafferBindings::DependencyNodeClass<Crop>();
 
-	enum_<Crop::AreaType>( "AreaType" )
+	enum_<Crop::AreaSource>( "AreaSource" )
 		.value( "Custom", Crop::Custom )
 		.value( "DataWindow", Crop::DataWindow )
 		.value( "DisplayWindow", Crop::DisplayWindow )

--- a/src/GafferImageBindings/CropBinding.cpp
+++ b/src/GafferImageBindings/CropBinding.cpp
@@ -1,0 +1,63 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "GafferBindings/DependencyNodeBinding.h"
+// #include "IECorePython/RunTimeTypedBinding.h"
+
+#include "GafferImage/Crop.h"
+#include "GafferImageBindings/CropBinding.h"
+
+using namespace boost::python;
+using namespace GafferImage;
+using namespace GafferBindings;
+
+namespace GafferImageBindings
+{
+
+void bindCrop()
+{
+
+	scope s = GafferBindings::DependencyNodeClass<Crop>();
+
+	enum_<Crop::AreaType>( "AreaType" )
+		.value( "Custom", Crop::Custom )
+		.value( "DataWindow", Crop::DataWindow )
+		.value( "DisplayWindow", Crop::DisplayWindow )
+	;
+
+}
+
+} // namespace GafferImageBindings

--- a/src/GafferImageModule/GafferImageModule.cpp
+++ b/src/GafferImageModule/GafferImageModule.cpp
@@ -60,6 +60,7 @@
 #include "GafferImage/CopyImageMetadata.h"
 #include "GafferImage/Premultiply.h"
 #include "GafferImage/Unpremultiply.h"
+#include "GafferImage/Crop.h"
 
 #include "GafferImageBindings/ImageNodeBinding.h"
 #include "GafferImageBindings/ImageProcessorBinding.h"
@@ -76,6 +77,7 @@
 #include "GafferImageBindings/FormatDataBinding.h"
 #include "GafferImageBindings/ImageReaderBinding.h"
 #include "GafferImageBindings/ShuffleBinding.h"
+#include "GafferImageBindings/CropBinding.h"
 
 using namespace boost::python;
 using namespace GafferImage;
@@ -122,6 +124,7 @@ BOOST_PYTHON_MODULE( _GafferImage )
 	GafferImageBindings::bindImageReader();
 	GafferImageBindings::bindMerge();
 	GafferImageBindings::bindShuffle();
+	GafferImageBindings::bindCrop();
 
 	GafferBindings::ExecutableNodeClass<ImageWriter>();
 }

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -271,6 +271,8 @@ nodeMenu.append( "/Scene/OpenGL/Render", GafferScene.OpenGLRender, searchText = 
 import GafferImage
 import GafferImageUI
 
+
+
 nodeMenu.append( "/Image/Source/Display", GafferImage.Display )
 nodeMenu.append( "/Image/Source/Reader", GafferImage.ImageReader, searchText = "ImageReader" )
 nodeMenu.append( "/Image/Source/Writer", GafferImage.ImageWriter, searchText = "ImageWriter" )
@@ -284,6 +286,7 @@ nodeMenu.append( "/Image/Merge/Merge", GafferImage.Merge )
 nodeMenu.append( "/Image/Merge/Switch", GafferImage.ImageSwitch, searchText = "ImageSwitch" )
 nodeMenu.append( "/Image/Transform/Reformat", GafferImage.Reformat )
 nodeMenu.append( "/Image/Transform/Transform", GafferImage.ImageTransform, searchText = "ImageTransform" )
+nodeMenu.append( "/Image/Transform/Crop", GafferImage.Crop, postCreator = GafferImageUI.CropUI.postCreateCrop )
 nodeMenu.append( "/Image/Channels/Shuffle", GafferImageUI.ShuffleUI.nodeMenuCreateCommand, searchText = "Shuffle" )
 nodeMenu.append( "/Image/Channels/Delete", GafferImage.DeleteChannels, searchText = "DeleteChannels" )
 nodeMenu.append( "/Image/Context/Time Warp", GafferImage.ImageTimeWarp, searchText = "ImageTimeWarp" )
@@ -343,9 +346,9 @@ nodeMenu.append( "/Utility/Reference", GafferUI.ReferenceUI.nodeMenuCreateComman
 nodeMenu.definition().append( "/Utility/Backdrop", { "command" : GafferUI.BackdropUI.nodeMenuCreateCommand } )
 nodeMenu.append( "/Utility/Dot", Gaffer.Dot )
 
-# appleseed uses GafferOSL shaders so  we need to 
+# appleseed uses GafferOSL shaders so  we need to
 # add the paths to them to OSL_SHADER_PATHS environment var.
-# this has to happen after GafferOSL is initialized otherwise 
+# this has to happen after GafferOSL is initialized otherwise
 # appleseed shaders also show on the OSL menu.
 if "APPLESEED" in os.environ :
 


### PR DESCRIPTION
Here's a Crop node. Everything should be there - let me know if there are any issues, technically or stylistically.

Functionality:

Can set the Data Window, the Display Window or both.
Can get its area from a custom Box2iPlug, or get it from the input Display Window or Data Window
Only ever intersects with the existing Data Window. It will not pad with black.


This PR also includes a small change to NodeMenu. It allows a postCreator argument to be passed to nodeMenu.append() which should be a method that will be called after the node has been created, connected and positioned. In the case of the Crop node, it sets the initial 'area' for the node to either the input Display Window or the script's default format.