### PR TITLE
FileSystemPath supports sequences

### DIFF
--- a/include/Gaffer/FileSequencePathFilter.h
+++ b/include/Gaffer/FileSequencePathFilter.h
@@ -1,0 +1,94 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFER_FILESEQUENCEPATHFILTER_H
+#define GAFFER_FILESEQUENCEPATHFILTER_H
+
+#include "Gaffer/PathFilter.h"
+#include "Gaffer/TypeIds.h"
+
+namespace Gaffer
+{
+
+IE_CORE_FORWARDDECLARE( FileSequencePathFilter )
+
+/// FileSequencePathFilters can filter the results
+/// of FileSystemPath::children() to provide a masked view
+/// that either includes or excludes FileSequences
+class FileSequencePathFilter : public PathFilter
+{
+
+	public :
+
+		/// Defines which child paths should remain after the filter runs.
+		enum Keep
+		{
+			/// Leaf paths which are not valid as files in an IECore::FileSequence
+			Files = 0x00000001,
+			/// Leaf paths which are valid as files in an IECore::FileSequence
+			SequentialFiles = 0x00000002,
+			/// Leaf paths which are themselves valid IECore::FileSequences
+			Sequences = 0x00000004,
+			Concise = Files | Sequences,
+			Verbose = Files | SequentialFiles,
+			All = Files | SequentialFiles | Sequences,
+		};
+		
+		FileSequencePathFilter( Keep mode = Concise, IECore::CompoundDataPtr userData = NULL );
+		virtual ~FileSequencePathFilter();
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::FileSequencePathFilter, FileSequencePathFilterTypeId, Gaffer::PathFilter );
+		
+		Keep getMode() const;
+		void setMode( Keep mode );
+
+	protected :
+
+		virtual void doFilter( std::vector<PathPtr> &paths ) const;
+	
+	private :
+		
+		bool remove( PathPtr path ) const;
+		
+		Keep m_mode;
+
+};
+
+IE_CORE_DECLAREPTR( FileSequencePathFilter )
+
+} // namespace Gaffer
+
+#endif // GAFFER_FILESEQUENCEPATHFILTER_H

--- a/include/Gaffer/FileSystemPath.h
+++ b/include/Gaffer/FileSystemPath.h
@@ -79,7 +79,7 @@ class FileSystemPath : public Path
 		// with the FrameList that exists on disk.
 		IECore::FileSequencePtr fileSequence( bool ls = false ) const;
 
-		static PathFilterPtr createStandardFilter( const std::vector<std::string> &extensions = std::vector<std::string>(), const std::string &extensionsLabel = "" );
+		static PathFilterPtr createStandardFilter( const std::vector<std::string> &extensions = std::vector<std::string>(), const std::string &extensionsLabel = "", bool includeSequenceFilter = false );
 
 	protected :
 

--- a/include/Gaffer/FileSystemPath.h
+++ b/include/Gaffer/FileSystemPath.h
@@ -1,7 +1,7 @@
 //////////////////////////////////////////////////////////////////////////
 //
 //  Copyright (c) 2011-2012, John Haddon. All rights reserved.
-//  Copyright (c) 2012-2014, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2012-2015, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -38,6 +38,8 @@
 #ifndef GAFFER_FILESYSTEMPATH_H
 #define GAFFER_FILESYSTEMPATH_H
 
+#include "IECore/FileSequence.h"
+
 #include "Gaffer/Path.h"
 
 namespace Gaffer
@@ -48,9 +50,9 @@ class FileSystemPath : public Path
 
 	public :
 
-		FileSystemPath( PathFilterPtr filter = NULL );
-		FileSystemPath( const std::string &path, PathFilterPtr filter = NULL );
-		FileSystemPath( const Names &names, const IECore::InternedString &root = "/", PathFilterPtr filter = NULL );
+		FileSystemPath( PathFilterPtr filter = NULL, bool includeSequences = false );
+		FileSystemPath( const std::string &path, PathFilterPtr filter = NULL, bool includeSequences = false );
+		FileSystemPath( const Names &names, const IECore::InternedString &root = "/", PathFilterPtr filter = NULL, bool includeSequences = false );
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::FileSystemPath, FileSystemPathTypeId, Path );
 
@@ -65,14 +67,27 @@ class FileSystemPath : public Path
 		/// "fileSystem:group" -> StringData
 		/// "fileSystem:modificationTime" -> DateTimeData, in UTC time
 		/// "fileSystem:size" -> UInt64Data, in bytes
+		/// "fileSystem:frameRange" -> StringData
 		virtual IECore::ConstRunTimeTypedPtr property( const IECore::InternedString &name ) const;
 		virtual PathPtr copy() const;
+
+		// returns true if this FileSystemPath includes FileSequences
+		bool includeSequences() const;
+		// returns the FileSequence that represents the current leaf
+		// or NULL if this path is not a leaf, or does not represent
+		// a FileSequnce. Use ls = true to retrieve the FileSequnce
+		// with the FrameList that exists on disk.
+		IECore::FileSequencePtr fileSequence( bool ls = false ) const;
 
 		static PathFilterPtr createStandardFilter( const std::vector<std::string> &extensions = std::vector<std::string>(), const std::string &extensionsLabel = "" );
 
 	protected :
 
 		virtual void doChildren( std::vector<PathPtr> &children ) const;
+	
+	private :
+		
+		bool m_includeSequences;
 
 };
 

--- a/include/Gaffer/FileSystemPath.h
+++ b/include/Gaffer/FileSystemPath.h
@@ -71,13 +71,16 @@ class FileSystemPath : public Path
 		virtual IECore::ConstRunTimeTypedPtr property( const IECore::InternedString &name ) const;
 		virtual PathPtr copy() const;
 
-		// returns true if this FileSystemPath includes FileSequences
-		bool includeSequences() const;
-		// returns the FileSequence that represents the current leaf
+		// Returns true if this FileSystemPath includes FileSequences
+		bool getIncludeSequences() const;
+		// Determines whether this FileSystemPath includes FileSequences
+		void setIncludeSequences( bool includeSequences );
+		// Returns true if the path represents a FileSequence.
+		bool isFileSequence() const;
+		// Returns the FileSequence that represents the current leaf
 		// or NULL if this path is not a leaf, or does not represent
-		// a FileSequnce. Use ls = true to retrieve the FileSequnce
-		// with the FrameList that exists on disk.
-		IECore::FileSequencePtr fileSequence( bool ls = false ) const;
+		// a FileSequence.
+		IECore::FileSequencePtr fileSequence() const;
 
 		static PathFilterPtr createStandardFilter( const std::vector<std::string> &extensions = std::vector<std::string>(), const std::string &extensionsLabel = "", bool includeSequenceFilter = false );
 

--- a/include/Gaffer/TypeIds.h
+++ b/include/Gaffer/TypeIds.h
@@ -126,6 +126,7 @@ enum TypeId
 	MatchPatternPathFilterTypeId = 110079,
 	FileSystemPathTypeId = 110080,
 	LoopComputeNodeTypeId = 110081,
+	FileSequencePathFilterTypeId = 110082,
 
 	LastTypeId = 110180,
 

--- a/include/GafferBindings/FileSequencePathFilterBinding.h
+++ b/include/GafferBindings/FileSequencePathFilterBinding.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERBINDINGS_FILESEQUENCEPATHFILTERBINDING_H
+#define GAFFERBINDINGS_FILESEQUENCEPATHFILTERBINDING_H
+
+namespace GafferBindings
+{
+
+void bindFileSequencePathFilter();
+
+} // namespace GafferBindings
+
+#endif // GAFFERBINDINGS_FILESEQUENCEPATHFILTERBINDING_H

--- a/python/Gaffer/SequencePath.py
+++ b/python/Gaffer/SequencePath.py
@@ -40,6 +40,7 @@ import IECore
 
 import Gaffer
 
+## \deprecated: Use FileSystemPath and FileSequencePathFilter instead.
 class SequencePath( Gaffer.Path ) :
 
 	def __init__( self, path, root="/", minSequenceSize=1, filter=None ) :

