### PR TITLE
Exclusive image bounds (max)

### DIFF
--- a/include/GafferImage/Format.h
+++ b/include/GafferImage/Format.h
@@ -79,26 +79,25 @@ class Format
 
 		/// @name Coordinate system conversions.
 		/// The image coordinate system used by Gaffer has the origin at the
-		/// bottom, with increasing Y coordinates going up. The Cortex and OpenEXR
-		/// coordinate systems have the origin at the top with increasing Y
-		/// coordinates going down. These methods assist in converting between
-		/// the two coordinate systems. They assume that the format has been
-		/// constructed using exactly the same display window as is being
-		/// used in the corresponding Y-down space - note that this means it
-		/// is not necessary to perform any conversion on the display window
-		/// itself.
+		/// bottom, with increasing Y coordinates going up. It also considers
+		/// image bounds to be exclusive at the max end.
+		/// The Cortex and OpenEXR coordinate systems have the origin at the
+		/// top with increasing Y coordinates going down. They use inclusive
+		/// image bounds.
+		/// These methods assist in converting between the two coordinate
+		/// systems.
 		////////////////////////////////////////////////////////////////////
 		//@{
-		/// Converts from the Y-down coordinate space to the Y-up space of
+		/// Converts from the EXR coordinate space to the internal space of
 		/// the Format.
-		inline int yDownToFormatSpace( int yDown ) const;
-		inline Imath::V2i yDownToFormatSpace( const Imath::V2i &yDown ) const;
-		inline Imath::Box2i yDownToFormatSpace( const Imath::Box2i &yDown ) const;
-		/// Converts from the Y-up space of the format to the Y-down
+		inline int fromEXRSpace( int exrSpace ) const;
+		inline Imath::V2i fromEXRSpace( const Imath::V2i &exrSpace ) const;
+		inline Imath::Box2i fromEXRSpace( const Imath::Box2i &exrSpace ) const;
+		/// Converts from the internal space of the format to the EXR
 		/// coordinate space.
-		inline int formatToYDownSpace( int yUp ) const;
-		inline Imath::V2i formatToYDownSpace( const Imath::V2i &yUp ) const;
-		inline Imath::Box2i formatToYDownSpace( const Imath::Box2i &yUp ) const;
+		inline int toEXRSpace( int internalSpace ) const;
+		inline Imath::V2i toEXRSpace( const Imath::V2i &internalSpace ) const;
+		inline Imath::Box2i toEXRSpace( const Imath::Box2i &internalSpace ) const;
 		//@}
 
 		/// @name Default Format methods

--- a/include/GafferImage/Format.h
+++ b/include/GafferImage/Format.h
@@ -62,7 +62,7 @@ class Format
 		typedef boost::signal<void (const std::string&)> UnaryFormatSignal;
 
 		inline Format();
-		inline explicit Format( const Imath::Box2i &displayWindow, double pixelAspect = 1. );
+		inline explicit Format( const Imath::Box2i &displayWindow, double pixelAspect = 1., bool fromEXRSpace = false );
 		inline Format( int width, int height, double pixelAspect = 1. );
 
 		inline const Imath::Box2i &getDisplayWindow() const;

--- a/include/GafferImage/Format.inl
+++ b/include/GafferImage/Format.inl
@@ -56,7 +56,7 @@ inline Format::Format( int width, int height, double pixelAspect )
 {
 	width = std::max( 0, width );
 	height = std::max( 0, height );
-	m_displayWindow = Imath::Box2i( Imath::V2i( 0, 0 ), Imath::V2i( width-1, height-1 ) );
+	m_displayWindow = Imath::Box2i( Imath::V2i( 0, 0 ), Imath::V2i( width, height ) );
 }
 
 inline const Imath::Box2i &Format::getDisplayWindow() const
@@ -75,7 +75,7 @@ inline int Format::width() const
 	{
 		return 0;
 	}
-	return m_displayWindow.max.x - m_displayWindow.min.x + 1;
+	return m_displayWindow.max.x - m_displayWindow.min.x;
 }
 
 inline int Format::height() const
@@ -84,7 +84,7 @@ inline int Format::height() const
 	{
 		return 0;
 	}
-	return m_displayWindow.max.y - m_displayWindow.min.y + 1;
+	return m_displayWindow.max.y - m_displayWindow.min.y;
 }
 
 inline double Format::getPixelAspect() const
@@ -110,7 +110,7 @@ inline bool Format::operator != ( const Format& rhs ) const
 inline int Format::yDownToFormatSpace( int yDown ) const
 {
 	const int distanceFromTop = yDown - m_displayWindow.min.y;
-	return m_displayWindow.max.y - distanceFromTop;
+	return m_displayWindow.max.y - 1 - distanceFromTop;
 }
 
 inline Imath::V2i Format::yDownToFormatSpace( const Imath::V2i &yDown ) const
@@ -122,13 +122,14 @@ inline Imath::Box2i Format::yDownToFormatSpace( const Imath::Box2i &yDown ) cons
 {
 	Imath::Box2i result;
 	result.extendBy( yDownToFormatSpace( yDown.min ) );
-	result.extendBy( yDownToFormatSpace( yDown.max ) );
+	result.extendBy( yDownToFormatSpace( yDown.max - Imath::V2i( 0, 1 ) ) );
+	result.max += Imath::V2i( 0, 1 );
 	return result;
 }
 
 inline int Format::formatToYDownSpace( int yUp ) const
 {
-	const int distanceFromTop = m_displayWindow.max.y - yUp;
+	const int distanceFromTop = m_displayWindow.max.y - 1 - yUp;
 	return m_displayWindow.min.y + distanceFromTop;
 }
 
@@ -141,7 +142,8 @@ inline Imath::Box2i Format::formatToYDownSpace( const Imath::Box2i &yUp ) const
 {
 	Imath::Box2i result;
 	result.extendBy( formatToYDownSpace( yUp.min ) );
-	result.extendBy( formatToYDownSpace( yUp.max ) );
+	result.extendBy( formatToYDownSpace( yUp.max - Imath::V2i( 0, 1 ) ) );
+	result.max += Imath::V2i( 0, 1 );
 	return result;
 }
 

--- a/include/GafferImage/Format.inl
+++ b/include/GafferImage/Format.inl
@@ -45,10 +45,14 @@ inline Format::Format()
 {
 }
 
-inline Format::Format( const Imath::Box2i &displayWindow, double pixelAspect )
+inline Format::Format( const Imath::Box2i &displayWindow, double pixelAspect, bool fromEXRSpace )
 	:	m_displayWindow( displayWindow ),
 		m_pixelAspect( pixelAspect )
 {
+	if( fromEXRSpace )
+	{
+		m_displayWindow.max += Imath::V2i( 1 );
+	}
 }
 
 inline Format::Format( int width, int height, double pixelAspect )

--- a/include/GafferImage/Format.inl
+++ b/include/GafferImage/Format.inl
@@ -121,8 +121,9 @@ inline Imath::V2i Format::fromEXRSpace( const Imath::V2i &exrSpace ) const
 inline Imath::Box2i Format::fromEXRSpace( const Imath::Box2i &exrSpace ) const
 {
 	return Imath::Box2i(
-			Imath::V2i( exrSpace.min.x, fromEXRSpace( exrSpace.max.y ) ),
-			Imath::V2i( exrSpace.max.x + 1, fromEXRSpace( exrSpace.min.y ) + 1 ) );
+		Imath::V2i( exrSpace.min.x, fromEXRSpace( exrSpace.max.y ) ),
+		Imath::V2i( exrSpace.max.x + 1, fromEXRSpace( exrSpace.min.y ) + 1 )
+	);
 }
 
 inline int Format::toEXRSpace( int internalSpace ) const
@@ -139,8 +140,9 @@ inline Imath::V2i Format::toEXRSpace( const Imath::V2i &internalSpace ) const
 inline Imath::Box2i Format::toEXRSpace( const Imath::Box2i &internalSpace ) const
 {
 	return Imath::Box2i(
-			Imath::V2i( internalSpace.min.x, toEXRSpace( internalSpace.max.y - 1 ) ),
-			Imath::V2i( internalSpace.max.x - 1, toEXRSpace( internalSpace.min.y ) ) );
+		Imath::V2i( internalSpace.min.x, toEXRSpace( internalSpace.max.y - 1 ) ),
+		Imath::V2i( internalSpace.max.x - 1, toEXRSpace( internalSpace.min.y ) )
+	);
 }
 
 } // namespace GafferImage

--- a/include/GafferImage/Format.inl
+++ b/include/GafferImage/Format.inl
@@ -124,6 +124,10 @@ inline Imath::Box2i Format::yDownToFormatSpace( const Imath::Box2i &yDown ) cons
 	result.extendBy( yDownToFormatSpace( yDown.min ) );
 	result.extendBy( yDownToFormatSpace( yDown.max - Imath::V2i( 0, 1 ) ) );
 	result.max += Imath::V2i( 0, 1 );
+	if( yDown.max.y == yDown.min.y )
+	{
+		result.max.y = result.min.y;
+	}
 	return result;
 }
 
@@ -144,6 +148,10 @@ inline Imath::Box2i Format::formatToYDownSpace( const Imath::Box2i &yUp ) const
 	result.extendBy( formatToYDownSpace( yUp.min ) );
 	result.extendBy( formatToYDownSpace( yUp.max - Imath::V2i( 0, 1 ) ) );
 	result.max += Imath::V2i( 0, 1 );
+	if( yUp.max.y == yUp.min.y )
+	{
+		result.max.y = result.min.y;
+	}
 	return result;
 }
 

--- a/include/GafferImage/Format.inl
+++ b/include/GafferImage/Format.inl
@@ -107,52 +107,40 @@ inline bool Format::operator != ( const Format& rhs ) const
 	return m_displayWindow != rhs.m_displayWindow || m_pixelAspect != rhs.m_pixelAspect;
 }
 
-inline int Format::yDownToFormatSpace( int yDown ) const
+inline int Format::fromEXRSpace( int exrSpace ) const
 {
-	const int distanceFromTop = yDown - m_displayWindow.min.y;
+	const int distanceFromTop = exrSpace - m_displayWindow.min.y;
 	return m_displayWindow.max.y - 1 - distanceFromTop;
 }
 
-inline Imath::V2i Format::yDownToFormatSpace( const Imath::V2i &yDown ) const
+inline Imath::V2i Format::fromEXRSpace( const Imath::V2i &exrSpace ) const
 {
-	return Imath::V2i( yDown.x, yDownToFormatSpace( yDown.y ) );
+	return Imath::V2i( exrSpace.x, fromEXRSpace( exrSpace.y ) );
 }
 
-inline Imath::Box2i Format::yDownToFormatSpace( const Imath::Box2i &yDown ) const
+inline Imath::Box2i Format::fromEXRSpace( const Imath::Box2i &exrSpace ) const
 {
-	Imath::Box2i result;
-	result.extendBy( yDownToFormatSpace( yDown.min ) );
-	result.extendBy( yDownToFormatSpace( yDown.max - Imath::V2i( 0, 1 ) ) );
-	result.max += Imath::V2i( 0, 1 );
-	if( yDown.max.y == yDown.min.y )
-	{
-		result.max.y = result.min.y;
-	}
-	return result;
+	return Imath::Box2i(
+			Imath::V2i( exrSpace.min.x, fromEXRSpace( exrSpace.max.y ) ),
+			Imath::V2i( exrSpace.max.x + 1, fromEXRSpace( exrSpace.min.y ) + 1 ) );
 }
 
