### PR TITLE
Fixing type cast for gcc 4.1.2

### DIFF
--- a/src/Gaffer/Box.cpp
+++ b/src/Gaffer/Box.cpp
@@ -82,12 +82,12 @@ Plug *Box::promotePlug( Plug *descendantPlug )
 	// for types like CompoundNumericPlug that create children in their constructors.
 	const Gaffer::TypeId compoundTypes[] = { PlugTypeId, ValuePlugTypeId, CompoundPlugTypeId, ArrayPlugTypeId };
 	const Gaffer::TypeId *compoundTypesEnd = compoundTypes + 4;
-	if( find( compoundTypes, compoundTypesEnd, externalPlug->typeId() ) != compoundTypesEnd )
+	if( find( compoundTypes, compoundTypesEnd, (Gaffer::TypeId)externalPlug->typeId() ) != compoundTypesEnd )
 	{
 		for( RecursivePlugIterator it( externalPlug.get() ); it != it.end(); ++it )
 		{
 			(*it)->setFlags( Plug::Dynamic, true );
-			if( find( compoundTypes, compoundTypesEnd, (*it)->typeId() ) != compoundTypesEnd )
+			if( find( compoundTypes, compoundTypesEnd, (Gaffer::TypeId)(*it)->typeId() ) != compoundTypesEnd )
 			{
 				it.prune();
 			}


### PR DESCRIPTION
This was introduced recently and fails to compile (with -Werror) on gcc 4.1.2.

I wonder, does Travis have any gcc4.1 machines we can run the tests on alongside gcc4.8 and clang?