--- a/python/GafferCortexUI/FileSequenceParameterValueWidget.py
+++ b/python/GafferCortexUI/FileSequenceParameterValueWidget.py
@@ -46,6 +46,12 @@ class FileSequenceParameterValueWidget( GafferCortexUI.PathParameterValueWidget 
 
 		GafferCortexUI.PathParameterValueWidget.__init__( self, parameterHandler, **kw )
 
+		includeFrameRange = True
+		with IECore.IgnoredExceptions( KeyError ) :
+			includeFrameRange = self.parameterHandler().parameter().userData()["UI"]["includeFrameRange"].value
+
+		Gaffer.Metadata.registerPlugValue( self.plug(), "fileSystemPathPlugValueWidget:includeSequenceFrameRange", includeFrameRange )
+
 		path = self._path()
 		path.setFromString( str( self.plugValueWidget().getPath() ) )
 		self.plugValueWidget().setPath( path )

--- a/python/GafferCortexUI/FileSequenceParameterValueWidget.py
+++ b/python/GafferCortexUI/FileSequenceParameterValueWidget.py
@@ -46,6 +46,10 @@ class FileSequenceParameterValueWidget( GafferCortexUI.PathParameterValueWidget 
 
 		GafferCortexUI.PathParameterValueWidget.__init__( self, parameterHandler, **kw )
 
+		path = self._path()
+		path.setFromString( str( self.plugValueWidget().getPath() ) )
+		self.plugValueWidget().setPath( path )
+
 	def _path( self ) :
 
 		return Gaffer.FileSystemPath( "/", filter = self._filter(), includeSequences = True )

--- a/python/GafferCortexUI/FileSequenceParameterValueWidget.py
+++ b/python/GafferCortexUI/FileSequenceParameterValueWidget.py
@@ -48,10 +48,6 @@ class FileSequenceParameterValueWidget( GafferCortexUI.PathParameterValueWidget 
 
 		GafferCortexUI.PathParameterValueWidget.__init__( self, parameterHandler, **kw )
 
-		path = self._path()
-		path.setFromString( str( self.plugValueWidget().getPath() ) )
-		self.plugValueWidget().setPath( path )
-
 	def _path( self ) :
 
 		return Gaffer.FileSystemPath( "/", filter = self._filter(), includeSequences = True )

--- a/python/GafferCortexUI/FileSequenceParameterValueWidget.py
+++ b/python/GafferCortexUI/FileSequenceParameterValueWidget.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2012, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2012-2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -48,6 +48,10 @@ class FileSequenceParameterValueWidget( GafferCortexUI.PathParameterValueWidget 
 
 	def _path( self ) :
 
-		return Gaffer.SequencePath( "/", filter = self._filter() )
+		return Gaffer.FileSystemPath( "/", filter = self._filter(), includeSequences = True )
+
+	def _filter( self ) :
+
+		return Gaffer.FileSystemPath.createStandardFilter( includeSequenceFilter = True )
 
 GafferCortexUI.ParameterValueWidget.registerType( IECore.FileSequenceParameter, FileSequenceParameterValueWidget )

--- a/python/GafferCortexUI/PathParameterValueWidget.py
+++ b/python/GafferCortexUI/PathParameterValueWidget.py
@@ -48,9 +48,9 @@ class PathParameterValueWidget( GafferCortexUI.ParameterValueWidget ) :
 
 		self.__pathWidget = GafferUI.FileSystemPathPlugValueWidget(
 			parameterHandler.plug(),
+			self._path(),
 			pathChooserDialogueKeywords = Gaffer.WeakMethod( self._pathChooserDialogueKeywords ),
 		)
-		self.__pathWidget.setPath( self._path() )
 		
 		GafferCortexUI.ParameterValueWidget.__init__(
 

--- a/python/GafferCortexUI/PathParameterValueWidget.py
+++ b/python/GafferCortexUI/PathParameterValueWidget.py
@@ -46,12 +46,12 @@ class PathParameterValueWidget( GafferCortexUI.ParameterValueWidget ) :
 
 	def __init__( self, parameterHandler, **kw ) :
 
-		self.__pathWidget = GafferUI.PathPlugValueWidget(
+		self.__pathWidget = GafferUI.FileSystemPathPlugValueWidget(
 			parameterHandler.plug(),
-			self._path(),
 			pathChooserDialogueKeywords = Gaffer.WeakMethod( self._pathChooserDialogueKeywords ),
 		)
-
+		self.__pathWidget.setPath( self._path() )
+		
 		GafferCortexUI.ParameterValueWidget.__init__(
 
 			self,

--- a/python/GafferImageUI/ImageReaderUI.py
+++ b/python/GafferImageUI/ImageReaderUI.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2014, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2014-2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -66,6 +66,7 @@ Gaffer.Metadata.registerNode(
 			"pathPlugValueWidget:bookmarks", "image",
 			"fileSystemPathPlugValueWidget:extensions", IECore.StringVectorData( GafferImage.ImageReader.supportedExtensions() ),
 			"fileSystemPathPlugValueWidget:extensionsLabel", "Show only image files",
+			"fileSystemPathPlugValueWidget:includeSequences", True,
 
 		],
 

--- a/python/GafferImageUI/ImageWriterUI.py
+++ b/python/GafferImageUI/ImageWriterUI.py
@@ -78,6 +78,7 @@ Gaffer.Metadata.registerNode(
 			"pathPlugValueWidget:bookmarks", "image",
 			"fileSystemPathPlugValueWidget:extensions", IECore.StringVectorData( GafferImage.ImageReader.supportedExtensions() ),
 			"fileSystemPathPlugValueWidget:extensionsLabel", "Show only image files",
+			"fileSystemPathPlugValueWidget:includeSequences", True,
 
 		],
 

--- a/python/GafferTest/FileSequencePathFilterTest.py
+++ b/python/GafferTest/FileSequencePathFilterTest.py
@@ -48,7 +48,7 @@ class FileSequencePathFilterTest( GafferTest.TestCase ) :
 	def test( self ) :
 
 		p = Gaffer.FileSystemPath( self.__dir, includeSequences = True )
-		self.assertTrue( p.includeSequences() )
+		self.assertTrue( p.getIncludeSequences() )
 
 		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
 			self.__dir + "/singleFile.txt",
@@ -121,7 +121,7 @@ class FileSequencePathFilterTest( GafferTest.TestCase ) :
 		] ) )
 
 		p = Gaffer.FileSystemPath( self.__dir, includeSequences = True )
-		self.assertTrue( p.includeSequences() )
+		self.assertTrue( p.getIncludeSequences() )
 
 		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
 			self.__dir + "/singleFile.txt",
@@ -201,7 +201,7 @@ class FileSequencePathFilterTest( GafferTest.TestCase ) :
 		# but we may as well verify that it works.
 
 		p = Gaffer.FileSystemPath( self.__dir, includeSequences = False )
-		self.assertFalse( p.includeSequences() )
+		self.assertFalse( p.getIncludeSequences() )
 
 		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
 			self.__dir + "/singleFile.txt",
@@ -268,7 +268,7 @@ class FileSequencePathFilterTest( GafferTest.TestCase ) :
 	def testEnabled( self ) :
 
 		p = Gaffer.FileSystemPath( self.__dir, includeSequences = True )
-		self.assertTrue( p.includeSequences() )
+		self.assertTrue( p.getIncludeSequences() )
 
 		p.setFilter( Gaffer.FileSequencePathFilter( mode = Gaffer.FileSequencePathFilter.Keep.Files ) )
 		self.assertEqual( p.getFilter().getMode(), Gaffer.FileSequencePathFilter.Keep.Files )

--- a/python/GafferTest/FileSequencePathFilterTest.py
+++ b/python/GafferTest/FileSequencePathFilterTest.py
@@ -196,9 +196,9 @@ class FileSequencePathFilterTest( GafferTest.TestCase ) :
 	def testNoSequences( self ) :
 
 		# it doesn't really make sense to do this,
-		# as we're using a sequecne filter on a
+		# as we're using a sequence filter on a
 		# path that by definition has no sequences,
-		# but we may as well verifyt that it works.
+		# but we may as well verify that it works.
 
 		p = Gaffer.FileSystemPath( self.__dir, includeSequences = False )
 		self.assertFalse( p.includeSequences() )
@@ -306,7 +306,8 @@ class FileSequencePathFilterTest( GafferTest.TestCase ) :
 
 	def tearDown( self ) :
 
-		os.chdir( self.__originalCWD )
+		if os.path.exists( self.__dir ) :
+			shutil.rmtree( self.__dir )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/FileSequencePathFilterTest.py
+++ b/python/GafferTest/FileSequencePathFilterTest.py
@@ -1,0 +1,312 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import os
+import shutil
+import unittest
+
+import Gaffer
+import GafferTest
+
+class FileSequencePathFilterTest( GafferTest.TestCase ) :
+
+	__dir = "/tmp/gafferFileSequencePathFilterTest"
+
+	def test( self ) :
+
+		p = Gaffer.FileSystemPath( self.__dir, includeSequences = True )
+		self.assertTrue( p.includeSequences() )
+
+		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
+			self.__dir + "/singleFile.txt",
+			self.__dir + "/a.001.txt",
+			self.__dir + "/a.002.txt",
+			self.__dir + "/a.004.txt",
+			self.__dir + "/b.003.txt",
+			self.__dir + "/dir",
+			self.__dir + "/a.###.txt",
+			self.__dir + "/b.###.txt"
+		] ) )
+
+		p.setFilter( Gaffer.FileSequencePathFilter( mode = Gaffer.FileSequencePathFilter.Keep.Files ) )
+		self.assertEqual( p.getFilter().getMode(), Gaffer.FileSequencePathFilter.Keep.Files )
+		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
+			self.__dir + "/singleFile.txt",
+			self.__dir + "/dir",
+		] ) )
+
+
+		p.getFilter().setMode( Gaffer.FileSequencePathFilter.Keep.SequentialFiles )
+		self.assertEqual( p.getFilter().getMode(), Gaffer.FileSequencePathFilter.Keep.SequentialFiles )
+		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
+			self.__dir + "/a.001.txt",
+			self.__dir + "/a.002.txt",
+			self.__dir + "/a.004.txt",
+			self.__dir + "/b.003.txt",
+			self.__dir + "/dir",
+		] ) )
+
+		p.getFilter().setMode( Gaffer.FileSequencePathFilter.Keep.Sequences )
+		self.assertEqual( p.getFilter().getMode(), Gaffer.FileSequencePathFilter.Keep.Sequences )
+		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
+			self.__dir + "/dir",
+			self.__dir + "/a.###.txt",
+			self.__dir + "/b.###.txt"
+		] ) )
+
+		p.getFilter().setMode( Gaffer.FileSequencePathFilter.Keep.Concise )
+		self.assertEqual( p.getFilter().getMode(), Gaffer.FileSequencePathFilter.Keep.Concise )
+		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
+			self.__dir + "/singleFile.txt",
+			self.__dir + "/dir",
+			self.__dir + "/a.###.txt",
+			self.__dir + "/b.###.txt"
+		] ) )
+
+		p.getFilter().setMode( Gaffer.FileSequencePathFilter.Keep.Verbose )
+		self.assertEqual( p.getFilter().getMode(), Gaffer.FileSequencePathFilter.Keep.Verbose )
+		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
+			self.__dir + "/singleFile.txt",
+			self.__dir + "/a.001.txt",
+			self.__dir + "/a.002.txt",
+			self.__dir + "/a.004.txt",
+			self.__dir + "/b.003.txt",
+			self.__dir + "/dir",
+		] ) )
+
+		p.getFilter().setMode( Gaffer.FileSequencePathFilter.Keep.All )
+		self.assertEqual( p.getFilter().getMode(), Gaffer.FileSequencePathFilter.Keep.All )
+		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
+			self.__dir + "/singleFile.txt",
+			self.__dir + "/a.001.txt",
+			self.__dir + "/a.002.txt",
+			self.__dir + "/a.004.txt",
+			self.__dir + "/b.003.txt",
+			self.__dir + "/dir",
+			self.__dir + "/a.###.txt",
+			self.__dir + "/b.###.txt"
+		] ) )
+
+		p = Gaffer.FileSystemPath( self.__dir, includeSequences = True )
+		self.assertTrue( p.includeSequences() )
+
+		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
+			self.__dir + "/singleFile.txt",
+			self.__dir + "/a.001.txt",
+			self.__dir + "/a.002.txt",
+			self.__dir + "/a.004.txt",
+			self.__dir + "/b.003.txt",
+			self.__dir + "/dir",
+			self.__dir + "/a.###.txt",
+			self.__dir + "/b.###.txt"
+		] ) )
+
+		p.setFilter( Gaffer.FileSequencePathFilter( mode = Gaffer.FileSequencePathFilter.Keep.Files ) )
+		self.assertEqual( p.getFilter().getMode(), Gaffer.FileSequencePathFilter.Keep.Files )
+		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
+			self.__dir + "/singleFile.txt",
+			self.__dir + "/dir",
+		] ) )
+
+
+		p.getFilter().setMode( Gaffer.FileSequencePathFilter.Keep.SequentialFiles )
+		self.assertEqual( p.getFilter().getMode(), Gaffer.FileSequencePathFilter.Keep.SequentialFiles )
+		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
+			self.__dir + "/a.001.txt",
+			self.__dir + "/a.002.txt",
+			self.__dir + "/a.004.txt",
+			self.__dir + "/b.003.txt",
+			self.__dir + "/dir",
+		] ) )
+
+		p.getFilter().setMode( Gaffer.FileSequencePathFilter.Keep.Sequences )
+		self.assertEqual( p.getFilter().getMode(), Gaffer.FileSequencePathFilter.Keep.Sequences )
+		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
+			self.__dir + "/dir",
+			self.__dir + "/a.###.txt",
+			self.__dir + "/b.###.txt"
+		] ) )
+
+		p.getFilter().setMode( Gaffer.FileSequencePathFilter.Keep.Concise )
+		self.assertEqual( p.getFilter().getMode(), Gaffer.FileSequencePathFilter.Keep.Concise )
+		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
+			self.__dir + "/singleFile.txt",
+			self.__dir + "/dir",
+			self.__dir + "/a.###.txt",
+			self.__dir + "/b.###.txt"
+		] ) )
+
+		p.getFilter().setMode( Gaffer.FileSequencePathFilter.Keep.Verbose )
+		self.assertEqual( p.getFilter().getMode(), Gaffer.FileSequencePathFilter.Keep.Verbose )
+		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
+			self.__dir + "/singleFile.txt",
+			self.__dir + "/a.001.txt",
+			self.__dir + "/a.002.txt",
+			self.__dir + "/a.004.txt",
+			self.__dir + "/b.003.txt",
+			self.__dir + "/dir",
+		] ) )
+
+		p.getFilter().setMode( Gaffer.FileSequencePathFilter.Keep.All )
+		self.assertEqual( p.getFilter().getMode(), Gaffer.FileSequencePathFilter.Keep.All )
+		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
+			self.__dir + "/singleFile.txt",
+			self.__dir + "/a.001.txt",
+			self.__dir + "/a.002.txt",
+			self.__dir + "/a.004.txt",
+			self.__dir + "/b.003.txt",
+			self.__dir + "/dir",
+			self.__dir + "/a.###.txt",
+			self.__dir + "/b.###.txt"
+		] ) )
+
+	def testNoSequences( self ) :
+
+		# it doesn't really make sense to do this,
+		# as we're using a sequecne filter on a
+		# path that by definition has no sequences,
+		# but we may as well verifyt that it works.
+
+		p = Gaffer.FileSystemPath( self.__dir, includeSequences = False )
+		self.assertFalse( p.includeSequences() )
+
+		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
+			self.__dir + "/singleFile.txt",
+			self.__dir + "/a.001.txt",
+			self.__dir + "/a.002.txt",
+			self.__dir + "/a.004.txt",
+			self.__dir + "/b.003.txt",
+			self.__dir + "/dir",
+		] ) )
+
+		p.setFilter( Gaffer.FileSequencePathFilter( mode = Gaffer.FileSequencePathFilter.Keep.Files ) )
+		self.assertEqual( p.getFilter().getMode(), Gaffer.FileSequencePathFilter.Keep.Files )
+		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
+			self.__dir + "/singleFile.txt",
+			self.__dir + "/dir",
+		] ) )
+
+
+		p.getFilter().setMode( Gaffer.FileSequencePathFilter.Keep.SequentialFiles )
+		self.assertEqual( p.getFilter().getMode(), Gaffer.FileSequencePathFilter.Keep.SequentialFiles )
+		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
+			self.__dir + "/a.001.txt",
+			self.__dir + "/a.002.txt",
+			self.__dir + "/a.004.txt",
+			self.__dir + "/b.003.txt",
+			self.__dir + "/dir",
+		] ) )
+
+		p.getFilter().setMode( Gaffer.FileSequencePathFilter.Keep.Sequences )
+		self.assertEqual( p.getFilter().getMode(), Gaffer.FileSequencePathFilter.Keep.Sequences )
+		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
+			self.__dir + "/dir",
+		] ) )
+
+		p.getFilter().setMode( Gaffer.FileSequencePathFilter.Keep.Concise )
+		self.assertEqual( p.getFilter().getMode(), Gaffer.FileSequencePathFilter.Keep.Concise )
+		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
+			self.__dir + "/singleFile.txt",
+			self.__dir + "/dir",
+		] ) )
+
+		p.getFilter().setMode( Gaffer.FileSequencePathFilter.Keep.Verbose )
+		self.assertEqual( p.getFilter().getMode(), Gaffer.FileSequencePathFilter.Keep.Verbose )
+		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
+			self.__dir + "/singleFile.txt",
+			self.__dir + "/a.001.txt",
+			self.__dir + "/a.002.txt",
+			self.__dir + "/a.004.txt",
+			self.__dir + "/b.003.txt",
+			self.__dir + "/dir",
+		] ) )
+
+		p.getFilter().setMode( Gaffer.FileSequencePathFilter.Keep.All )
+		self.assertEqual( p.getFilter().getMode(), Gaffer.FileSequencePathFilter.Keep.All )
+		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
+			self.__dir + "/singleFile.txt",
+			self.__dir + "/a.001.txt",
+			self.__dir + "/a.002.txt",
+			self.__dir + "/a.004.txt",
+			self.__dir + "/b.003.txt",
+			self.__dir + "/dir",
+		] ) )
+
+	def testEnabled( self ) :
+
+		p = Gaffer.FileSystemPath( self.__dir, includeSequences = True )
+		self.assertTrue( p.includeSequences() )
+
+		p.setFilter( Gaffer.FileSequencePathFilter( mode = Gaffer.FileSequencePathFilter.Keep.Files ) )
+		self.assertEqual( p.getFilter().getMode(), Gaffer.FileSequencePathFilter.Keep.Files )
+		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
+			self.__dir + "/singleFile.txt",
+			self.__dir + "/dir",
+		] ) )
+
+		p.getFilter().setEnabled( False )
+		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
+			self.__dir + "/singleFile.txt",
+			self.__dir + "/a.001.txt",
+			self.__dir + "/a.002.txt",
+			self.__dir + "/a.004.txt",
+			self.__dir + "/b.003.txt",
+			self.__dir + "/dir",
+			self.__dir + "/a.###.txt",
+			self.__dir + "/b.###.txt"
+		] ) )
+
+	def setUp( self ) :
+
+		self.__originalCWD = os.getcwd()
+
+		# clear out old files and make empty directory
+		# to work in
+		if os.path.exists( self.__dir ) :
+			shutil.rmtree( self.__dir )
+		os.mkdir( self.__dir )
+		
+		os.mkdir( self.__dir + "/dir" )
+		for n in [ "singleFile.txt", "a.001.txt", "a.002.txt", "a.004.txt", "b.003.txt" ] :
+			with open( self.__dir + "/" + n, "w" ) as f :
+				f.write( "AAAA" )
+
+	def tearDown( self ) :
+
+		os.chdir( self.__originalCWD )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferTest/FileSystemPathTest.py
+++ b/python/GafferTest/FileSystemPathTest.py
@@ -1,7 +1,7 @@
 ##########################################################################
 #
 #  Copyright (c) 2011, John Haddon. All rights reserved.
