### PR TITLE
ShaderSwitch NodeGraph UI Fix

### DIFF
--- a/python/GafferSceneUI/GroupUI.py
+++ b/python/GafferSceneUI/GroupUI.py
@@ -56,12 +56,6 @@ Gaffer.Metadata.registerNode(
 
 	plugs = {
 
-		"in*" : [
-
-			"plugValueWidget:type", "",
-
-		],
-
 		"name" : [
 
 			"description",

--- a/python/GafferSceneUI/SceneProcessorUI.py
+++ b/python/GafferSceneUI/SceneProcessorUI.py
@@ -54,6 +54,7 @@ Gaffer.Metadata.registerNode(
 		"in" : [
 
 			"description", lambda plug : "The input scene" + ( "s" if isinstance( plug, Gaffer.ArrayPlug ) else "" ),
+			"plugValueWidget:type", "",
 			"nodule:type", lambda plug : "GafferUI::CompoundNodule" if isinstance( plug, Gaffer.ArrayPlug ) else "GafferUI::StandardNodule",
 			"compoundNodule:spacing", 2.0,
 

--- a/python/GafferSceneUI/SceneSwitchUI.py
+++ b/python/GafferSceneUI/SceneSwitchUI.py
@@ -50,12 +50,6 @@ Gaffer.Metadata.registerNode(
 
 	plugs = {
 
-		"in*" : [
-
-			"plugValueWidget:type", "",
-
-		],
-
 		"index" : [
 
 			"description",

--- a/python/GafferSceneUI/ShaderSwitchUI.py
+++ b/python/GafferSceneUI/ShaderSwitchUI.py
@@ -54,20 +54,19 @@ Gaffer.Metadata.registerNode(
 
 	plugs = {
 
-		"in*" : [
-
-			"nodeGadget:nodulePosition", "left",
-			"plugValueWidget:type", "",
-
-		],
-
 		"in" : [
 
 			"description",
 			"""
-			The first input shader - the one passed through when
-			the index is 0.
+			The input shaders - the index plug decides
+			which of these is passed through to the output.
 			""",
+
+			"plugValueWidget:type", "",
+			"nodule:type", "GafferUI::CompoundNodule",
+			"nodeGadget:nodulePosition", "left",
+			"compoundNodule:orientation", "y",
+			"compoundNodule:spacing", 0.2,
 
 		],
 


### PR DESCRIPTION
This fixes the representation of the ShaderSwitch in the NodeGraph - the new input ArrayPlug was being displayed as a single parent plug rather than having all its children displayed. It also tidies up a few unnecessary metadata registrations hanging around from the pre-array days.