-inline int Format::formatToYDownSpace( int yUp ) const
+inline int Format::toEXRSpace( int internalSpace ) const
 {
-	const int distanceFromTop = m_displayWindow.max.y - 1 - yUp;
+	const int distanceFromTop = m_displayWindow.max.y - 1 - internalSpace;
 	return m_displayWindow.min.y + distanceFromTop;
 }
 
-inline Imath::V2i Format::formatToYDownSpace( const Imath::V2i &yUp ) const
+inline Imath::V2i Format::toEXRSpace( const Imath::V2i &internalSpace ) const
 {
-	return Imath::V2i( yUp.x, formatToYDownSpace( yUp.y ) );
+	return Imath::V2i( internalSpace.x, toEXRSpace( internalSpace.y ) );
 }
 
-inline Imath::Box2i Format::formatToYDownSpace( const Imath::Box2i &yUp ) const
+inline Imath::Box2i Format::toEXRSpace( const Imath::Box2i &internalSpace ) const
 {
-	Imath::Box2i result;
-	result.extendBy( formatToYDownSpace( yUp.min ) );
-	result.extendBy( formatToYDownSpace( yUp.max - Imath::V2i( 0, 1 ) ) );
-	result.max += Imath::V2i( 0, 1 );
-	if( yUp.max.y == yUp.min.y )
-	{
-		result.max.y = result.min.y;
-	}
-	return result;
+	return Imath::Box2i(
+			Imath::V2i( internalSpace.min.x, toEXRSpace( internalSpace.max.y - 1 ) ),
+			Imath::V2i( internalSpace.max.x - 1, toEXRSpace( internalSpace.min.y ) ) );
 }
 
 } // namespace GafferImage

--- a/include/GafferImage/ImagePlug.h
+++ b/include/GafferImage/ImagePlug.h
@@ -71,7 +71,7 @@ namespace GafferImage
 /// will modify the metadata are the Metadata specific nodes. Other image processing may occur which
 /// causes the implied meaning of certain metadata entries to become invalid (such as oiio:ColorSpace)
 /// but those nodes will not alter the metadata, nor behave differently based on its value.
-/// 
+///
 /// Some notes on color space:
 /// GafferImage nodes expect to operate in linear space, with associated alpha. Users are responsible
 /// for meeting that expectation (or knowing what they're doing when they don't).
@@ -136,7 +136,6 @@ class ImagePlug : public Gaffer::ValuePlug
 		//@}
 
 		static int tileSize() { return 64; };
-		static Imath::Box2i tileBound( const Imath::V2i &tileOrigin ) { return Imath::Box2i( tileOrigin * tileSize(), ( tileOrigin + Imath::V2i( 1 ) ) * tileSize() - Imath::V2i( 1 ) ); }
 		static const IECore::FloatVectorData *blackTile();
 		static const IECore::FloatVectorData *whiteTile();
 
@@ -152,7 +151,7 @@ class ImagePlug : public Gaffer::ValuePlug
 	private :
 
 		static void compoundObjectToCompoundData( const IECore::CompoundObject *object, IECore::CompoundData *data );
-		
+
 		static size_t g_firstPlugIndex;
 };
 

--- a/include/GafferImage/Sampler.inl
+++ b/include/GafferImage/Sampler.inl
@@ -98,20 +98,20 @@ float Sampler::sample( int x, int y )
 	// Return 0 for pixels outside of our sample window.
 	if ( m_boundingMode == Black )
 	{
-		if ( p.x < m_sampleWindow.min.x || p.x > m_sampleWindow.max.x )
+		if ( p.x < m_sampleWindow.min.x || p.x >= m_sampleWindow.max.x )
 		{
 			return 0.;
 		}
 
-		if ( p.y < m_sampleWindow.min.y || p.y > m_sampleWindow.max.y )
+		if ( p.y < m_sampleWindow.min.y || p.y >= m_sampleWindow.max.y )
 		{
 			return 0.;
 		}
 	}
 	else if ( m_boundingMode == Clamp )
 	{
-		p.x = std::max( std::min( p.x, m_sampleWindow.max.x ), m_sampleWindow.min.x );
-		p.y = std::max( std::min( p.y, m_sampleWindow.max.y ), m_sampleWindow.min.y );
+		p.x = std::max( std::min( p.x, m_sampleWindow.max.x - 1 ), m_sampleWindow.min.x );
+		p.y = std::max( std::min( p.y, m_sampleWindow.max.y - 1 ), m_sampleWindow.min.y );
 	}
 
 	const float *tileData;

--- a/python/GafferImageTest/CropTest.py
+++ b/python/GafferImageTest/CropTest.py
@@ -104,7 +104,7 @@ class CropTest( unittest.TestCase ) :
 		crop["affectDataWindow"].setValue( True )
 		crop["affectDisplayWindow"].setValue( False )
 
-		self.assertEqual( crop["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( 40 ), IECore.V2i( 49 ) ) )
+		self.assertEqual( crop["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( 40 ), IECore.V2i( 50 ) ) )
 		self.assertEqual( i["out"]["format"].getValue(), crop["out"]["format"].getValue() )
 
 	def testAffectDisplayWindow( self ) :
@@ -119,7 +119,7 @@ class CropTest( unittest.TestCase ) :
 		crop["affectDataWindow"].setValue( False )
 		crop["affectDisplayWindow"].setValue( True )
 
-		self.assertEqual( crop["out"]["format"].getValue().getDisplayWindow(), IECore.Box2i( IECore.V2i( 40 ), IECore.V2i( 49 ) ) )
+		self.assertEqual( crop["out"]["format"].getValue().getDisplayWindow(), IECore.Box2i( IECore.V2i( 40 ), IECore.V2i( 50 ) ) )
 		self.assertEqual( i["out"]["dataWindow"].getValue(), crop["out"]["dataWindow"].getValue() )
 
 	def testIntersectDataWindow( self ) :
@@ -134,7 +134,7 @@ class CropTest( unittest.TestCase ) :
 		crop["affectDataWindow"].setValue( True )
 		crop["affectDisplayWindow"].setValue( False )
 
-		self.assertEqual( crop["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( 30 ), IECore.V2i( 49 ) ) )
+		self.assertEqual( crop["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( 30 ), IECore.V2i( 50 ) ) )
 
 	def testDataWindowToDisplayWindow( self ) :
 

--- a/python/GafferImageTest/FormatPlugTest.py
+++ b/python/GafferImageTest/FormatPlugTest.py
@@ -34,6 +34,7 @@
 #
 ##########################################################################
 
+import os
 import unittest
 
 import IECore
@@ -42,6 +43,14 @@ import Gaffer
 import GafferImage
 
 class FormatPlugTest( unittest.TestCase ) :
+
+	def testOldFormatCompatibility( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( os.path.dirname( __file__ ) + "/scripts/formatCompatibility-0.15.0.0.gfr" )
+		s.load()
+
+		self.assertEqual( s["c"]["format"].getValue(), GafferImage.Format( 1920, 1080, 1. ) )
 
 	def testSerialisation( self ) :
 

--- a/python/GafferImageTest/FormatTest.py
+++ b/python/GafferImageTest/FormatTest.py
@@ -233,9 +233,32 @@ class FormatTest( GafferTest.TestCase ) :
 			pDown = f.formatToYDownSpace( p )
 			self.assertEqual( f.yDownToFormatSpace( pDown ), p )
 
-	def testDefaultFormatContextName( self ) :
+			b = IECore.Box2i()
+			b.extendBy( IECore.V2i( int( random.uniform( -500, 500 ) ), int( random.uniform( -500, 500 ) ) ) )
+			b.extendBy( IECore.V2i( int( random.uniform( -500, 500 ) ), int( random.uniform( -500, 500 ) ) ) )
 
-		self.assertEqual( GafferImage.Format.defaultFormatContextName, "image:defaultFormat" )
+			bDown = f.formatToYDownSpace( b )
+			self.assertEqual( f.yDownToFormatSpace( bDown ), b )
+
+	def testDisplayWindowCoordinateSystemTransforms( self ) :
+
+		f = GafferImage.Format( 10, 10, 1.0 )
+
+		self.assertEqual( f.formatToYDownSpace( 0 ), 9 )
+		self.assertEqual( f.formatToYDownSpace( 9 ), 0 )
+
+		self.assertEqual( f.yDownToFormatSpace( 9 ), 0 )
+		self.assertEqual( f.yDownToFormatSpace( 0 ), 9 )
+
+		self.assertEqual(
+			f.formatToYDownSpace( f.getDisplayWindow() ),
+			IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 10 ) )
+		)
+
+		self.assertEqual(
+			f.yDownToFormatSpace( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 10 ) ) ),
+			f.getDisplayWindow()
+		)
 
 	def tearDown( self ) :
 

--- a/python/GafferImageTest/FormatTest.py
+++ b/python/GafferImageTest/FormatTest.py
@@ -99,6 +99,14 @@ class FormatTest( GafferTest.TestCase ) :
 		self.assertEqual( f.height(), 150 )
 		self.assertEqual( f.getPixelAspect(), 1.3 )
 
+	def testDefaultPixelAspect( self ) :
+
+		f = GafferImage.Format( 100, 100 )
+		self.assertEqual( f.getPixelAspect(), 1. )
+
+		f = GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 100, 100 ) ) )
+		self.assertEqual( f.getPixelAspect(), 1. )
+
 	def testWH( self ) :
 
 		f = GafferImage.Format( 101, 102, 1. )
@@ -108,6 +116,12 @@ class FormatTest( GafferTest.TestCase ) :
 		f = GafferImage.Format( 0, 0, 1. )
 		self.assertEqual( f.width(), 0 )
 		self.assertEqual( f.height(), 0 )
+
+	def testEXRSpaceFormat( self ) :
+
+		f = GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 99 ) ), 1.0, True )
+		self.assertEqual( f.width(), 100 )
+		self.assertEqual( f.height(), 100 )
 
 	def testDefaultFormatContext( self ) :
 

--- a/python/GafferImageTest/FormatTest.py
+++ b/python/GafferImageTest/FormatTest.py
@@ -260,6 +260,10 @@ class FormatTest( GafferTest.TestCase ) :
 			f.getDisplayWindow()
 		)
 
+	def testDefaultFormatContextName( self ) :
+
+		self.assertEqual( GafferImage.Format.defaultFormatContextName, "image:defaultFormat" )
+
 	def tearDown( self ) :
 
 		GafferTest.TestCase.tearDown( self )

--- a/python/GafferImageTest/FormatTest.py
+++ b/python/GafferImageTest/FormatTest.py
@@ -209,54 +209,54 @@ class FormatTest( GafferTest.TestCase ) :
 
 		f = GafferImage.Format( IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 501, 301 ) ), 1 )
 
-		self.assertEqual( f.yDownToFormatSpace( IECore.V2i( -100, -200 ) ), IECore.V2i( -100, 300 ) )
-		self.assertEqual( f.yDownToFormatSpace( IECore.V2i( -100, 300 ) ), IECore.V2i( -100, -200 ) )
+		self.assertEqual( f.fromEXRSpace( IECore.V2i( -100, -200 ) ), IECore.V2i( -100, 300 ) )
+		self.assertEqual( f.fromEXRSpace( IECore.V2i( -100, 300 ) ), IECore.V2i( -100, -200 ) )
 