-#  Copyright (c) 2012-2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2012-2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -229,6 +229,81 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 		self.assertTrue( "fileSystem:owner" in a )
 		self.assertTrue( "fileSystem:modificationTime" in a )
 		self.assertTrue( "fileSystem:size" in a )
+		
+		self.assertTrue( "fileSystem:frameRange" not in a )
+		p = Gaffer.FileSystemPath( self.__dir, includeSequences = True )
+		self.assertTrue( "fileSystem:frameRange" in p.propertyNames() )
+
+	def testSequences( self ) :
+
+		os.mkdir( self.__dir + "/dir" )
+		for n in [ "singleFile.txt", "a.001.txt", "a.002.txt", "a.004.txt", "b.003.txt" ] :
+			with open( self.__dir + "/" + n, "w" ) as f :
+				f.write( "AAAA" )
+
+		p = Gaffer.FileSystemPath( self.__dir, includeSequences = True )
+		self.assertTrue( p.includeSequences() )
+
+		c = p.children()
+		self.assertEqual( len( c ), 8 )
+
+		s = sorted( c, key=str )
+		self.assertEqual( str(s[0]), self.__dir + "/a.###.txt" )
+		self.assertEqual( str(s[1]), self.__dir + "/a.001.txt" )
+		self.assertEqual( str(s[2]), self.__dir + "/a.002.txt" )
+		self.assertEqual( str(s[3]), self.__dir + "/a.004.txt" )
+		self.assertEqual( str(s[4]), self.__dir + "/b.###.txt" )
+		self.assertEqual( str(s[5]), self.__dir + "/b.003.txt" )
+		self.assertEqual( str(s[6]), self.__dir + "/dir" )
+		self.assertEqual( str(s[7]), self.__dir + "/singleFile.txt" )
+
+		for x in s :
+
+			self.assertTrue( x.isValid() )
+			if not os.path.isdir( str(x) ) :
+				self.assertTrue( x.isLeaf() )
+
+			self.assertEqual( x.property( "fileSystem:owner" ), pwd.getpwuid( os.stat( str( p ) ).st_uid ).pw_name )
+			self.assertEqual( x.property( "fileSystem:group" ), grp.getgrgid( os.stat( str( p ) ).st_gid ).gr_name )
+			self.assertTrue( (datetime.datetime.utcnow() - x.property( "fileSystem:modificationTime" )).total_seconds() < 1 )
+			if "###" not in str(x) :
+				self.assertEqual( x.property( "fileSystem:frameRange" ), "" )
+				if os.path.isdir( str(x) ) :
+					self.assertEqual( x.property( "fileSystem:size" ), 0 )
+				else :
+					self.assertEqual( x.property( "fileSystem:size" ), 4 )
+
+		self.assertEqual( s[0].property( "fileSystem:frameRange" ), "1-2,4" )
+		self.assertTrue( isinstance( s[0].fileSequence(), IECore.FileSequence ) )
+		self.assertEqual( s[0].fileSequence(), IECore.FileSequence( str(s[0]), IECore.EmptyFrameList() ) )
+		self.assertEqual( s[0].fileSequence( ls = True ), IECore.FileSequence( str(s[0]), IECore.frameListFromList( [ 1, 2, 4 ] ) ) )
+		self.assertEqual( s[0].property( "fileSystem:size" ), 4 * 3 )
+
+		self.assertEqual( s[4].property( "fileSystem:frameRange" ), "3" )
+		self.assertTrue( isinstance( s[4].fileSequence(), IECore.FileSequence ) )
+		self.assertEqual( s[4].fileSequence(), IECore.FileSequence( str(s[4]), IECore.EmptyFrameList() ) )
+		self.assertEqual( s[4].fileSequence( ls = True ), IECore.FileSequence( str(s[4]), IECore.frameListFromList( [ 3 ] ) ) )
+		self.assertEqual( s[4].property( "fileSystem:size" ), 4 )
+
+		# make sure we can copy
+		p2 = p.copy()
+		self.assertTrue( p2.includeSequences() )
+		self.assertEqual( len( p2.children() ), 8 )
+
+		# make sure we can still exclude the sequences
+		p = Gaffer.FileSystemPath( self.__dir, includeSequences = False )
+		self.assertFalse( p.includeSequences() )
+
+		c = p.children()
+		self.assertEqual( len( c ), 6 )
+
+		s = sorted( c, key=str )
+		self.assertEqual( str(s[0]), self.__dir + "/a.001.txt" )
+		self.assertEqual( str(s[1]), self.__dir + "/a.002.txt" )
+		self.assertEqual( str(s[2]), self.__dir + "/a.004.txt" )
+		self.assertEqual( str(s[3]), self.__dir + "/b.003.txt" )
+		self.assertEqual( str(s[4]), self.__dir + "/dir" )
+		self.assertEqual( str(s[5]), self.__dir + "/singleFile.txt" )
 
 	def setUp( self ) :
 

