### PR TITLE
Prune isolate tweaks

### DIFF
--- a/python/GafferSceneTest/IsolateTest.py
+++ b/python/GafferSceneTest/IsolateTest.py
@@ -322,5 +322,25 @@ class IsolateTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( isolate["out"].childNames( "/group1" ), IECore.InternedStringVectorData( [ "group2", "light3" ] ) )
 		self.assertEqual( isolate["out"].childNames( "/group1/group2" ), IECore.InternedStringVectorData( [ "light1" ] ) )
 
+	def testIsolateNothing( self ) :
+
+		sphere = GafferScene.Sphere()
+		sphere["sets"].setValue("sphereSet")
+
+		i = GafferScene.Isolate()
+		i["in"].setInput( sphere["out"] )
+		pathFilter = GafferScene.PathFilter()
+		i["filter"].setInput( pathFilter["out"] )
+		pathFilter["paths"].setValue( IECore.StringVectorData( [ "/sphere" ] ) )
+
+		self.assertEqual( i["out"].childNames("/"), IECore.InternedStringVectorData( [ "sphere" ] ) )
+		self.assertEqual( i["out"].set( "sphereSet" ).value.paths(), ["/sphere"] )
+
+		pathFilter["paths"].setValue( IECore.StringVectorData() )
+
+		self.assertEqual( i["out"].set( "sphereSet" ).value.paths(), [] )
+		self.assertEqual( i["out"].childNames("/"), IECore.InternedStringVectorData() )
+
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/PruneTest.py
+++ b/python/GafferSceneTest/PruneTest.py
@@ -260,6 +260,22 @@ class PruneTest( GafferSceneTest.SceneTestCase ) :
 		lightSet = prune["out"].set( "__lights" )
 		self.assertEqual( set( lightSet.value.paths() ), set( [ "/group/group1/light" ] ) )
 
+	def testPruneRoot( self ) :
+
+		sphere = GafferScene.Sphere()
+		sphere["sets"].setValue("sphereSet")
+
+		p = GafferScene.Prune()
+		p["in"].setInput( sphere["out"] )
+		pathFilter = GafferScene.PathFilter()
+		p["filter"].setInput( pathFilter["out"] )
+
+		self.assertEqual( p["out"].childNames("/"), IECore.InternedStringVectorData( [ "sphere" ] ) )
+		self.assertEqual( p["out"].set( "sphereSet" ).value.paths(), ["/sphere"] )
+		pathFilter["paths"].setValue( IECore.StringVectorData( ["/"] ) )
+		self.assertEqual( p["out"].set( "sphereSet" ).value.paths(), [] )
+		self.assertEqual( p["out"].childNames("/"), IECore.InternedStringVectorData() )
+
 	def testFilterPromotion( self ) :
 
 		b = Gaffer.Box()

--- a/src/GafferScene/Isolate.cpp
+++ b/src/GafferScene/Isolate.cpp
@@ -287,5 +287,5 @@ bool Isolate::mayPruneChildren( const ScenePath &path, unsigned filterValue ) co
 		return false;
 	}
 
-	return filterValue == Filter::DescendantMatch;
+	return filterValue == Filter::DescendantMatch || filterValue == Filter::NoMatch;
 }

--- a/src/GafferScene/Prune.cpp
+++ b/src/GafferScene/Prune.cpp
@@ -128,8 +128,13 @@ void Prune::hashChildNames( const ScenePath &path, const Gaffer::Context *contex
 {
 	ContextPtr tmpContext = filterContext( context );
 	Context::Scope scopedContext( tmpContext.get() );
+	Filter::Result m = (Filter::Result)filterPlug()->getValue();
 
-	if( filterPlug()->getValue() & Filter::DescendantMatch )
+	if( m & Filter::ExactMatch )
+	{
+		inPlug()->childNamesPlug()->defaultValue()->hash( h );
+	}
+	else if( m & Filter::DescendantMatch )
 	{
 		// we might be computing new childnames for this level.
 		FilteredSceneProcessor::hashChildNames( path, context, parent, h );
@@ -147,8 +152,13 @@ IECore::ConstInternedStringVectorDataPtr Prune::computeChildNames( const ScenePa
 {
 	ContextPtr tmpContext = filterContext( context );
 	Context::Scope scopedContext( tmpContext.get() );
+	Filter::Result m = (Filter::Result)filterPlug()->getValue();
 
-	if( filterPlug()->getValue() & Filter::DescendantMatch )
+	if( m & Filter::ExactMatch  )
+	{
+		return inPlug()->childNamesPlug()->defaultValue();
+	}
+	else if( m & Filter::DescendantMatch )
 	{
 		// we may need to delete one or more of our children
 		ConstInternedStringVectorDataPtr inputChildNamesData = inPlug()->childNamesPlug()->getValue();

--- a/src/GafferScene/Prune.cpp
+++ b/src/GafferScene/Prune.cpp
@@ -128,10 +128,11 @@ void Prune::hashChildNames( const ScenePath &path, const Gaffer::Context *contex
 {
 	ContextPtr tmpContext = filterContext( context );
 	Context::Scope scopedContext( tmpContext.get() );
-	Filter::Result m = (Filter::Result)filterPlug()->getValue();
+	const Filter::Result m = (Filter::Result)filterPlug()->getValue();
 
 	if( m & Filter::ExactMatch )
 	{
+		h = IECore::MurmurHash();
 		inPlug()->childNamesPlug()->defaultValue()->hash( h );
 	}
 	else if( m & Filter::DescendantMatch )
@@ -152,7 +153,7 @@ IECore::ConstInternedStringVectorDataPtr Prune::computeChildNames( const ScenePa
 {
 	ContextPtr tmpContext = filterContext( context );
 	Context::Scope scopedContext( tmpContext.get() );
-	Filter::Result m = (Filter::Result)filterPlug()->getValue();
+	const Filter::Result m = (Filter::Result)filterPlug()->getValue();
 
 	if( m & Filter::ExactMatch  )
 	{


### PR DESCRIPTION
Mathias was running into situations where Prune/Isolate nodes cleared out all the sets without doing anything to the scene. It turns out this was because the computeChildNames behavior for these nodes was inconsistent with the computeSets behaviour, so I've made this pull request to bring the two in line.