-		self.assertEqual( f.formatToYDownSpace( IECore.V2i( -100, -200 ) ), IECore.V2i( -100, 300 ) )
-		self.assertEqual( f.formatToYDownSpace( IECore.V2i( -100, 300 ) ), IECore.V2i( -100, -200 ) )
+		self.assertEqual( f.toEXRSpace( IECore.V2i( -100, -200 ) ), IECore.V2i( -100, 300 ) )
+		self.assertEqual( f.toEXRSpace( IECore.V2i( -100, 300 ) ), IECore.V2i( -100, -200 ) )
 
-		self.assertEqual( f.formatToYDownSpace(
+		self.assertEqual( f.toEXRSpace(
 				IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 501, 301 ) ) ),
-				IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 501, 301 ) ) )
+				IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 500, 300 ) ) )
 
-		self.assertEqual( f.formatToYDownSpace(
+		self.assertEqual( f.toEXRSpace(
 				IECore.Box2i( IECore.V2i( -100, -100 ), IECore.V2i( 501, 301 ) ) ),
-				IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 501, 201 ) ) )
+				IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 500, 200 ) ) )
 
-		self.assertEqual( f.formatToYDownSpace(
+		self.assertEqual( f.toEXRSpace(
 				IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 501, -100 ) ) ),
-				IECore.Box2i( IECore.V2i( -100, 201 ), IECore.V2i( 501, 301 ) ) )
+				IECore.Box2i( IECore.V2i( -100, 201 ), IECore.V2i( 500, 300 ) ) )
 
 		for i in range( 0, 1000 ) :
 
 			p = IECore.V2i( int( random.uniform( -500, 500 ) ), int( random.uniform( -500, 500 ) ) )
-			pDown = f.formatToYDownSpace( p )
-			self.assertEqual( f.yDownToFormatSpace( pDown ), p )
+			pDown = f.toEXRSpace( p )
+			self.assertEqual( f.fromEXRSpace( pDown ), p )
 
 			b = IECore.Box2i()
 			b.extendBy( IECore.V2i( int( random.uniform( -500, 500 ) ), int( random.uniform( -500, 500 ) ) ) )
 			b.extendBy( IECore.V2i( int( random.uniform( -500, 500 ) ), int( random.uniform( -500, 500 ) ) ) )
 
-			bDown = f.formatToYDownSpace( b )
-			self.assertEqual( f.yDownToFormatSpace( bDown ), b )
+			bDown = f.toEXRSpace( b )
+			self.assertEqual( f.fromEXRSpace( bDown ), b )
 
 	def testDisplayWindowCoordinateSystemTransforms( self ) :
 
 		f = GafferImage.Format( 10, 10, 1.0 )
 
-		self.assertEqual( f.formatToYDownSpace( 0 ), 9 )
-		self.assertEqual( f.formatToYDownSpace( 9 ), 0 )
+		self.assertEqual( f.toEXRSpace( 0 ), 9 )
+		self.assertEqual( f.toEXRSpace( 9 ), 0 )
 
-		self.assertEqual( f.yDownToFormatSpace( 9 ), 0 )
-		self.assertEqual( f.yDownToFormatSpace( 0 ), 9 )
+		self.assertEqual( f.fromEXRSpace( 9 ), 0 )
+		self.assertEqual( f.fromEXRSpace( 0 ), 9 )
 
 		self.assertEqual(
-			f.formatToYDownSpace( f.getDisplayWindow() ),
-			IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 10 ) )
+			f.toEXRSpace( f.getDisplayWindow() ),
+			IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 9 ) )
 		)
 
 		self.assertEqual(
-			f.yDownToFormatSpace( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 10 ) ) ),
+			f.fromEXRSpace( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 9 ) ) ),
 			f.getDisplayWindow()
 		)
 

--- a/python/GafferImageTest/FormatTest.py
+++ b/python/GafferImageTest/FormatTest.py
@@ -85,7 +85,7 @@ class FormatTest( GafferTest.TestCase ) :
 
 	def testOffsetDisplayWindow( self ) :
 
-		box = IECore.Box2i( IECore.V2i( 6, -4 ), IECore.V2i( 49, 149 ) )
+		box = IECore.Box2i( IECore.V2i( 6, -4 ), IECore.V2i( 50, 150 ) )
 		f = GafferImage.Format( box, 1.1 )
 		self.assertEqual( f.getDisplayWindow(), box )
 		self.assertEqual( f.width(), 44 )
@@ -94,7 +94,7 @@ class FormatTest( GafferTest.TestCase ) :
 
 	def testBoxAspectConstructor( self ) :
 
-		f = GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 49, 149 ) ), 1.3 )
+		f = GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 50, 150 ) ), 1.3 )
 		self.assertEqual( f.width(), 50 )
 		self.assertEqual( f.height(), 150 )
 		self.assertEqual( f.getPixelAspect(), 1.3 )
@@ -207,13 +207,25 @@ class FormatTest( GafferTest.TestCase ) :
 
 	def testCoordinateSystemTransforms( self ) :
 
-		f = GafferImage.Format( IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 500, 300 ) ), 1 )
+		f = GafferImage.Format( IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 501, 301 ) ), 1 )
 
 		self.assertEqual( f.yDownToFormatSpace( IECore.V2i( -100, -200 ) ), IECore.V2i( -100, 300 ) )
 		self.assertEqual( f.yDownToFormatSpace( IECore.V2i( -100, 300 ) ), IECore.V2i( -100, -200 ) )
 
 		self.assertEqual( f.formatToYDownSpace( IECore.V2i( -100, -200 ) ), IECore.V2i( -100, 300 ) )
 		self.assertEqual( f.formatToYDownSpace( IECore.V2i( -100, 300 ) ), IECore.V2i( -100, -200 ) )
+
+		self.assertEqual( f.formatToYDownSpace(
+				IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 501, 301 ) ) ),
+				IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 501, 301 ) ) )
+
+		self.assertEqual( f.formatToYDownSpace(
+				IECore.Box2i( IECore.V2i( -100, -100 ), IECore.V2i( 501, 301 ) ) ),
+				IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 501, 201 ) ) )
+
+		self.assertEqual( f.formatToYDownSpace(
+				IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 501, -100 ) ) ),
+				IECore.Box2i( IECore.V2i( -100, 201 ), IECore.V2i( 501, 301 ) ) )
 
 		for i in range( 0, 1000 ) :
 
@@ -236,7 +248,7 @@ class FormatTest( GafferTest.TestCase ) :
 		self.assertEqual( testFormat.getPixelAspect(), 1.4 )
 		self.assertEqual( testFormat.width(), 1234 )
 		self.assertEqual( testFormat.height(), 5678 )
-		self.assertEqual( testFormat.getDisplayWindow(), IECore.Box2i( IECore.V2i( 0, 0 ), IECore.V2i( 1233, 5677 ) ) )
+		self.assertEqual( testFormat.getDisplayWindow(), IECore.Box2i( IECore.V2i( 0, 0 ), IECore.V2i( 1234, 5678 ) ) )
 
 	def __testFormatValue( self ) :
 

--- a/python/GafferImageTest/FormatTest.py
+++ b/python/GafferImageTest/FormatTest.py
@@ -215,17 +215,26 @@ class FormatTest( GafferTest.TestCase ) :
 		self.assertEqual( f.toEXRSpace( IECore.V2i( -100, -200 ) ), IECore.V2i( -100, 300 ) )
 		self.assertEqual( f.toEXRSpace( IECore.V2i( -100, 300 ) ), IECore.V2i( -100, -200 ) )
 
-		self.assertEqual( f.toEXRSpace(
-				IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 501, 301 ) ) ),
-				IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 500, 300 ) ) )
+		self.assertEqual(
+			f.toEXRSpace(
+				IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 501, 301 ) )
+			),
+			IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 500, 300 ) )
+		)
 
-		self.assertEqual( f.toEXRSpace(
-				IECore.Box2i( IECore.V2i( -100, -100 ), IECore.V2i( 501, 301 ) ) ),
-				IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 500, 200 ) ) )
+		self.assertEqual(
+			f.toEXRSpace(
+				IECore.Box2i( IECore.V2i( -100, -100 ), IECore.V2i( 501, 301 ) )
+			),
+			IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 500, 200 ) )
+		)
 
-		self.assertEqual( f.toEXRSpace(
-				IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 501, -100 ) ) ),
-				IECore.Box2i( IECore.V2i( -100, 201 ), IECore.V2i( 500, 300 ) ) )
+		self.assertEqual(
+			f.toEXRSpace(
+				IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 501, -100 ) )
+			),
+			IECore.Box2i( IECore.V2i( -100, 201 ), IECore.V2i( 500, 300 ) )
+		)
 
 		for i in range( 0, 1000 ) :
 

--- a/python/GafferImageTest/ImagePlugTest.py
+++ b/python/GafferImageTest/ImagePlugTest.py
@@ -66,26 +66,6 @@ class ImagePlugTest( GafferTest.TestCase ) :
 				expectedResult
 			)
 
-	def testTileStaticMethod( self ) :
-
-		tileSize = GafferImage.ImagePlug.tileSize()
-
-		self.assertEqual(
-			GafferImage.ImagePlug.tileBound( IECore.V2i( 0 ) ),
-			IECore.Box2i(
-				IECore.V2i( 0, 0 ),
-				IECore.V2i( tileSize - 1, tileSize - 1 )
-			)
-		)
-
-		self.assertEqual(
-			GafferImage.ImagePlug.tileBound( IECore.V2i( 0, 1 ) ),
-			IECore.Box2i(
-				IECore.V2i( 0, tileSize ),
-				IECore.V2i( tileSize - 1, tileSize * 2 - 1 )
-			)
-		)
-
 	def testDefaultChannelNamesMethod( self ) :
 
 		channelNames = GafferImage.ImagePlug()['channelNames'].defaultValue()

--- a/python/GafferImageTest/ImageReaderTest.py
+++ b/python/GafferImageTest/ImageReaderTest.py
@@ -61,6 +61,10 @@ class ImageReaderTest( unittest.TestCase ) :
 		image = r.read()
 		exrDisplayWindow = image.displayWindow
 		exrDataWindow = image.dataWindow
+
+		exrDisplayWindow.max += IECore.V2i( 1 )
+		exrDataWindow.max += IECore.V2i( 1 )
+
 		n = GafferImage.ImageReader()
 		n["fileName"].setValue( self.negativeDataWindowFileName )
 		internalDisplayWindow = n["out"]["format"].getValue().getDisplayWindow()
@@ -74,8 +78,8 @@ class ImageReaderTest( unittest.TestCase ) :
 		n = GafferImage.ImageReader()
 		n["fileName"].setValue( self.fileName )
 