--- a/python/GafferTest/FileSystemPathTest.py
+++ b/python/GafferTest/FileSystemPathTest.py
@@ -242,7 +242,7 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 				f.write( "AAAA" )
 
 		p = Gaffer.FileSystemPath( self.__dir, includeSequences = True )
-		self.assertTrue( p.includeSequences() )
+		self.assertTrue( p.getIncludeSequences() )
 
 		c = p.children()
 		self.assertEqual( len( c ), 8 )
@@ -267,6 +267,8 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 			self.assertEqual( x.property( "fileSystem:group" ), grp.getgrgid( os.stat( str( p ) ).st_gid ).gr_name )
 			self.assertTrue( (datetime.datetime.utcnow() - x.property( "fileSystem:modificationTime" )).total_seconds() < 1 )
 			if "###" not in str(x) :
+				self.assertFalse( x.isFileSequence() )
+				self.assertEqual( x.fileSequence(), None )
 				self.assertEqual( x.property( "fileSystem:frameRange" ), "" )
 				if os.path.isdir( str(x) ) :
 					self.assertEqual( x.property( "fileSystem:size" ), 0 )
@@ -274,25 +276,25 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 					self.assertEqual( x.property( "fileSystem:size" ), 4 )
 
 		self.assertEqual( s[0].property( "fileSystem:frameRange" ), "1-2,4" )
