### PR TITLE
UIEditor : Never edit user plug for Box nodes.

### DIFF
--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -176,14 +176,12 @@ class UIEditor( GafferUI.NodeSetEditor ) :
 			self.__sectionEditor.setPlugParent( None )
 		else :
 			plugParent = self.__node["user"]
-			if isinstance( self.__node, Gaffer.Box ) and not len( plugParent ) :
+			if isinstance( self.__node, Gaffer.Box ) :
 				# For Boxes we want the user to edit the plugs directly
 				# parented to the Box, because that is where promoted plugs go,
 				# and because we want to leave the "user" plug empty so that it
 				# is available for use by the user on Reference nodes once a Box has
-				# been exported and referenced. We make a small concession to old-skool
-				# boxes (where we mistakenly used to promote to the "user" plug) by
-				# editing the user plugs instead if any exist.
+				# been exported and referenced.
 				plugParent = self.__node
 			self.__plugListing.setPlugParent( plugParent )
 			self.__sectionEditor.setPlugParent( plugParent )


### PR DESCRIPTION
We only want the user to edit plugs directly on the box, so that the user plug is available to downstream users of References (and one day gizmo type things). But we were trying to provide help for old boxes by editing the user plugs instead if they'd been used previously. This isn't working out, so we're removing that fallback, and will provide a separate means of upgrading old boxes internally at IE.