-		self.assertEqual( n["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 199, 149 ) ) )
-		self.assertEqual( n["out"]["format"].getValue().getDisplayWindow(), IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 199, 149 ) ) )
+		self.assertEqual( n["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 200, 150 ) ) )
+		self.assertEqual( n["out"]["format"].getValue().getDisplayWindow(), IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 200, 150 ) ) )
 
 		expectedMetadata = IECore.CompoundObject( {
 			"oiio:ColorSpace" : IECore.StringData( 'Linear' ),
@@ -107,8 +111,8 @@ class ImageReaderTest( unittest.TestCase ) :
 		n["fileName"].setValue( self.negativeDisplayWindowFileName )
 		f = n["out"]["format"].getValue()
 		d = n["out"]["dataWindow"].getValue()
-		self.assertEqual( f.getDisplayWindow(), IECore.Box2i( IECore.V2i( -5, -5 ), IECore.V2i( 20, 20 ) ) )
-		self.assertEqual( d, IECore.Box2i( IECore.V2i( 2, -14 ), IECore.V2i( 35, 19 ) ) )
+		self.assertEqual( f.getDisplayWindow(), IECore.Box2i( IECore.V2i( -5, -5 ), IECore.V2i( 21, 21 ) ) )
+		self.assertEqual( d, IECore.Box2i( IECore.V2i( 2, -14 ), IECore.V2i( 36, 20 ) ) )
 
 		expectedImage = IECore.Reader.create( self.negativeDisplayWindowFileName ).read()
 		outImage = n["out"].image()
@@ -120,8 +124,8 @@ class ImageReaderTest( unittest.TestCase ) :
 
 		n = GafferImage.ImageReader()
 		n["fileName"].setValue( self.negativeDataWindowFileName )
-		self.assertEqual( n["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( -25, -30 ), IECore.V2i( 174, 119 ) ) )
-		self.assertEqual( n["out"]["format"].getValue().getDisplayWindow(), IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 199, 149 ) ) )
+		self.assertEqual( n["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( -25, -30 ), IECore.V2i( 175, 120 ) ) )
+		self.assertEqual( n["out"]["format"].getValue().getDisplayWindow(), IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 200, 150 ) ) )
 
 		channelNames = n["out"]["channelNames"].getValue()
 		self.failUnless( isinstance( channelNames, IECore.StringVectorData ) )

--- a/python/GafferImageTest/ImageReaderTest.py
+++ b/python/GafferImageTest/ImageReaderTest.py
@@ -62,16 +62,19 @@ class ImageReaderTest( unittest.TestCase ) :
 		exrDisplayWindow = image.displayWindow
 		exrDataWindow = image.dataWindow
 
-		exrDisplayWindow.max += IECore.V2i( 1 )
-		exrDataWindow.max += IECore.V2i( 1 )
-
 		n = GafferImage.ImageReader()
 		n["fileName"].setValue( self.negativeDataWindowFileName )
-		internalDisplayWindow = n["out"]["format"].getValue().getDisplayWindow()
-		internalDataWindow = n["out"]["dataWindow"].getValue()
-		expectedDataWindow = IECore.Box2i( IECore.V2i( exrDataWindow.min.x, exrDisplayWindow.max.y - exrDataWindow.max.y ), IECore.V2i( exrDataWindow.max.x, exrDisplayWindow.max.y - exrDataWindow.min.y ) )
-		self.assertEqual( internalDisplayWindow, exrDisplayWindow )
-		self.assertEqual( internalDataWindow, expectedDataWindow )
+		gafferFormat = n["out"]["format"].getValue()
+
+		self.assertEqual(
+			gafferFormat.toEXRSpace( gafferFormat.getDisplayWindow() ),
+			exrDisplayWindow,
+		)
+
+		self.assertEqual(
+			gafferFormat.toEXRSpace( n["out"]["dataWindow"].getValue() ),
+			exrDataWindow,
+		)
 
 	def test( self ) :
 

--- a/python/GafferImageTest/ImageStatsTest.py
+++ b/python/GafferImageTest/ImageStatsTest.py
@@ -188,12 +188,12 @@ class ImageStatsTest( unittest.TestCase ) :
 		s["in"].setInput( r["out"] )
 		s["channels"].setValue( IECore.StringVectorData( [ "R", "G", "B", "A" ] ) )
 
-		s["regionOfInterest"].setValue( IECore.Box2i( IECore.V2i( 20, 20 ), IECore.V2i( 24, 24 ) ) )
+		s["regionOfInterest"].setValue( IECore.Box2i( IECore.V2i( 20, 20 ), IECore.V2i( 25, 25 ) ) )
 		self.__assertColour( s["average"].getValue(), IECore.Color4f( 0.5, 0, 0, 0.5 ) )
 		self.__assertColour( s["max"].getValue(), IECore.Color4f( 0.5, 0, 0, 0.5 ) )
 		self.__assertColour( s["min"].getValue(), IECore.Color4f( 0.5, 0, 0, 0.5 ) )
 
-		s["regionOfInterest"].setValue( IECore.Box2i( IECore.V2i( 20, 20 ), IECore.V2i( 40, 29 ) ) )
+		s["regionOfInterest"].setValue( IECore.Box2i( IECore.V2i( 20, 20 ), IECore.V2i( 41, 30 ) ) )
 		self.__assertColour( s["average"].getValue(), IECore.Color4f( 0.4048, 0.1905, 0, 0.5952 ) )
 		self.__assertColour( s["min"].getValue(), IECore.Color4f( 0.25, 0, 0, 0.5 ) )
 		self.__assertColour( s["max"].getValue(), IECore.Color4f( 0.5, 0.5, 0, 0.75 ) )

--- a/python/GafferImageTest/ImageWriterTest.py
+++ b/python/GafferImageTest/ImageWriterTest.py
@@ -691,6 +691,27 @@ class ImageWriterTest( unittest.TestCase ) :
 		self.assertTrue( os.path.isfile( s["w1"]["fileName"].getValue() ) )
 		self.assertTrue( os.path.isfile( s["w2"]["fileName"].getValue() ) )
 
+	def testBackgroundDispatch( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["c"] = GafferImage.Constant()
+
+		s["w"] = GafferImage.ImageWriter()
+		s["w"]["in"].setInput( s["c"]["out"] )
+		s["w"]["fileName"].setValue( self.__testDir + "/test.exr" )
+
+		d = Gaffer.LocalDispatcher()
+		d["jobsDirectory"].setValue( self.__testDir + "/jobs" )
+		d["executeInBackground"].setValue( True )
+
+		with s.context() :
+			d.dispatch( [ s["w"] ] )
+
+		d.jobPool().waitForAll()
+
+		self.assertTrue( os.path.isfile( s["w"]["fileName"].getValue() ) )
+
 	def tearDown( self ) :
 
 		if os.path.isdir( self.__testDir ) :

--- a/python/GafferImageTest/ImageWriterTest.py
+++ b/python/GafferImageTest/ImageWriterTest.py
@@ -312,15 +312,15 @@ class ImageWriterTest( unittest.TestCase ) :
 
 			self.failUnless( os.path.exists( testFile ) )
 			i = IECore.Reader.create( testFile ).read()
-			i.blindData().clear()
 
-			# Because i.displayWindow is straight from IECore,
-			# it will be inclusive, so add 1 to the max value
-			# to make it line up with the Gaffer standard
-			expectedDisplayWindow = i.displayWindow
-			expectedDisplayWindow.max += IECore.V2i( 1 )
+			# Cortex uses the EXR convention, which differs
+			# from Gaffer's, so we use the conversion methods to
+			# check that the image windows are as expected.
 
-			self.assertEqual( expectedDisplayWindow, format.getDisplayWindow() )
+			self.assertEqual(
+				format.toEXRSpace( format.getDisplayWindow() ),
+				i.displayWindow
+			)
 
 	def testHash( self ) :
 

--- a/python/GafferImageTest/ReformatTest.py
+++ b/python/GafferImageTest/ReformatTest.py
@@ -92,7 +92,7 @@ class ReformatTest( unittest.TestCase ) :
 		reformat["format"].setValue( GafferImage.Format( 150, 125, 1. ) )
 		reformat["in"].setInput( read["out"] )
 		reformatWindow = reformat["out"]["dataWindow"].getValue()
-		self.assertEqual( reformatWindow, IECore.Box2i( IECore.V2i( 45, 37 ), IECore.V2i( 119, 99 )  ) )
+		self.assertEqual( reformatWindow, IECore.Box2i( IECore.V2i( 45, 37 ), IECore.V2i( 120, 100 )  ) )
 
 	def testNegativeDisplayWindowReformat( self ) :
 
@@ -101,7 +101,7 @@ class ReformatTest( unittest.TestCase ) :
 
 		# Resize the image and check the size of the output data window.
 		reformat = GafferImage.Reformat()
-		f = GafferImage.Format( IECore.Box2i( IECore.V2i( -22, -13 ), IECore.V2i( 33, 58 ) ), 1. )
+		f = GafferImage.Format( IECore.Box2i( IECore.V2i( -22, -13 ), IECore.V2i( 34, 59 ) ), 1. )
 		reformat["format"].setValue( f )
 		reformat["in"].setInput( read["out"] )
 		reformat["filter"].setValue( "Bilinear" )
@@ -110,7 +110,7 @@ class ReformatTest( unittest.TestCase ) :
 		reformatFormat = reformat["out"]["format"].getValue()
 
 		# Check the data and display windows.
-		self.assertEqual( reformatDataWindow, IECore.Box2i( IECore.V2i( -66, -97 ), IECore.V2i( 365, 319 ) ) )
+		self.assertEqual( reformatDataWindow, IECore.Box2i( IECore.V2i( -66, -97 ), IECore.V2i( 366, 320 ) ) )
 		self.assertEqual( reformatFormat, f )
 
 		# Check the image data.

--- a/python/GafferImageTest/ResampleTest.py
+++ b/python/GafferImageTest/ResampleTest.py
@@ -76,8 +76,7 @@ class ResampleTest( GafferTest.TestCase ) :
 
 			resample = GafferImage.Resample()
 			resample["in"].setInput( reader["out"] )
-			## \todo Adjust for #1438
-			resample["dataWindow"].setValue( IECore.Box2f( IECore.V2f( 0 ), IECore.V2f( size.x, size.y ) - IECore.V2f( 1 ) ) )
+			resample["dataWindow"].setValue( IECore.Box2f( IECore.V2f( 0 ), IECore.V2f( size.x, size.y ) ) )
 			resample["filter"].setValue( filter )
 			resample["boundingMode"].setValue( GafferImage.Sampler.BoundingMode.Clamp )
 

--- a/python/GafferImageTest/ResizeTest.py
+++ b/python/GafferImageTest/ResizeTest.py
@@ -127,8 +127,7 @@ class ResizeTest( GafferTest.TestCase ) :
 	def testMismatchedDataWindow( self ) :
 
 		constant = GafferImage.Constant()
-		## \todo Adjust for #1438.
-		constant["format"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 255, 255 ) ), 1 ) )
+		constant["format"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 256, 256 ) ), 1 ) )
 
 		crop = GafferImage.Crop()
 		crop["in"].setInput( constant["out"] )
@@ -139,18 +138,17 @@ class ResizeTest( GafferTest.TestCase ) :
 
 		resize = GafferImage.Resize()
 		resize["in"].setInput( crop["out"] )
-		resize["format"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 511, 511 ) ), 1 ) )
+		resize["format"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 512, 512 ) ), 1 ) )
 
 		self.assertEqual(
 			resize["out"]["dataWindow"].getValue(),
-			IECore.Box2i( IECore.V2i( 128 ), IECore.V2i( 255 ) )
+			IECore.Box2i( IECore.V2i( 128 ), IECore.V2i( 256 ) )
 		)
 
 	def testDataWindowRounding( self ) :
 
 		constant = GafferImage.Constant()
-		## \todo Adjust for #1438.
-		constant["format"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 199, 149 ) ), 1 ) )
+		constant["format"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 200, 150 ) ), 1 ) )
 
 		resize = GafferImage.Resize()
 		resize["in"].setInput( constant["out"] )
@@ -159,14 +157,14 @@ class ResizeTest( GafferTest.TestCase ) :
 			resize["format"].setValue( GafferImage.Format( width, 150, 1 ) )
 			dataWindow = resize["out"]["dataWindow"].getValue()
 			self.assertEqual( dataWindow.min.x, 0 )