+		self.assertTrue( s[0].isFileSequence() )
 		self.assertTrue( isinstance( s[0].fileSequence(), IECore.FileSequence ) )
-		self.assertEqual( s[0].fileSequence(), IECore.FileSequence( str(s[0]), IECore.EmptyFrameList() ) )
-		self.assertEqual( s[0].fileSequence( ls = True ), IECore.FileSequence( str(s[0]), IECore.frameListFromList( [ 1, 2, 4 ] ) ) )
+		self.assertEqual( s[0].fileSequence(), IECore.FileSequence( str(s[0]), IECore.frameListFromList( [ 1, 2, 4 ] ) ) )
 		self.assertEqual( s[0].property( "fileSystem:size" ), 4 * 3 )
 
 		self.assertEqual( s[4].property( "fileSystem:frameRange" ), "3" )
+		self.assertTrue( s[4].isFileSequence() )
 		self.assertTrue( isinstance( s[4].fileSequence(), IECore.FileSequence ) )
-		self.assertEqual( s[4].fileSequence(), IECore.FileSequence( str(s[4]), IECore.EmptyFrameList() ) )
-		self.assertEqual( s[4].fileSequence( ls = True ), IECore.FileSequence( str(s[4]), IECore.frameListFromList( [ 3 ] ) ) )
+		self.assertEqual( s[4].fileSequence(), IECore.FileSequence( str(s[4]), IECore.frameListFromList( [ 3 ] ) ) )
 		self.assertEqual( s[4].property( "fileSystem:size" ), 4 )
 
 		# make sure we can copy
 		p2 = p.copy()
-		self.assertTrue( p2.includeSequences() )
+		self.assertTrue( p2.getIncludeSequences() )
 		self.assertEqual( len( p2.children() ), 8 )
 
 		# make sure we can still exclude the sequences
 		p = Gaffer.FileSystemPath( self.__dir, includeSequences = False )
-		self.assertFalse( p.includeSequences() )
+		self.assertFalse( p.getIncludeSequences() )
 
 		c = p.children()
 		self.assertEqual( len( c ), 6 )
@@ -304,6 +306,13 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 		self.assertEqual( str(s[3]), self.__dir + "/b.003.txt" )
 		self.assertEqual( str(s[4]), self.__dir + "/dir" )
 		self.assertEqual( str(s[5]), self.__dir + "/singleFile.txt" )
+		
+		# and we can include them again
+		p.setIncludeSequences( True )
+		self.assertTrue( p.getIncludeSequences() )
+
+		c = p.children()
+		self.assertEqual( len( c ), 8 )
 
 	def setUp( self ) :
 

--- a/python/GafferTest/__init__.py
+++ b/python/GafferTest/__init__.py
@@ -1,7 +1,7 @@
 ##########################################################################
 #
 #  Copyright (c) 2011-2012, John Haddon. All rights reserved.
-#  Copyright (c) 2011-2014, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2011-2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -134,6 +134,7 @@ from LoopTest import LoopTest
 from WedgeTest import WedgeTest
 from TaskContextVariablesTest import TaskContextVariablesTest
 from SubGraphTest import SubGraphTest
+from FileSequencePathFilterTest import FileSequencePathFilterTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferUI/CompoundPathFilterWidget.py
+++ b/python/GafferUI/CompoundPathFilterWidget.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2012, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2012-2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -69,7 +69,7 @@ class CompoundPathFilterWidget( GafferUI.PathFilterWidget ) :
 
 			self.__grid[gridPos.x, gridPos.y] = filterWidget
 
-			if gridPos.x < 2 :
+			if gridPos.x < 3 :
 				gridPos.x += 1
 			else :
 				gridPos.x = 0

--- a/python/GafferUI/FileSequencePathFilterWidget.py
+++ b/python/GafferUI/FileSequencePathFilterWidget.py
@@ -1,0 +1,75 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import re
+import time
+import fnmatch
+
+import IECore
+
+import Gaffer
+import GafferUI
+
+class FileSequencePathFilterWidget( GafferUI.PathFilterWidget ) :
+
+	def __init__( self, pathFilter, **kw ) :
+
+		self.__checkBox = GafferUI.BoolWidget( str( pathFilter ) )
+
+		GafferUI.PathFilterWidget.__init__( self, self.__checkBox, pathFilter )
+
+		self.__stateChangedConnection = self.__checkBox.stateChangedSignal().connect( Gaffer.WeakMethod( self.__stateChanged ) )
+
+		self._updateFromPathFilter()
+
+	def _updateFromPathFilter( self ) :
+
+		label = str( self.pathFilter() )
+		with IECore.IgnoredExceptions( KeyError ) :
+			label = self.pathFilter().userData()["UI"]["label"].value
+		self.__checkBox.setText( label )
+		self.__checkBox.setState( self.pathFilter().getMode() == Gaffer.FileSequencePathFilter.Keep.Concise )
+
+	def __stateChanged( self, checkBox ) :
+
+		if checkBox.getState() :
+			mode = Gaffer.FileSequencePathFilter.Keep.Concise
+		else :
+			mode = Gaffer.FileSequencePathFilter.Keep.Verbose
+
+		self.pathFilter().setMode( mode )
+
+GafferUI.PathFilterWidget.registerType( Gaffer.FileSequencePathFilter, FileSequencePathFilterWidget )

--- a/python/GafferUI/FileSequencePathFilterWidget.py
+++ b/python/GafferUI/FileSequencePathFilterWidget.py
@@ -34,10 +34,6 @@
 #
 ##########################################################################
 
-import re
-import time
-import fnmatch
-
 import IECore
 
 import Gaffer
@@ -57,10 +53,7 @@ class FileSequencePathFilterWidget( GafferUI.PathFilterWidget ) :
 
 	def _updateFromPathFilter( self ) :
 
-		label = str( self.pathFilter() )
-		with IECore.IgnoredExceptions( KeyError ) :
-			label = self.pathFilter().userData()["UI"]["label"].value
-		self.__checkBox.setText( label )
+		self.__checkBox.setText( "Show sequences" )
 		self.__checkBox.setState( self.pathFilter().getMode() == Gaffer.FileSequencePathFilter.Keep.Concise )
 
 	def __stateChanged( self, checkBox ) :

--- a/python/GafferUI/FileSystemPathPlugValueWidget.py
+++ b/python/GafferUI/FileSystemPathPlugValueWidget.py
@@ -47,12 +47,12 @@ import GafferUI
 # - "fileSystemPathPlugValueWidget:includeSequenceFrameRange"
 class FileSystemPathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
 
-	def __init__( self, plug, **kw ) :
+	def __init__( self, plug, path=None, **kw ) :
 
 		GafferUI.PathPlugValueWidget.__init__(
 			self,
 			plug,
-			Gaffer.FileSystemPath( "/" ),
+			path,
 			**kw
 		)
 
@@ -82,17 +82,15 @@ class FileSystemPathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
 
 		includeSequences = Gaffer.Metadata.plugValue( self.getPlug(), "fileSystemPathPlugValueWidget:includeSequences" ) or False
 
-		self.setPath(
-			Gaffer.FileSystemPath(
-				str(self.getPath()),
-				filter =  Gaffer.FileSystemPath.createStandardFilter(
-					list( extensions ),
-					Gaffer.Metadata.plugValue( self.getPlug(), "fileSystemPathPlugValueWidget:extensionsLabel" ) or "",
-					includeSequenceFilter = includeSequences,
-				),
-				includeSequences = includeSequences,
+		self.path().setFilter(
+			Gaffer.FileSystemPath.createStandardFilter(
+				list( extensions ),
+				Gaffer.Metadata.plugValue( self.getPlug(), "fileSystemPathPlugValueWidget:extensionsLabel" ) or "",
+				includeSequenceFilter = includeSequences,
 			)
 		)
+
+		self.path().setIncludeSequences( includeSequences )
 
 	def _setPlugFromPath( self, path ) :
 

--- a/python/GafferUI/FileSystemPathPlugValueWidget.py
+++ b/python/GafferUI/FileSystemPathPlugValueWidget.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import IECore
+
 import Gaffer
 import GafferUI
 
@@ -42,6 +44,7 @@ import GafferUI
 # - "fileSystemPathPlugValueWidget:extensions"
 # - "fileSystemPathPlugValueWidget:extensionsLabel"
 # - "fileSystemPathPlugValueWidget:includeSequences"
+# - "fileSystemPathPlugValueWidget:includeSequenceFrameRange"
 class FileSystemPathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
 
 	def __init__( self, plug, **kw ) :
@@ -90,6 +93,17 @@ class FileSystemPathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
 				includeSequences = includeSequences,
 			)
 		)
