### PR TITLE
ScriptNode : Save version metadata in `serialiseToFile()`.

### DIFF
--- a/python/GafferTest/ScriptNodeTest.py
+++ b/python/GafferTest/ScriptNodeTest.py
@@ -1216,6 +1216,29 @@ a = A()"""
 		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:minorVersion" ), Gaffer.About.minorVersion() )
 		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:patchVersion" ), Gaffer.About.patchVersion() )
 
+	def testFileVersioningUpdatesOnSave( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( os.path.dirname( __file__ ) + "/scripts/previousSerialisationVersion.gfr" )
+		s.load()
+
+		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:milestoneVersion" ), 0 )
+		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:majorVersion" ), 14 )
+		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:minorVersion" ), 0 )
+		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:patchVersion" ), 0 )
+
+		s["fileName"].setValue( "/tmp/test.gfr" )
+		s.save()
+
+		s2 = Gaffer.ScriptNode()
+		s2["fileName"].setValue( "/tmp/test.gfr" )
+		s2.load()
+
+		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:milestoneVersion" ), Gaffer.About.milestoneVersion() )
+		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:majorVersion" ), Gaffer.About.majorVersion() )
+		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:minorVersion" ), Gaffer.About.minorVersion() )
+		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:patchVersion" ), Gaffer.About.patchVersion() )
+
 	def tearDown( self ) :
 
 		for f in (

--- a/python/GafferTest/ScriptNodeTest.py
+++ b/python/GafferTest/ScriptNodeTest.py
@@ -1181,6 +1181,41 @@ a = A()"""
 		s = Gaffer.ScriptNode()
 		self.assertRaisesRegexp( RuntimeError, "Line 2 .* name 'iDontExist' is not defined", s.execute, "a = 10\na=iDontExist" )
 
+	def testFileVersioning( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:milestoneVersion" ), None )
+		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:majorVersion" ), None )
+		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:minorVersion" ), None )
+		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:patchVersion" ), None )
+
+		s.serialiseToFile( "/tmp/test.gfr" )
+
+		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:milestoneVersion" ), None )
+		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:majorVersion" ), None )
+		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:minorVersion" ), None )
+		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:patchVersion" ), None )
+
+		s2 = Gaffer.ScriptNode()
+		s2["fileName"].setValue( "/tmp/test.gfr" )
+		s2.load()
+
+		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:milestoneVersion" ), Gaffer.About.milestoneVersion() )
+		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:majorVersion" ), Gaffer.About.majorVersion() )
+		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:minorVersion" ), Gaffer.About.minorVersion() )
+		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:patchVersion" ), Gaffer.About.patchVersion() )
+
+		s["fileName"].setValue( "/tmp/test.gfr" )
+		s.save()
+
+		s2.load()
+
+		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:milestoneVersion" ), Gaffer.About.milestoneVersion() )
+		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:majorVersion" ), Gaffer.About.majorVersion() )
+		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:minorVersion" ), Gaffer.About.minorVersion() )
+		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:patchVersion" ), Gaffer.About.patchVersion() )
+
 	def tearDown( self ) :
 
 		for f in (

--- a/python/GafferTest/scripts/previousSerialisationVersion.gfr
+++ b/python/GafferTest/scripts/previousSerialisationVersion.gfr
@@ -1,0 +1,6 @@
+import Gaffer
+
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:majorVersion", 14, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:minorVersion", 0, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:patchVersion", 0, persistent=False )

--- a/src/Gaffer/Box.cpp
+++ b/src/Gaffer/Box.cpp
@@ -375,7 +375,6 @@ void Box::exportForReference( const std::string &fileName ) const
 	ContextPtr context = new Context;
 	context->set( "valuePlugSerialiser:resetParentPlugDefaults", true );
 	context->set( "serialiser:includeParentMetadata", true );
-	context->set( "serialiser:includeVersionMetadata", true );
 	Context::Scope scopedContext( context.get() );
 
 	script->serialiseToFile( fileName, this, toExport.get() );

--- a/src/GafferBindings/ScriptNodeBinding.cpp
+++ b/src/GafferBindings/ScriptNodeBinding.cpp
@@ -166,6 +166,10 @@ class ScriptNodeWrapper : public NodeWrapper<ScriptNode>
 
 		virtual void serialiseToFile( const std::string &fileName, const Node *parent, const Set *filter ) const
 		{
+			ContextPtr context = new Context( *Context::current(), Context::Borrowed );
+			context->set( "serialiser:includeVersionMetadata", true );
+			Context::Scope scopedContext( context.get() );
+
 			std::string s = serialise( parent, filter );
 
 			std::ofstream f( fileName.c_str() );


### PR DESCRIPTION
This can be used for informational purposes and also to assist in providing backwards compatibility with old files. This mechanism has been in use for some time in the Box/Reference export code - this just generalises it for all serialised files. At the time we introduced it for Boxes I was unsure if it should apply elsewhere, but we now have a use case for it on ScriptNodes (Hugh's #1444). Since serialising to file implies later reloading that file, it seemed worth providing this information everywhere a file is saved, rather than just in `ScriptNode::save()`.

When importing a file into an existing ScriptNode, the values of the version metadata are potentially a little confusing, since the import overrides the existing value. The metadata is therefore best viewed as "the version of gaffer used to write the last file that was loaded or imported". Since our primary use case is during loading, hopefully this is acceptable for now.

Fixes #1436.