-			self.assertEqual( dataWindow.max.x, width - 1 )
+			self.assertEqual( dataWindow.max.x, width )
 
 		resize["fitMode"].setValue( resize.FitMode.Vertical )
 		for height in range( 1, 2000 ) :
 			resize["format"].setValue( GafferImage.Format( 200, height, 1 ) )
 			dataWindow = resize["out"]["dataWindow"].getValue()
 			self.assertEqual( dataWindow.min.y, 0 )
-			self.assertEqual( dataWindow.max.y, height - 1 )
+			self.assertEqual( dataWindow.max.y, height )
 
 	def testFilterAffectsChannelData( self ) :
 

--- a/python/GafferImageTest/SamplerTest.py
+++ b/python/GafferImageTest/SamplerTest.py
@@ -114,12 +114,12 @@ class SamplerTest( unittest.TestCase ) :
 		testCases = [
 			( bounds.min.x-1, bounds.min.y ),
 			( bounds.min.x, bounds.min.y-1 ),
-			( bounds.max.x, bounds.max.y+1 ),
-			( bounds.max.x+1, bounds.max.y ),
-			( bounds.min.x-1, bounds.max.y ),
-			( bounds.min.x, bounds.max.y+1 ),
-			( bounds.max.x+1, bounds.min.y ),
-			( bounds.max.x, bounds.min.y-1 )
+			( bounds.max.x-1, bounds.max.y ),
+			( bounds.max.x, bounds.max.y-1 ),
+			( bounds.min.x-1, bounds.max.y-1 ),
+			( bounds.min.x, bounds.max.y ),
+			( bounds.max.x, bounds.min.y ),
+			( bounds.max.x-1, bounds.min.y-1 )
 		]
 
 		self.assertTrue( "Box" in GafferImage.Filter.filters() )
@@ -132,9 +132,9 @@ class SamplerTest( unittest.TestCase ) :
 
 			# Check that the bounding pixels are non zero.
 			self.assertNotEqual( s.sample( bounds.min.x+.5, bounds.min.y+.5 ), 0. )
-			self.assertNotEqual( s.sample( bounds.max.x+.5, bounds.max.y+.5 ), 0. )
-			self.assertNotEqual( s.sample( bounds.min.x+.5, bounds.max.y+.5 ), 0. )
-			self.assertNotEqual( s.sample( bounds.max.x+.5, bounds.min.y+.5 ), 0. )
+			self.assertNotEqual( s.sample( bounds.max.x-.5, bounds.max.y-.5 ), 0. )
+			self.assertNotEqual( s.sample( bounds.min.x+.5, bounds.max.y-.5 ), 0. )
+			self.assertNotEqual( s.sample( bounds.max.x-.5, bounds.min.y+.5 ), 0. )
 
 			# Sample out of bounds and assert that a zero is returned.
 			for x, y in testCases :
@@ -161,19 +161,19 @@ class SamplerTest( unittest.TestCase ) :
 
 			# Get the values of the corner pixels.
 			bl = s.sample( bounds.min.x+.5, bounds.min.y+.5 )
-			br = s.sample( bounds.max.x+.5, bounds.min.y+.5 )
-			tr = s.sample( bounds.max.x+.5, bounds.max.y+.5 )
-			tl = s.sample( bounds.min.x+.5, bounds.max.y+.5 )
+			br = s.sample( bounds.max.x-.5, bounds.min.y+.5 )
+			tr = s.sample( bounds.max.x-.5, bounds.max.y-.5 )
+			tl = s.sample( bounds.min.x+.5, bounds.max.y-.5 )
 
 			# Sample out of bounds and assert that the same value as the nearest pixel is returned.
 			self.assertEqual( s.sample( bounds.min.x-1, bounds.min.y ), bl )
 			self.assertEqual( s.sample( bounds.min.x, bounds.min.y-1 ), bl )
-			self.assertEqual( s.sample( bounds.max.x, bounds.max.y+1 ), tr )
-			self.assertEqual( s.sample( bounds.max.x+1, bounds.max.y ), tr )
-			self.assertEqual( s.sample( bounds.min.x-1, bounds.max.y ), tl )
-			self.assertEqual( s.sample( bounds.min.x, bounds.max.y+1 ), tl )
-			self.assertEqual( s.sample( bounds.max.x+1, bounds.min.y ), br )
-			self.assertEqual( s.sample( bounds.max.x, bounds.min.y-1 ), br )
+			self.assertEqual( s.sample( bounds.max.x-1, bounds.max.y ), tr )
+			self.assertEqual( s.sample( bounds.max.x, bounds.max.y-1 ), tr )
+			self.assertEqual( s.sample( bounds.min.x-1, bounds.max.y-1 ), tl )
+			self.assertEqual( s.sample( bounds.min.x, bounds.max.y ), tl )
+			self.assertEqual( s.sample( bounds.max.x, bounds.min.y ), br )
+			self.assertEqual( s.sample( bounds.max.x-1, bounds.min.y-1 ), br )
 
 	# Test that the hash() method accumulates all of the hashes of the tiles within the sample area
 	# for a large number of different sample areas.
@@ -217,11 +217,10 @@ class SamplerTest( unittest.TestCase ) :
 		# Get the hash from the tiles within our desired sample area.
 		with c :
 			y = box.min.y
-			while y <= box.max.y :
+			while y < box.max.y :
 				x = box.min.x
-				while x <= box.max.x :
+				while x < box.max.x :
 					tileOrigin = GafferImage.ImagePlug.tileOrigin( IECore.V2i( x, y ) )
-					tile = IECore.Box2i( tileOrigin, tileOrigin + IECore.V2i( GafferImage.ImagePlug.tileSize()-1 ) )
 					h2.append( plug.channelDataHash( channel, tileOrigin ) )
 					x += GafferImage.ImagePlug.tileSize()
 				y += GafferImage.ImagePlug.tileSize()