+
+	def _setPlugFromPath( self, path ) :
+
+		if Gaffer.Metadata.plugValue( self.getPlug(), "fileSystemPathPlugValueWidget:includeSequenceFrameRange" ) :
+			sequence = path.fileSequence()
+			if sequence :
+				sequence.frameList = IECore.FrameList.parse( path.property( "fileSystem:frameRange" ) )
+				self.getPlug().setValue( str(sequence) )
+				return
+
+		GafferUI.PathPlugValueWidget._setPlugFromPath( self, path )
 
 	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
 

--- a/python/GafferUI/FileSystemPathPlugValueWidget.py
+++ b/python/GafferUI/FileSystemPathPlugValueWidget.py
@@ -45,6 +45,9 @@ import GafferUI
 # - "fileSystemPathPlugValueWidget:extensionsLabel"
 # - "fileSystemPathPlugValueWidget:includeSequences"
 # - "fileSystemPathPlugValueWidget:includeSequenceFrameRange"
+#	Note that includeSequenceFrameRange is primarily used
+#	by GafferCortex. Think twice before using it elsewhere
+#	as it may not exist in the future. 
 class FileSystemPathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
 
 	def __init__( self, plug, path=None, **kw ) :

--- a/python/GafferUI/FileSystemPathPlugValueWidget.py
+++ b/python/GafferUI/FileSystemPathPlugValueWidget.py
@@ -99,7 +99,6 @@ class FileSystemPathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
 		if Gaffer.Metadata.plugValue( self.getPlug(), "fileSystemPathPlugValueWidget:includeSequenceFrameRange" ) :
 			sequence = path.fileSequence()
 			if sequence :
-				sequence.frameList = IECore.FrameList.parse( path.property( "fileSystem:frameRange" ) )
 				self.getPlug().setValue( str(sequence) )
 				return
 

--- a/python/GafferUI/PathPlugValueWidget.py
+++ b/python/GafferUI/PathPlugValueWidget.py
@@ -80,6 +80,15 @@ class PathPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		self._updateFromPlug()
 
+	def getPath( self ) :
+
+		return self.__path
+
+	def setPath( self, path ) :
+
+		self.__path = path.copy()
+		self.pathWidget().setPath( self.__path )
+
 	## Returns the PathWidget used to display the path.
 	def pathWidget( self ) :
 

--- a/python/GafferUI/PathPlugValueWidget.py
+++ b/python/GafferUI/PathPlugValueWidget.py
@@ -155,13 +155,17 @@ class PathPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.pathWidget().setEditable( self._editable() )
 		self.__row[1].setEnabled( self._editable() ) # button
 
+	def _setPlugFromPath( self, path ) :
+
+		self.getPlug().setValue( str( self.__path ) )
+
 	def __setPlugValue( self, *args ) :
 
 		if not self._editable() :
 			return
 
 		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
-			self.getPlug().setValue( str( self.__path ) )
+			self._setPlugFromPath( self.__path )
 
 		# now we've transferred the text changes to the global undo queue, we remove them
 		# from the widget's private text editing undo queue. it will then ignore undo shortcuts,

--- a/python/GafferUI/PathPlugValueWidget.py
+++ b/python/GafferUI/PathPlugValueWidget.py
@@ -80,14 +80,9 @@ class PathPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		self._updateFromPlug()
 
-	def getPath( self ) :
+	def path( self ) :
 
 		return self.__path
-
-	def setPath( self, path ) :
-
-		self.__path = path.copy()
-		self.pathWidget().setPath( self.__path )
 
 	## Returns the PathWidget used to display the path.
 	def pathWidget( self ) :

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -1635,6 +1635,7 @@ class _PlugEditor( GafferUI.Widget ) :
 		__MetadataDefinition( "pathPlugValueWidget:bookmarks", "Bookmarks Category", _StringMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
 		__MetadataDefinition( "pathPlugValueWidget:valid", "File Must Exist", _BoolMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
 		__MetadataDefinition( "pathPlugValueWidget:leaf", "No Directories", _BoolMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
+		__MetadataDefinition( "fileSystemPathPlugValueWidget:includeSequences", "Allow sequences", _BoolMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
 	)
 
 	__GadgetDefinition = collections.namedtuple( "GadgetDefinition", ( "label", "plugType", "metadata" ) )

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -1636,6 +1636,8 @@ class _PlugEditor( GafferUI.Widget ) :
 		__MetadataDefinition( "pathPlugValueWidget:valid", "File Must Exist", _BoolMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
 		__MetadataDefinition( "pathPlugValueWidget:leaf", "No Directories", _BoolMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
 		__MetadataDefinition( "fileSystemPathPlugValueWidget:includeSequences", "Allow sequences", _BoolMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
+		# Note that includeSequenceFrameRange is primarily used by GafferCortex.
+		# Think twice before using it elsewhere	as it may not exist in the future.
 		__MetadataDefinition( "fileSystemPathPlugValueWidget:includeSequenceFrameRange", "Sequences include frame range", _BoolMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
 	)
 

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -1636,6 +1636,7 @@ class _PlugEditor( GafferUI.Widget ) :
 		__MetadataDefinition( "pathPlugValueWidget:valid", "File Must Exist", _BoolMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
 		__MetadataDefinition( "pathPlugValueWidget:leaf", "No Directories", _BoolMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
 		__MetadataDefinition( "fileSystemPathPlugValueWidget:includeSequences", "Allow sequences", _BoolMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
+		__MetadataDefinition( "fileSystemPathPlugValueWidget:includeSequenceFrameRange", "Sequences include frame range", _BoolMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
 	)
 
 	__GadgetDefinition = collections.namedtuple( "GadgetDefinition", ( "label", "plugType", "metadata" ) )

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -172,6 +172,7 @@ from PathFilterWidget import PathFilterWidget
 from CompoundPathFilterWidget import CompoundPathFilterWidget
 from InfoPathFilterWidget import InfoPathFilterWidget
 from MatchPatternPathFilterWidget import MatchPatternPathFilterWidget
+from FileSequencePathFilterWidget import FileSequencePathFilterWidget
 from BusyWidget import BusyWidget
 from NumericSlider import NumericSlider
 from ColorChooser import ColorChooser

--- a/src/Gaffer/FileSequencePathFilter.cpp
+++ b/src/Gaffer/FileSequencePathFilter.cpp
@@ -1,0 +1,129 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/bind.hpp"
+#include "boost/filesystem.hpp"
+
+#include "IECore/FileSequence.h"
+#include "IECore/FileSequenceFunctions.h"
+
+#include "Gaffer/FileSystemPath.h"
+#include "Gaffer/FileSequencePathFilter.h"
+
+using namespace std;
+using namespace IECore;
+using namespace Gaffer;
+
+IE_CORE_DEFINERUNTIMETYPED( FileSequencePathFilter );
+
+FileSequencePathFilter::FileSequencePathFilter( Keep mode, IECore::CompoundDataPtr userData )
+	:	PathFilter( userData ), m_mode( mode )
+{
+}
+
+FileSequencePathFilter::~FileSequencePathFilter()
+{
+}
+
+FileSequencePathFilter::Keep FileSequencePathFilter::getMode() const
+{
+	return m_mode;
+}
+
+void FileSequencePathFilter::setMode( Keep mode )
+{
+	if ( mode == m_mode )
+	{
+		return;
+	}
+
+	m_mode = mode;
+	changedSignal()( this );
+}
+
+void FileSequencePathFilter::doFilter( std::vector<PathPtr> &paths ) const
+{
+	paths.erase(
+		std::remove_if(
+			paths.begin(),
+			paths.end(),
+			boost::bind( &FileSequencePathFilter::remove, this, ::_1 )
+		),
+		paths.end()
+	);
+}
+
+bool FileSequencePathFilter::remove( PathPtr path ) const
+{
+	FileSystemPath *fileSystemPath = IECore::runTimeCast<FileSystemPath>( path.get() );
+	if( !fileSystemPath )
+	{
+		// if it's not a FileSystemPath we shouldn't be removing anything
+		return false;
+	}
+
+	if( m_mode == All || boost::filesystem::is_directory( fileSystemPath->string() ) )
+	{
+		// always keep directories (and All)
+		return false;
+	}
+
+	if( ( m_mode & Sequences ) && ( fileSystemPath->fileSequence() != NULL ) )
+	{
+		// its a valid sequence, so keep it
+		return false;
+	}
+
+	std::vector<std::string> names( 1, fileSystemPath->string() );
+	std::vector<FileSequencePtr> sequences;
+	IECore::findSequences( names, sequences, /* minSequenceSize = */ 1 );
+	bool isSequentialFile = !sequences.empty();
+	
+	if( ( m_mode & SequentialFiles ) && isSequentialFile )
+	{
+		// its a file that could be part of a sequence, so keep it
+		return false;
+	}
+
+	if( ( m_mode & Files ) && !isSequentialFile && boost::filesystem::is_regular_file( fileSystemPath->string() ) )
+	{
+		// its a real file on disk that isn't a sequential file, so keep it
+		return false;
+	}
+
+	// remove anything that got here
+	return true;
+}

--- a/src/Gaffer/FileSequencePathFilter.cpp
+++ b/src/Gaffer/FileSequencePathFilter.cpp
@@ -101,7 +101,7 @@ bool FileSequencePathFilter::remove( PathPtr path ) const
 		return false;
 	}
 
-	if( ( m_mode & Sequences ) && ( fileSystemPath->fileSequence() != NULL ) )
+	if( ( m_mode & Sequences ) && ( fileSystemPath->isFileSequence() ) )
 	{
 		// its a valid sequence, so keep it
 		return false;

--- a/src/Gaffer/FileSystemPath.cpp
+++ b/src/Gaffer/FileSystemPath.cpp
@@ -375,13 +375,7 @@ PathFilterPtr FileSystemPath::createStandardFilter( const std::vector<std::strin
 	// Filter for sequences
 	if( includeSequenceFilter )
 	{
-		FileSequencePathFilterPtr sequenceFilter = new FileSequencePathFilter( /* mode = */ FileSequencePathFilter::Concise );
-
-		CompoundDataPtr sequenceUIUserData = new CompoundData;
-		sequenceUIUserData->writable()["label"] = new StringData( "Show sequences" );
-		sequenceFilter->userData()->writable()["UI"] = sequenceUIUserData;
-
-		result->addFilter( sequenceFilter );
+		result->addFilter( new FileSequencePathFilter( /* mode = */ FileSequencePathFilter::Concise ) );
 	}
 
 	// Filter for hidden files

--- a/src/Gaffer/FileSystemPath.cpp
+++ b/src/Gaffer/FileSystemPath.cpp
@@ -95,7 +95,7 @@ bool FileSystemPath::isValid() const
 		return false;
 	}
 
-	if( m_includeSequences && fileSequence() != NULL )
+	if( m_includeSequences && isFileSequence() )
 	{
 		return true;
 	}
@@ -109,23 +109,21 @@ bool FileSystemPath::isLeaf() const
 	return isValid() && !is_directory( path( this->string() ) );
 }
 
-bool FileSystemPath::includeSequences() const
+bool FileSystemPath::getIncludeSequences() const
 {
 	return m_includeSequences;
 }
 
-FileSequencePtr FileSystemPath::fileSequence( bool ls ) const
+void FileSystemPath::setIncludeSequences( bool includeSequences )
+{
+	m_includeSequences = includeSequences;
+}
+
+bool FileSystemPath::isFileSequence() const
 {
 	if( !m_includeSequences || is_directory( path( this->string() ) ) )
 	{
-		return NULL;
-	}
-	
-	if( ls )
-	{
-		FileSequencePtr sequence = 0;
-		IECore::ls( this->string(), sequence, /* minSequenceSize = */ 1 );
-		return sequence;
+		return false;
 	}
 
 	try
@@ -135,8 +133,20 @@ FileSequencePtr FileSystemPath::fileSequence( bool ls ) const
 	catch( ... )
 	{
 	}
-
+	
 	return NULL;
+}
+
+FileSequencePtr FileSystemPath::fileSequence() const
+{
+	if( !m_includeSequences || is_directory( path( this->string() ) ) )
+	{
+		return NULL;
+	}
+	
+	FileSequencePtr sequence = NULL;
+	IECore::ls( this->string(), sequence, /* minSequenceSize = */ 1 );
+	return sequence;
 }
 
 void FileSystemPath::propertyNames( std::vector<IECore::InternedString> &names ) const
@@ -160,7 +170,7 @@ IECore::ConstRunTimeTypedPtr FileSystemPath::property( const IECore::InternedStr
 	{
 		if( m_includeSequences )
 		{
-			FileSequencePtr sequence = fileSequence( /* ls = */ true );
+			FileSequencePtr sequence = fileSequence();
 			if( sequence )
 			{
 				std::vector<std::string> files;
@@ -197,7 +207,7 @@ IECore::ConstRunTimeTypedPtr FileSystemPath::property( const IECore::InternedStr
 	{
 		if( m_includeSequences )
 		{
-			FileSequencePtr sequence = fileSequence( /* ls = */ true );
+			FileSequencePtr sequence = fileSequence();
 			if( sequence )
 			{
 				std::vector<std::string> files;
@@ -236,7 +246,7 @@ IECore::ConstRunTimeTypedPtr FileSystemPath::property( const IECore::InternedStr
 		
 		if( m_includeSequences )
 		{
-			FileSequencePtr sequence = fileSequence( /* ls = */ true );
+			FileSequencePtr sequence = fileSequence();
 			if( sequence )
 			{
 				std::vector<std::string> files;
@@ -265,7 +275,7 @@ IECore::ConstRunTimeTypedPtr FileSystemPath::property( const IECore::InternedStr
 		
 		if( m_includeSequences )
 		{
-			FileSequencePtr sequence = fileSequence( /* ls = */ true );
+			FileSequencePtr sequence = fileSequence();
 			if( sequence )
 			{
 				std::vector<std::string> files;
@@ -290,7 +300,7 @@ IECore::ConstRunTimeTypedPtr FileSystemPath::property( const IECore::InternedStr
 	}
 	else if( name == g_frameRangePropertyName )
 	{
-		FileSequencePtr sequence = fileSequence( /* ls = */ true );
+		FileSequencePtr sequence = fileSequence();
 		if( sequence )
 		{
 			return new StringData( sequence->getFrameList()->asString() );

--- a/src/Gaffer/FileSystemPath.cpp
+++ b/src/Gaffer/FileSystemPath.cpp
@@ -50,6 +50,7 @@
 
 #include "Gaffer/PathFilter.h"
 #include "Gaffer/FileSystemPath.h"
+#include "Gaffer/FileSequencePathFilter.h"
 #include "Gaffer/CompoundPathFilter.h"
 #include "Gaffer/MatchPatternPathFilter.h"
 
@@ -336,7 +337,7 @@ void FileSystemPath::doChildren( std::vector<PathPtr> &children ) const
 	}
 }
 
-PathFilterPtr FileSystemPath::createStandardFilter( const std::vector<std::string> &extensions, const std::string &extensionsLabel )
+PathFilterPtr FileSystemPath::createStandardFilter( const std::vector<std::string> &extensions, const std::string &extensionsLabel, bool includeSequenceFilter )
 {
 	CompoundPathFilterPtr result = new CompoundPathFilter();
 
@@ -369,6 +370,18 @@ PathFilterPtr FileSystemPath::createStandardFilter( const std::vector<std::strin
 		fileNameFilter->userData()->writable()["UI"] = uiUserData;
 
 		result->addFilter( fileNameFilter );
+	}
+
+	// Filter for sequences
+	if( includeSequenceFilter )
+	{
+		FileSequencePathFilterPtr sequenceFilter = new FileSequencePathFilter( /* mode = */ FileSequencePathFilter::Concise );
+
+		CompoundDataPtr sequenceUIUserData = new CompoundData;
+		sequenceUIUserData->writable()["label"] = new StringData( "Show sequences" );
+		sequenceFilter->userData()->writable()["UI"] = sequenceUIUserData;
+
+		result->addFilter( sequenceFilter );
 	}
 
 	// Filter for hidden files

--- a/src/Gaffer/FileSystemPath.cpp
+++ b/src/Gaffer/FileSystemPath.cpp
@@ -134,7 +134,7 @@ bool FileSystemPath::isFileSequence() const
 	{
 	}
 	
-	return NULL;
+	return false;
 }
 
 FileSequencePtr FileSystemPath::fileSequence() const

--- a/src/Gaffer/FileSystemPath.cpp
+++ b/src/Gaffer/FileSystemPath.cpp
@@ -128,7 +128,7 @@ bool FileSystemPath::isFileSequence() const
 
 	try
 	{
-		return new FileSequence( this->string() );
+		return boost::regex_match( this->string(), FileSequence::fileNameValidator() );
 	}
 	catch( ... )
 	{

--- a/src/GafferBindings/FileSequencePathFilterBinding.cpp
+++ b/src/GafferBindings/FileSequencePathFilterBinding.cpp
@@ -1,0 +1,74 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "IECorePython/RunTimeTypedBinding.h"
+
+#include "Gaffer/FileSequencePathFilter.h"
+#include "GafferBindings/FileSequencePathFilterBinding.h"
+
+using namespace boost::python;
+using namespace IECore;
+using namespace IECorePython;
+using namespace Gaffer;
+
+void GafferBindings::bindFileSequencePathFilter()
+{
+	RunTimeTypedClass<FileSequencePathFilter> filterClass( "FileSequencePathFilter" );
+	scope s = filterClass;
+
+	enum_<FileSequencePathFilter::Keep>( "Keep" )
+		.value( "Files", FileSequencePathFilter::Files )
+		.value( "SequentialFiles", FileSequencePathFilter::SequentialFiles )
+		.value( "Sequences", FileSequencePathFilter::Sequences )
+		.value( "Concise", FileSequencePathFilter::Concise )
+		.value( "Verbose", FileSequencePathFilter::Verbose )
+		.value( "All", FileSequencePathFilter::All )
+	;
+
+	filterClass
+		.def( init<FileSequencePathFilter::Keep, CompoundDataPtr>(
+			(
+				arg( "mode" ) = FileSequencePathFilter::Concise,
+				arg( "userData" ) = object()
+			)
+		) )
+		.def( "getMode", &FileSequencePathFilter::getMode )
+		.def( "setMode", &FileSequencePathFilter::setMode )
+	;
+
+}

--- a/src/GafferBindings/FileSystemPathBinding.cpp
+++ b/src/GafferBindings/FileSystemPathBinding.cpp
@@ -76,11 +76,10 @@ void GafferBindings::bindFileSystemPath()
 				arg( "includeSequences" ) = false
 			) )
 		)
-		.def( "includeSequences", &FileSystemPath::includeSequences )
-		.def( "fileSequence", &FileSystemPath::fileSequence, (
-				arg( "ls" ) = false
-			)
-		)
+		.def( "getIncludeSequences", &FileSystemPath::getIncludeSequences )
+		.def( "setIncludeSequences", &FileSystemPath::setIncludeSequences )
+		.def( "isFileSequence", &FileSystemPath::isFileSequence )
+		.def( "fileSequence", &FileSystemPath::fileSequence )
 		.def( "createStandardFilter", &createStandardFilter, (
 				arg( "extensions" ) = list(),
 				arg( "extensionsLabel" ) = "",

--- a/src/GafferBindings/FileSystemPathBinding.cpp
+++ b/src/GafferBindings/FileSystemPathBinding.cpp
@@ -50,11 +50,11 @@ using namespace GafferBindings;
 namespace
 {
 
-PathFilterPtr createStandardFilter( object pythonExtensions, const std::string &extensionsLabel )
+PathFilterPtr createStandardFilter( object pythonExtensions, const std::string &extensionsLabel, bool includeSequences )
 {
 	std::vector<std::string> extensions;
 	boost::python::container_utils::extend_container( extensions, pythonExtensions );
-	return FileSystemPath::createStandardFilter( extensions, extensionsLabel );
+	return FileSystemPath::createStandardFilter( extensions, extensionsLabel, includeSequences );
 }
 
 } // namespace
@@ -83,7 +83,8 @@ void GafferBindings::bindFileSystemPath()
 		)
 		.def( "createStandardFilter", &createStandardFilter, (
 				arg( "extensions" ) = list(),
-				arg( "extensionsLabel" ) = ""
+				arg( "extensionsLabel" ) = "",
+				arg( "includeSequenceFilter" ) = false
 			)
 		)
 		.staticmethod( "createStandardFilter" )

--- a/src/GafferBindings/FileSystemPathBinding.cpp
+++ b/src/GafferBindings/FileSystemPathBinding.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2014, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2014-2015, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -64,13 +64,22 @@ void GafferBindings::bindFileSystemPath()
 
 	PathClass<FileSystemPath>()
 		.def(
-			init<PathFilterPtr>( arg( "filter" ) = object() )
+			init<PathFilterPtr, bool>( (
+				arg( "filter" ) = object(),
+				arg( "includeSequences" ) = false
+			) )
 		)
 		.def(
-			init<const std::string &, PathFilterPtr>( (
+			init<const std::string &, PathFilterPtr, bool>( (
 				arg( "path" ),
-				arg( "filter" ) = object()
+				arg( "filter" ) = object(),
+				arg( "includeSequences" ) = false
 			) )
+		)
+		.def( "includeSequences", &FileSystemPath::includeSequences )
+		.def( "fileSequence", &FileSystemPath::fileSequence, (
+				arg( "ls" ) = false
+			)
 		)
 		.def( "createStandardFilter", &createStandardFilter, (
 				arg( "extensions" ) = list(),

--- a/src/GafferModule/GafferModule.cpp
+++ b/src/GafferModule/GafferModule.cpp
@@ -1,7 +1,7 @@
 //////////////////////////////////////////////////////////////////////////
 //
 //  Copyright (c) 2011-2012, John Haddon. All rights reserved.
-//  Copyright (c) 2011-2014, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2011-2015, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -90,6 +90,7 @@
 #include "GafferBindings/LeafPathFilterBinding.h"
 #include "GafferBindings/MatchPatternPathFilterBinding.h"
 #include "GafferBindings/FileSystemPathBinding.h"
+#include "GafferBindings/FileSequencePathFilterBinding.h"
 
 using namespace boost::python;
 using namespace Gaffer;
@@ -183,6 +184,7 @@ BOOST_PYTHON_MODULE( _Gaffer )
 	bindLeafPathFilter();
 	bindMatchPatternPathFilter();
 	bindFileSystemPath();
+	bindFileSequencePathFilter();
 
 	NodeClass<Backdrop>();
 

--- a/src/GafferUIBindings/PathListingWidgetBinding.cpp
+++ b/src/GafferUIBindings/PathListingWidgetBinding.cpp
@@ -57,6 +57,7 @@
 #include "IECorePython/ScopedGILLock.h"
 
 #include "Gaffer/Path.h"
+#include "Gaffer/FileSystemPath.h"
 
 #include "GafferUIBindings/PathListingWidgetBinding.h"
 
@@ -288,6 +289,21 @@ class FileIconColumn : public Column
 			if( role == Qt::DecorationRole )
 			{
 				std::string s = path->string();
+
+				if( const FileSystemPath *fileSystemPath = IECore::runTimeCast<const FileSystemPath>( path ) )
+				{
+					if( fileSystemPath->includeSequences() )
+					{
+						IECore::FileSequencePtr seq = fileSystemPath->fileSequence( /* ls = */ true );
+						if( seq )
+						{
+							std::vector<IECore::FrameList::Frame> frames;
+							seq->getFrameList()->asList( frames );
+							s = seq->fileNameForFrame( *frames.begin() );
+						}
+					}
+				}
+
 				QString qs( s.c_str() );
 				return m_iconProvider.icon( QFileInfo( qs ) );
 			}

--- a/src/GafferUIBindings/PathListingWidgetBinding.cpp
+++ b/src/GafferUIBindings/PathListingWidgetBinding.cpp
@@ -292,9 +292,9 @@ class FileIconColumn : public Column
 
 				if( const FileSystemPath *fileSystemPath = IECore::runTimeCast<const FileSystemPath>( path ) )
 				{
-					if( fileSystemPath->includeSequences() )
+					if( fileSystemPath->getIncludeSequences() )
 					{
-						IECore::FileSequencePtr seq = fileSystemPath->fileSequence( /* ls = */ true );
+						IECore::FileSequencePtr seq = fileSystemPath->fileSequence();
 						if( seq )
 						{
 							std::vector<IECore::FrameList::Frame> frames;


### PR DESCRIPTION
This brings support for `IECore::FileSequences` as valid `Gaffer::FileSystemPath` leaves. `FileSystemPath` has a new argument to the constructor to include sequences. If this is on, `children()` will list all directories, real files, and file sequences. `FileSystemPaths` which represent sequences provide the frame range as a property, not as part of the path itself. The children can then be filtered down to a subset using `FileSequencePathFilter` with the `Keep` bitmask as desired.

`FileSystemPath's` standard filter includes the `FileSequencePathFilter` if the path was set to include sequences, and this is represented in the `FileSystemPathPlugValueWidget` UI via `FileSequencePathFilterWidget`, which is a checkbox that toggles between `Concise` and `Verbose` mode on the filter.

The `ImageReader` and `ImageWriter` fileName plugs are set to include sequences by default, as is `FileSequenceParameterValueWidget`, and this option is exposed to the `UIEditor` so `Box`-makers can opt in as well.

`FileSystemPathValueWidget` can also optionally append the frame range to the plug value when a path representing a `FileSequence` is selected. This option can be set in the `UIEditor` for `Box`-maker convenience as well, and for `FileSequenceParameterValueWidget` it is driven by parameter userData.

Finally, `Gaffer::SequencePath` has been deprecated, though we haven't actually removed all uses of it within Gaffer just yet.