--- a/python/GafferImageTest/scripts/formatCompatibility-0.15.0.0.gfr
+++ b/python/GafferImageTest/scripts/formatCompatibility-0.15.0.0.gfr
@@ -1,0 +1,32 @@
+import Gaffer
+import GafferImage
+import IECore
+
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:majorVersion", 15, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:minorVersion", 0, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:patchVersion", 0, persistent=False )
+
+__children = {}
+
+parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "projectName", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectName"].addChild( Gaffer.StringPlug( "name", defaultValue = 'project:name', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectName"].addChild( Gaffer.StringPlug( "value", defaultValue = 'default', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "projectRootDirectory", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "name", defaultValue = 'project:rootDirectory', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "value", defaultValue = '$HOME/gaffer/projects/${project:name}', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["defaultFormat"] = GafferImage.FormatPlug( "defaultFormat", defaultValue = GafferImage.Format(), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, )
+parent.addChild( __children["defaultFormat"] )
+__children["defaultFormat"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 0, 0 ), IECore.V2i( 1919, 1079 ) ), 1.000 ) )
+__children["c"] = GafferImage.Constant( "c" )
+parent.addChild( __children["c"] )
+__children["c"]["format"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 0, 0 ), IECore.V2i( 1919, 1079 ) ), 1.000 ) )
+__children["c"]["color"].setValue( IECore.Color4f( 0.25, 0, 0, 1 ) )
+__children["c"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = IECore.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["c"]["__uiPosition"].setValue( IECore.V2f( -4, 7.79999733 ) )
+parent["variables"]["projectName"]["name"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
+parent["variables"]["projectRootDirectory"]["name"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
+
+
+del __children
+

--- a/python/GafferImageUI/CropUI.py
+++ b/python/GafferImageUI/CropUI.py
@@ -49,11 +49,7 @@ def postCreateCrop( node, menu ) :
 	else:
 		cropFormat = node.scriptNode()['defaultFormat'].getValue()
 
-	cropArea = cropFormat.getDisplayWindow()
-	cropArea.max += IECore.V2i( 1 )
-
-	node['area'].setValue( cropArea )
-
+	node['area'].setValue( cropFormat.getDisplayWindow() )
 
 Gaffer.Metadata.registerNode(
 

--- a/src/GafferImage/Crop.cpp
+++ b/src/GafferImage/Crop.cpp
@@ -259,10 +259,6 @@ void Crop::compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) 
 			default:
 			{
 				cropWindow = areaPlug()->getValue();
-				// Because we are treating the areaPlug as exclusive, but the
-				// cropWindow is inclusive, need to subtract 1 from the max
-				// values.
-				cropWindow.max -= Imath::V2i( 1 );
 				break;
 			}
 		}

--- a/src/GafferImage/Display.cpp
+++ b/src/GafferImage/Display.cpp
@@ -164,7 +164,7 @@ class GafferDisplayDriver : public IECore::DisplayDriver
 							int srcY = m_gafferFormat.toEXRSpace( y );
 							size_t srcIndex = ( ( srcY - box.min.y ) * ( box.size().x + 1 ) + ( transferBound.min.x - box.min.x ) ) * numChannels + channelIndex;
 							size_t dstIndex = ( y - tileBound.min.y ) * ImagePlug::tileSize() + transferBound.min.x - tileBound.min.x;
-							const size_t srcEndIndex = srcIndex + ( transferBound.size().x ) * numChannels;
+							const size_t srcEndIndex = srcIndex + transferBound.size().x * numChannels;
 							while( srcIndex < srcEndIndex )
 							{
 								updatedTile[dstIndex] = data[srcIndex];

--- a/src/GafferImage/ImagePlug.cpp
+++ b/src/GafferImage/ImagePlug.cpp
@@ -333,15 +333,15 @@ IECore::ImagePrimitivePtr ImagePlug::image() const
 {
 	Format format = formatPlug()->getValue();
 	Box2i dataWindow = dataWindowPlug()->getValue();
-	Box2i newDataWindow( Imath::V2i(0) );
+	Box2i newDataWindow( Imath::V2i( 0 ) );
 
-	if( dataWindow.isEmpty() )
+	if( dataWindow.hasVolume() )
 	{
-		dataWindow = Box2i( Imath::V2i(0) );
+		newDataWindow = format.toEXRSpace( dataWindow );
 	}
 	else
 	{
-		newDataWindow = format.toEXRSpace( dataWindow );
+		dataWindow = newDataWindow;
 	}
 
 	// use the default format if we don't have an explicit one.

--- a/src/GafferImage/ImagePlug.cpp
+++ b/src/GafferImage/ImagePlug.cpp
@@ -334,7 +334,6 @@ IECore::ImagePrimitivePtr ImagePlug::image() const
 	Format format = formatPlug()->getValue();
 	Box2i dataWindow = dataWindowPlug()->getValue();
 	Box2i newDataWindow( Imath::V2i(0) );
-	Box2i newDisplayWindow = format.getDisplayWindow();
 
 	if( dataWindow.isEmpty() )
 	{
@@ -342,7 +341,7 @@ IECore::ImagePrimitivePtr ImagePlug::image() const
 	}
 	else
 	{
-		newDataWindow = format.yDownToFormatSpace( dataWindow );
+		newDataWindow = format.toEXRSpace( dataWindow );
 	}
 
 	// use the default format if we don't have an explicit one.
@@ -351,13 +350,9 @@ IECore::ImagePrimitivePtr ImagePlug::image() const
 	if( format.getDisplayWindow().isEmpty() )
 	{
 		format = Context::current()->get<Format>( Format::defaultFormatContextName, Format() );
-		newDisplayWindow = format.getDisplayWindow();
 	}
 
-	// Convert data and display windows to be inclusive bounds
-	// rather than the exclusive (max) bounds of Gaffer
-	newDataWindow.max -= V2i( 1 );
-	newDisplayWindow.max -= V2i( 1 );
+	Box2i newDisplayWindow = format.toEXRSpace( format.getDisplayWindow() );
 
 	ImagePrimitivePtr result = new ImagePrimitive( newDataWindow, newDisplayWindow );
 

--- a/src/GafferImage/ImageReader.cpp
+++ b/src/GafferImage/ImageReader.cpp
@@ -122,7 +122,7 @@ void oiioParameterListToMetadata( const ImageIOParameterList &paramList, Compoun
 	for ( ImageIOParameterList::const_iterator it = paramList.begin(); it != paramList.end(); ++it )
 	{
 		ObjectPtr value = NULL;
-		
+
 		const TypeDesc &type = it->type();
 		switch ( type.basetype )
 		{
@@ -278,7 +278,7 @@ void oiioParameterListToMetadata( const ImageIOParameterList &paramList, Compoun
 				break;
 			}
 		}
-		
+
 		if ( value )
 		{
 			members[ it->name().string() ] = value;
@@ -308,7 +308,7 @@ ImageReader::ImageReader( const std::string &name )
 	{
 		(*it)->setFlags( Plug::Cacheable, false );
 	}
-	
+
 	plugSetSignal().connect( boost::bind( &ImageReader::plugSet, this, ::_1 ) );
 }
 
@@ -391,7 +391,7 @@ GafferImage::Format ImageReader::computeFormat( const Gaffer::Context *context, 
 	return GafferImage::Format(
 		Imath::Box2i(
 			Imath::V2i( spec->full_x, spec->full_y ),
-			Imath::V2i( spec->full_x + spec->full_width - 1, spec->full_y + spec->full_height - 1 )
+			Imath::V2i( spec->full_x + spec->full_width, spec->full_y + spec->full_height )
 		),
 		spec->get_float_attribute( "PixelAspectRatio", 1.0f )
 	);
@@ -412,8 +412,8 @@ Imath::Box2i ImageReader::computeDataWindow( const Gaffer::Context *context, con
 		return Box2i();
 	}
 
-	Format format( Imath::Box2i( Imath::V2i( spec->full_x, spec->full_y ), Imath::V2i( spec->full_width + spec->full_x - 1, spec->full_height + spec->full_y - 1 ) ) );
-	Imath::Box2i dataWindow( Imath::V2i( spec->x, spec->y ), Imath::V2i( spec->width + spec->x - 1, spec->height + spec->y - 1 ) );
+	Format format( Imath::Box2i( Imath::V2i( spec->full_x, spec->full_y ), Imath::V2i( spec->full_width + spec->full_x, spec->full_height + spec->full_y ) ) );
+	Imath::Box2i dataWindow( Imath::V2i( spec->x, spec->y ), Imath::V2i( spec->width + spec->x, spec->height + spec->y ) );
 
 	return format.yDownToFormatSpace( dataWindow );
 }
@@ -432,10 +432,10 @@ IECore::ConstCompoundObjectPtr ImageReader::computeMetadata( const Gaffer::Conte
 	{
 		return parent->metadataPlug()->defaultValue();
 	}
-	
+
 	CompoundObjectPtr result = new CompoundObject;
 	oiioParameterListToMetadata( spec->extra_attribs, result.get() );
-	
+
 	return result;
 }
 
@@ -485,7 +485,7 @@ IECore::ConstFloatVectorDataPtr ImageReader::computeChannelData( const std::stri
 		}
 	}
 
-	Format format( Imath::Box2i( Imath::V2i( spec->full_x, spec->full_y ), Imath::V2i( spec->full_width + spec->full_x - 1, spec->full_height + spec->full_y - 1 ) ) );
+	Format format( Imath::Box2i( Imath::V2i( spec->full_x, spec->full_y ), Imath::V2i( spec->full_width + spec->full_x, spec->full_height + spec->full_y ) ) );
 	const int newY = format.formatToYDownSpace( tileOrigin.y + ImagePlug::tileSize() - 1 );
 
 	std::vector<float> channelData( ImagePlug::tileSize() * ImagePlug::tileSize() );

--- a/src/GafferImage/ImageReader.cpp
+++ b/src/GafferImage/ImageReader.cpp
@@ -413,9 +413,9 @@ Imath::Box2i ImageReader::computeDataWindow( const Gaffer::Context *context, con
 	}
 
 	Format format( Imath::Box2i( Imath::V2i( spec->full_x, spec->full_y ), Imath::V2i( spec->full_width + spec->full_x, spec->full_height + spec->full_y ) ) );
-	Imath::Box2i dataWindow( Imath::V2i( spec->x, spec->y ), Imath::V2i( spec->width + spec->x, spec->height + spec->y ) );
+	Imath::Box2i dataWindow( Imath::V2i( spec->x, spec->y ), Imath::V2i( spec->width + spec->x - 1, spec->height + spec->y - 1 ) );
 
-	return format.yDownToFormatSpace( dataWindow );
+	return format.fromEXRSpace( dataWindow );
 }
 
 void ImageReader::hashMetadata( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const
@@ -486,7 +486,7 @@ IECore::ConstFloatVectorDataPtr ImageReader::computeChannelData( const std::stri
 	}
 
 	Format format( Imath::Box2i( Imath::V2i( spec->full_x, spec->full_y ), Imath::V2i( spec->full_width + spec->full_x, spec->full_height + spec->full_y ) ) );
-	const int newY = format.formatToYDownSpace( tileOrigin.y + ImagePlug::tileSize() - 1 );
+	const int newY = format.toEXRSpace( tileOrigin.y + ImagePlug::tileSize() - 1 );
 
 	std::vector<float> channelData( ImagePlug::tileSize() * ImagePlug::tileSize() );
 	size_t channelIndex = channelIt - spec->channelnames.begin();

--- a/src/GafferImage/ImageSampler.cpp
+++ b/src/GafferImage/ImageSampler.cpp
@@ -155,7 +155,7 @@ void ImageSampler::compute( Gaffer::ValuePlug *output, const Gaffer::Context *co
 			V2f pixel = pixelPlug()->getValue();
 			Box2i sampleWindow;
 			sampleWindow.extendBy( V2i( pixel ) - V2i( 1 ) );
-			sampleWindow.extendBy( V2i( pixel ) + V2i( 1 ) );
+			sampleWindow.extendBy( V2i( pixel ) );
 			Sampler sampler( imagePlug(), channel, sampleWindow, Filter::create( filterPlug()->getValue() ) );
 			sample = sampler.sample( pixel.x, pixel.y );
 		}

--- a/src/GafferImage/ImageStats.cpp
+++ b/src/GafferImage/ImageStats.cpp
@@ -332,9 +332,9 @@ void ImageStats::compute( ValuePlug *output, const Context *context ) const
 	float average = 0.f;
 
 	double sum = 0.;
-	for( int y = regionOfInterest.min.y; y <= regionOfInterest.max.y; ++y )
+	for( int y = regionOfInterest.min.y; y < regionOfInterest.max.y; ++y )
 	{
-		for( int x = regionOfInterest.min.x; x <= regionOfInterest.max.x; ++x )
+		for( int x = regionOfInterest.min.x; x < regionOfInterest.max.x; ++x )
 		{
 			float v = s.sample( x, y );
 			min = std::min( v, min );
@@ -342,7 +342,7 @@ void ImageStats::compute( ValuePlug *output, const Context *context ) const
 			sum += v;
 		}
 	}
-	average = sum / double( (regionOfInterest.size().x+1) * (regionOfInterest.size().y+1) );
+	average = sum / double( (regionOfInterest.size().x) * (regionOfInterest.size().y) );
 
 	if ( minPlug()->getChild( channelIndex ) == output )
 	{

--- a/src/GafferImage/ImageWriter.cpp
+++ b/src/GafferImage/ImageWriter.cpp
@@ -224,15 +224,15 @@ ImageSpec createImageSpec( const ImageWriter *node, const boost::shared_ptr<Imag
 	// Specify the display window.
 	spec.full_x = displayWindow.min.x;
 	spec.full_y = displayWindow.min.y;
-	spec.full_width = displayWindow.size().x+1;
-	spec.full_height = displayWindow.size().y+1;
+	spec.full_width = displayWindow.size().x + 1;
+	spec.full_height = displayWindow.size().y + 1;
 
 	if ( supportsDisplayWindow && dataWindow.hasVolume() )
 	{
 		spec.x = dataWindow.min.x;
 		spec.y = dataWindow.min.y;
-		spec.width = dataWindow.size().x+1;
-		spec.height = dataWindow.size().y+1;
+		spec.width = dataWindow.size().x + 1;
+		spec.height = dataWindow.size().y + 1;
 	}
 	else
 	{

--- a/src/GafferImage/Resample.cpp
+++ b/src/GafferImage/Resample.cpp
@@ -97,9 +97,8 @@ Box2i box2fToBox2i( const Box2f &b )
 // coordinates to input coordinates.
 void ratioAndOffset( const Box2f &dstDataWindow, const Box2i &srcDataWindow, V2f &ratio, V2f &offset )
 {
-	/// \todo Adjust for #1438.
-	const V2f dstSize = dstDataWindow.size() + V2i( 1 );
-	const V2f srcSize = srcDataWindow.size() + V2i( 1 );
+	const V2f dstSize = dstDataWindow.size();
+	const V2f srcSize = srcDataWindow.size();
 
 	ratio = dstSize / srcSize;
 	offset = srcDataWindow.min - dstDataWindow.min / ratio;

--- a/src/GafferImage/Resize.cpp
+++ b/src/GafferImage/Resize.cpp
@@ -205,8 +205,7 @@ void Resize::compute( ValuePlug *output, const Context *context ) const
 		const Box2i inDataWindow = inPlug()->dataWindowPlug()->getValue();
 		Box2f outDataWindow(
 			V2f( inDataWindow.min ) * dataWindowScale + dataWindowOffset,
-			/// \todo Adjust for #1438
-			V2f( inDataWindow.max + V2i( 1 ) ) * dataWindowScale + dataWindowOffset - V2f( 1.0f )
+			V2f( inDataWindow.max ) * dataWindowScale + dataWindowOffset
 		);
 
 		// It's important that we use floating point data windows in the Resample node

--- a/src/GafferImage/Sampler.cpp
+++ b/src/GafferImage/Sampler.cpp
@@ -75,21 +75,22 @@ void Sampler::setSampleWindow( const Imath::Box2i &window )
 	m_sampleWindow = boxIntersection( dataWindow, m_sampleWindow );
 
 	// The area that we actually have in the cache.
+	// Exclusive, so max value points at the next tile over
 	m_cacheWindow = Imath::Box2i(
 		Imath::V2i( ImagePlug::tileOrigin( m_sampleWindow.min ) ),
-		Imath::V2i( ImagePlug::tileOrigin( m_sampleWindow.max ) )
+		Imath::V2i( ImagePlug::tileOrigin( m_sampleWindow.max - Imath::V2i( 1 ) ) + Imath::V2i( ImagePlug::tileSize() ) )
 	);
 
-	m_cacheWidth = ( m_cacheWindow.max.x - m_cacheWindow.min.x ) / ImagePlug::tileSize() + 1;
-	int cacheHeight = ( m_cacheWindow.max.y - m_cacheWindow.min.y ) / ImagePlug::tileSize() + 1;
+	m_cacheWidth = int( ceil( float( m_cacheWindow.size().x ) / ImagePlug::tileSize() ) );
+	int cacheHeight = int( ceil( float( m_cacheWindow.size().y ) / ImagePlug::tileSize() ) );
 	m_dataCache.resize( m_cacheWidth * cacheHeight, NULL );
 }
 
 void Sampler::hash( IECore::MurmurHash &h ) const
 {
-	for ( int x = m_cacheWindow.min.x; x <= m_cacheWindow.max.x; x += GafferImage::ImagePlug::tileSize() )
+	for ( int x = m_cacheWindow.min.x; x < m_cacheWindow.max.x; x += GafferImage::ImagePlug::tileSize() )
 	{
-		for ( int y = m_cacheWindow.min.y; y <= m_cacheWindow.max.y; y += GafferImage::ImagePlug::tileSize() )
+		for ( int y = m_cacheWindow.min.y; y < m_cacheWindow.max.y; y += GafferImage::ImagePlug::tileSize() )
 		{
 			h.append( m_plug->channelDataHash( m_channelName, Imath::V2i( x, y ) ) );
 		}

--- a/src/GafferImageBindings/FormatBinding.cpp
+++ b/src/GafferImageBindings/FormatBinding.cpp
@@ -137,13 +137,13 @@ void bindFormat()
 		.def( "getDisplayWindow", &Format::getDisplayWindow, return_value_policy<copy_const_reference>() )
 		.def( "setDisplayWindow", &Format::setDisplayWindow )
 
-		.def( "yDownToFormatSpace", ( int (Format::*)( int ) const )&Format::yDownToFormatSpace )
-		.def( "yDownToFormatSpace", ( Imath::V2i (Format::*)( const Imath::V2i & ) const )&Format::yDownToFormatSpace )
-		.def( "yDownToFormatSpace", ( Imath::Box2i (Format::*)( const Imath::Box2i & ) const )&Format::yDownToFormatSpace )
+		.def( "fromEXRSpace", ( int (Format::*)( int ) const )&Format::fromEXRSpace )
+		.def( "fromEXRSpace", ( Imath::V2i (Format::*)( const Imath::V2i & ) const )&Format::fromEXRSpace )
+		.def( "fromEXRSpace", ( Imath::Box2i (Format::*)( const Imath::Box2i & ) const )&Format::fromEXRSpace )
 
-		.def( "formatToYDownSpace", ( int (Format::*)( int ) const )&Format::formatToYDownSpace )
-		.def( "formatToYDownSpace", ( Imath::V2i (Format::*)( const Imath::V2i & ) const )&Format::formatToYDownSpace )
-		.def( "formatToYDownSpace", ( Imath::Box2i (Format::*)( const Imath::Box2i & ) const )&Format::formatToYDownSpace )
+		.def( "toEXRSpace", ( int (Format::*)( int ) const )&Format::toEXRSpace )
+		.def( "toEXRSpace", ( Imath::V2i (Format::*)( const Imath::V2i & ) const )&Format::toEXRSpace )
+		.def( "toEXRSpace", ( Imath::Box2i (Format::*)( const Imath::Box2i & ) const )&Format::toEXRSpace )
 
 		// Static bindings
 		.def( "formatAddedSignal", &Format::formatAddedSignal, return_value_policy<reference_existing_object>() ).staticmethod( "formatAddedSignal" )

--- a/src/GafferImageBindings/FormatBinding.cpp
+++ b/src/GafferImageBindings/FormatBinding.cpp
@@ -125,9 +125,12 @@ void bindFormat()
 	static void (*setDefaultFormatPtr1)( ScriptNode *scriptNode, const Format & ) (&Format::setDefaultFormat);
 	static void (*setDefaultFormatPtr2)( ScriptNode *scriptNode, const std::string & ) (&Format::setDefaultFormat);
 
-	class_<Format>( "Format", init<int, int, double>() )
+	class_<Format>( "Format", init<int, int >() )
 
+		.def( init< int, int, double >() )
+		.def( init< const Imath::Box2i & >() )
 		.def( init< const Imath::Box2i &, double >() )
+		.def( init< const Imath::Box2i &, double, bool >() )
 		.def( init<>() )
 
 		.def( "width", &Format::width )

--- a/src/GafferImageBindings/FormatBinding.cpp
+++ b/src/GafferImageBindings/FormatBinding.cpp
@@ -93,6 +93,16 @@ std::string formatRepr( const GafferImage::Format &format )
 	{
 		return std::string( "GafferImage.Format()" );
 	}
+	else if ( format.getDisplayWindow().min == Imath::V2i( 0 ) )
+	{
+		Imath::Box2i box( format.getDisplayWindow() );
+		return std::string(
+			boost::str( boost::format(
+				"GafferImage.Format( %d, %d, %.3f )" )
+				% box.max.x % box.max.y % format.getPixelAspect()
+			)
+		);
+	}
 	else
 	{
 		Imath::Box2i box( format.getDisplayWindow() );

--- a/src/GafferImageBindings/ImagePlugBinding.cpp
+++ b/src/GafferImageBindings/ImagePlugBinding.cpp
@@ -83,7 +83,6 @@ void GafferImageBindings::bindImagePlug()
 		.def( "image", &image )
 		.def( "imageHash", &ImagePlug::imageHash )
 		.def( "tileSize", &ImagePlug::tileSize ).staticmethod( "tileSize" )
-		.def( "tileBound", &ImagePlug::tileBound ).staticmethod( "tileBound" )
 		.def( "tileOrigin", &ImagePlug::tileOrigin ).staticmethod( "tileOrigin" )
 	;
 

--- a/src/GafferImageUI/ImageView.cpp
+++ b/src/GafferImageUI/ImageView.cpp
@@ -614,7 +614,7 @@ class ImageViewGadget : public GafferUI::Gadget
 
 		virtual void doRender( const Style *style ) const
 		{
-			if( !m_texture && m_dataWindow.hasVolume() )
+			if( !m_texture )
 			{
 				// convert image to texture
 				ToGLTextureConverterPtr converter = new ToGLTextureConverter( boost::static_pointer_cast<const ImagePrimitive>( m_image ), true );
@@ -645,7 +645,6 @@ class ImageViewGadget : public GafferUI::Gadget
 			}
 
 			// Draw the image data.
-			if ( m_texture )
 			{
 				// Get the bounds of the data window in Gadget space.
 				Box2f b( V2f( m_dataBound.min.x, m_dataBound.min.y ), V2f( m_dataBound.max.x, m_dataBound.max.y ) );
@@ -715,7 +714,7 @@ class ImageViewGadget : public GafferUI::Gadget
 			glLoadIdentity();
 
 			// Draw the data window if it is different to the display window.
-			if ( m_dataWindow != m_displayWindow && m_dataWindow.hasVolume() )
+			if ( m_dataWindow != m_displayWindow && m_dataWindow.size() != Imath::V2i( 1 ) )
 			{
 				color = Color4f( .2f, .2f, .2f, 1.f );
 				glColor( color );

--- a/src/GafferImageUI/ImageView.cpp
+++ b/src/GafferImageUI/ImageView.cpp
@@ -47,7 +47,7 @@
 #include "IECore/BoxOps.h"
 #include "IECore/BoxAlgo.h"
 
-#include "IECoreGL/ColorTexture.h"
+#include "IECoreGL/ToGLTextureConverter.h"
 #include "IECoreGL/TextureLoader.h"
 #include "IECoreGL/Texture.h"
 #include "IECoreGL/ShaderLoader.h"
@@ -617,8 +617,8 @@ class ImageViewGadget : public GafferUI::Gadget
 			if( !m_texture && m_dataWindow.hasVolume() )
 			{
 				// convert image to texture
-				m_texture = new IECoreGL::ColorTexture( m_image.get(), /* mipMap = */ false );
-
+				ToGLTextureConverterPtr converter = new ToGLTextureConverter( boost::static_pointer_cast<const ImagePrimitive>( m_image ), true );
+				m_texture = IECore::runTimeCast<IECoreGL::Texture>( converter->convert() );
 				{
 					Texture::ScopedBinding scope( *m_texture );
 					glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR );

--- a/src/GafferImageUI/ImageView.cpp
+++ b/src/GafferImageUI/ImageView.cpp
@@ -47,7 +47,7 @@
 #include "IECore/BoxOps.h"
 #include "IECore/BoxAlgo.h"
 
-#include "IECoreGL/ToGLTextureConverter.h"
+#include "IECoreGL/ColorTexture.h"
 #include "IECoreGL/TextureLoader.h"
 #include "IECoreGL/Texture.h"
 #include "IECoreGL/ShaderLoader.h"
@@ -127,19 +127,22 @@ class ImageViewGadget : public GafferUI::Gadget
 				m_imageSampler( imageSampler ),
 				m_context( context )
 		{
-			V2f displayWindowCenter( ( m_displayWindow.min + m_displayWindow.max + V2f( 1 ) ) / Imath::V2f( 2. ) );
-			V2f dataWindowCenter( ( m_dataWindow.min + m_dataWindow.max + V2f( 1 ) ) / Imath::V2f( 2. ) );
+			m_displayWindow.max += Imath::V2i( 1 );
+			m_dataWindow.max += Imath::V2i( 1 );
+
+			V2f displayWindowCenter( ( m_displayWindow.min + m_displayWindow.max ) / Imath::V2f( 2. ) );
+			V2f dataWindowCenter( ( m_dataWindow.min + m_dataWindow.max ) / Imath::V2f( 2. ) );
 			V2f offset( dataWindowCenter.x - displayWindowCenter.x, displayWindowCenter.y - dataWindowCenter.y );
 
 			m_dataBound = Box3f(
 				V3f(
-					offset.x - ( m_dataWindow.size().x + 1 ) / 2.,
-					offset.y - ( m_dataWindow.size().y + 1 ) / 2.,
+					offset.x - ( m_dataWindow.size().x ) / 2.,
+					offset.y - ( m_dataWindow.size().y ) / 2.,
 					0.f
 				),
 				V3f(
-					offset.x + ( m_dataWindow.size().x + 1 ) / 2.,
-					offset.y + ( m_dataWindow.size().y + 1 ) / 2.,
+					offset.x + ( m_dataWindow.size().x ) / 2.,
+					offset.y + ( m_dataWindow.size().y ) / 2.,
 					0.f
 				)
 			);
@@ -375,11 +378,11 @@ class ImageViewGadget : public GafferUI::Gadget
 		V2f rasterToDisplaySpace( const V2f &point ) const
 		{
 			Box2f dispRasterBox( displayRasterBox() );
-			V2f wh( ( dispRasterBox.max.x - dispRasterBox.min.x ) + 1.f, ( dispRasterBox.min.y - dispRasterBox.max.y ) + 1.f );
+			V2f wh( ( dispRasterBox.max.x - dispRasterBox.min.x ), ( dispRasterBox.min.y - dispRasterBox.max.y ) );
 			V2f t( ( point[0] - dispRasterBox.min.x ) / wh[0], ( point[1] - dispRasterBox.max.y ) / wh[1] );
 			return V2f(
-				float( m_displayWindow.min.x ) + t.x * ( m_displayWindow.size().x + 1.f ),
-				float( m_displayWindow.max.y + 1.f ) - ( t.y * ( m_displayWindow.size().y + 1.f ) )
+				float( m_displayWindow.min.x ) + ( t.x * ( m_displayWindow.size().x ) ),
+				float( m_displayWindow.max.y ) - ( t.y * ( m_displayWindow.size().y ) )
 			);
 		}
 
@@ -499,8 +502,8 @@ class ImageViewGadget : public GafferUI::Gadget
 						fastFloatRound( roif.min.y )
 					),
 					V2i(
-						fastFloatRound( roif.max.x ) - 1,
-						fastFloatRound( roif.max.y ) - 1
+						fastFloatRound( roif.max.x ),
+						fastFloatRound( roif.max.y )
 					)
 				);
 				m_imageStats->regionOfInterestPlug()->setValue( roi );
@@ -611,12 +614,10 @@ class ImageViewGadget : public GafferUI::Gadget
 
 		virtual void doRender( const Style *style ) const
 		{
-
-			if( !m_texture )
+			if( !m_texture && m_dataWindow.hasVolume() )
 			{
 				// convert image to texture
-				ToGLTextureConverterPtr converter = new ToGLTextureConverter( boost::static_pointer_cast<const ImagePrimitive>( m_image ), true );
-				m_texture = IECore::runTimeCast<IECoreGL::Texture>( converter->convert() );
+				m_texture = new IECoreGL::ColorTexture( m_image.get(), /* mipMap = */ false );
 
 				{
 					Texture::ScopedBinding scope( *m_texture );
@@ -644,6 +645,7 @@ class ImageViewGadget : public GafferUI::Gadget
 			}
 
 			// Draw the image data.
+			if ( m_texture )
 			{
 				// Get the bounds of the data window in Gadget space.
 				Box2f b( V2f( m_dataBound.min.x, m_dataBound.min.y ), V2f( m_dataBound.max.x, m_dataBound.max.y ) );
@@ -706,7 +708,7 @@ class ImageViewGadget : public GafferUI::Gadget
 
 			///\todo: How do we handle looking up the format here when we have a pixel aspect other than 1?
 			/// Does the IECore::ImagePrimitive have a pixel aspect?
-			GafferImage::Format f( m_displayWindow.size().x+1, m_displayWindow.size().y+1, 1. );
+			GafferImage::Format f( m_displayWindow.size().x, m_displayWindow.size().y, 1. );
 			std::string formatName( Format::formatName( f ) ) ;
 
 			style->renderText( Style::LabelText, formatName );
@@ -720,7 +722,7 @@ class ImageViewGadget : public GafferUI::Gadget
 
 				Format format( m_displayWindow );
 				Box2i dataWindow( format.yDownToFormatSpace( m_dataWindow ) );
-				drawWindow( dataRasterBox, dataWindow.min, dataWindow.max + V2i( 1 ), style );
+				drawWindow( dataRasterBox, dataWindow.min, dataWindow.max, style );
 			}
 
 			/// Draw the selection window.

--- a/src/GafferImageUI/ImageView.cpp
+++ b/src/GafferImageUI/ImageView.cpp
@@ -721,7 +721,8 @@ class ImageViewGadget : public GafferUI::Gadget
 				glColor( color );
 
 				Format format( m_displayWindow );
-				Box2i dataWindow( format.yDownToFormatSpace( m_dataWindow ) );
+				Box2i dataWindow( format.toEXRSpace( m_dataWindow ) );
+				dataWindow.max += Imath::V2i( 1 );
 				drawWindow( dataRasterBox, dataWindow.min, dataWindow.max, style );
 			}
 

--- a/startup/GafferImage/formatCompatibility.py
+++ b/startup/GafferImage/formatCompatibility.py
@@ -89,11 +89,17 @@ def __scriptNodeLoad( self, *args, **kwargs ) :
 	finally:
 		__currentlyLoadingScript = None
 
-Gaffer.ScriptNode.__originalLoad = Gaffer.ScriptNode.load
-Gaffer.ScriptNode.load = __scriptNodeLoad
+# We shouldn't need this conditional, but IECore.loadConfig() will happily load
+# the same file twice if the same path has been included twice. That would cause
+# havoc for us, because injecting the methods twice means infinite recursion when
+# calling the "original" methods.
+if not hasattr( GafferImage.Format, "__originalRegisterFormat" ) :
 
-GafferImage.FormatPlug.__originalSetValue = GafferImage.FormatPlug.setValue
-GafferImage.FormatPlug.setValue = __formatPlugSetValue
+	Gaffer.ScriptNode.__originalLoad = Gaffer.ScriptNode.load
+	Gaffer.ScriptNode.load = __scriptNodeLoad
 
-GafferImage.Format.__originalRegisterFormat = GafferImage.Format.registerFormat
-GafferImage.Format.registerFormat = __formatRegisterFormat
+	GafferImage.FormatPlug.__originalSetValue = GafferImage.FormatPlug.setValue
+	GafferImage.FormatPlug.setValue = __formatPlugSetValue
+
+	GafferImage.Format.__originalRegisterFormat = GafferImage.Format.registerFormat
+	GafferImage.Format.registerFormat = __formatRegisterFormat

--- a/startup/GafferImage/formatCompatibility.py
+++ b/startup/GafferImage/formatCompatibility.py
@@ -1,0 +1,104 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import re
+import inspect
+
+import IECore
+import Gaffer
+import GafferImage
+
+__currentlyLoadingScript = None
+
+def __getSerialisedGafferVersion( scriptNode ) :
+	
+	return (
+		Gaffer.Metadata.nodeValue( scriptNode, "serialiser:milestoneVersion" ),
+		Gaffer.Metadata.nodeValue( scriptNode, "serialiser:majorVersion" ),
+		Gaffer.Metadata.nodeValue( scriptNode, "serialiser:minorVersion" ),
+		Gaffer.Metadata.nodeValue( scriptNode, "serialiser:patchVersion" )
+		)
+
+
+def __convertFormat( fmt ):
+
+	if not __currentlyLoadingScript :
+		return fmt
+
+	gafferVersion = __getSerialisedGafferVersion( __currentlyLoadingScript )
+
+	# TODO : Determine which version of Gaffer inclusive image bounds
+	# will be included in. Presuming 0.16.0.0 for now.
+	if ( gafferVersion < ( 0, 16, 0, 0 ) ) :
+		displayWindow = fmt.getDisplayWindow()
+		displayWindow.max += IECore.V2i( 1 )
+
+		return GafferImage.Format( displayWindow, fmt.getPixelAspect() )
+
+	return fmt
+
+def __FormatPlug__setValue( self, *args, **kwargs ) :
+
+	if args and isinstance( args[0], GafferImage.Format ) :
+		args = ( __convertFormat( args[0] ), ) + args[1:]
+
+	return self.__originalSetValue( *args, **kwargs )
+
+def __Format__registerFormat( *args, **kwargs ) :
+
+	if args and isinstance( args[0], GafferImage.Format ) :
+		args = ( __convertFormat( args[0] ), ) + args[1:]
+
+	return GafferImage.Format.__originalRegisterFormat( *args, **kwargs )
+
+def __ScriptNode__load( self, *args, **kwargs ) :
+
+	global __currentlyLoadingScript
+	__currentlyLoadingScript = self
+
+	try:
+		self.__originalLoad( *args, **kwargs )
+	finally:
+		__currentlyLoadingScript = None
+
+Gaffer.ScriptNode.__originalLoad = Gaffer.ScriptNode.load
+Gaffer.ScriptNode.load = __ScriptNode__load
+
+GafferImage.FormatPlug.__originalSetValue = GafferImage.FormatPlug.setValue
+GafferImage.FormatPlug.setValue = __FormatPlug__setValue
+
+GafferImage.Format.__originalRegisterFormat = GafferImage.Format.registerFormat
+GafferImage.Format.registerFormat = __Format__registerFormat

--- a/startup/GafferImage/formatCompatibility.py
+++ b/startup/GafferImage/formatCompatibility.py
@@ -44,7 +44,7 @@ import GafferImage
 __currentlyLoadingScript = None
 
 def __getSerialisedGafferVersion( scriptNode ) :
-	
+
 	return (
 		Gaffer.Metadata.nodeValue( scriptNode, "serialiser:milestoneVersion" ),
 		Gaffer.Metadata.nodeValue( scriptNode, "serialiser:majorVersion" ),
@@ -62,7 +62,7 @@ def __convertFormat( fmt ):
 
 	# TODO : Determine which version of Gaffer inclusive image bounds
 	# will be included in. Presuming 0.16.0.0 for now.
-	if ( gafferVersion < ( 0, 16, 0, 0 ) ) :
+	if ( gafferVersion < ( 0, 17, 0, 0 ) ) :
 		displayWindow = fmt.getDisplayWindow()
 		displayWindow.max += IECore.V2i( 1 )
 

--- a/startup/GafferImage/formatCompatibility.py
+++ b/startup/GafferImage/formatCompatibility.py
@@ -34,10 +34,8 @@
 #
 ##########################################################################
 
-import re
-import inspect
-
 import IECore
+
 import Gaffer
 import GafferImage
 
@@ -50,8 +48,7 @@ def __getSerialisedGafferVersion( scriptNode ) :
 		Gaffer.Metadata.nodeValue( scriptNode, "serialiser:majorVersion" ),
 		Gaffer.Metadata.nodeValue( scriptNode, "serialiser:minorVersion" ),
 		Gaffer.Metadata.nodeValue( scriptNode, "serialiser:patchVersion" )
-		)
-
+	)
 
 def __convertFormat( fmt ):
 
@@ -60,8 +57,6 @@ def __convertFormat( fmt ):
 
 	gafferVersion = __getSerialisedGafferVersion( __currentlyLoadingScript )
 
-	# TODO : Determine which version of Gaffer inclusive image bounds
-	# will be included in. Presuming 0.16.0.0 for now.
 	if ( gafferVersion < ( 0, 17, 0, 0 ) ) :
 		displayWindow = fmt.getDisplayWindow()
 		displayWindow.max += IECore.V2i( 1 )
@@ -70,21 +65,21 @@ def __convertFormat( fmt ):
 
 	return fmt
 
-def __FormatPlug__setValue( self, *args, **kwargs ) :
+def __formatPlugSetValue( self, *args, **kwargs ) :
 
 	if args and isinstance( args[0], GafferImage.Format ) :
 		args = ( __convertFormat( args[0] ), ) + args[1:]
 
 	return self.__originalSetValue( *args, **kwargs )
 
-def __Format__registerFormat( *args, **kwargs ) :
+def __formatRegisterFormat( *args, **kwargs ) :
 
 	if args and isinstance( args[0], GafferImage.Format ) :
 		args = ( __convertFormat( args[0] ), ) + args[1:]
 
 	return GafferImage.Format.__originalRegisterFormat( *args, **kwargs )
 
-def __ScriptNode__load( self, *args, **kwargs ) :
+def __scriptNodeLoad( self, *args, **kwargs ) :
 
 	global __currentlyLoadingScript
 	__currentlyLoadingScript = self
@@ -95,10 +90,10 @@ def __ScriptNode__load( self, *args, **kwargs ) :
 		__currentlyLoadingScript = None
 
 Gaffer.ScriptNode.__originalLoad = Gaffer.ScriptNode.load
-Gaffer.ScriptNode.load = __ScriptNode__load
+Gaffer.ScriptNode.load = __scriptNodeLoad
 
 GafferImage.FormatPlug.__originalSetValue = GafferImage.FormatPlug.setValue
-GafferImage.FormatPlug.setValue = __FormatPlug__setValue
+GafferImage.FormatPlug.setValue = __formatPlugSetValue
 
 GafferImage.Format.__originalRegisterFormat = GafferImage.Format.registerFormat
-GafferImage.Format.registerFormat = __Format__registerFormat
+GafferImage.Format.registerFormat = __formatRegisterFormat


### PR DESCRIPTION
Not ready to be merged yet, but I'm putting in this PR for discussion as I go through it all.

This is the lowest level of modifications for converting the internal image bounds to be exclusive at the top end.

This just contains changes to Format and ImagePlug (and their respective tests)

All tests pass on these two classes.

It's going to be hard to confirm that they do full work until ImageReader and either ImageView or ImageWriter have been modified accordingly.