### PR TITLE
Box : Copy all metadata when promoting plugs.

### DIFF
--- a/python/GafferTest/BoxTest.py
+++ b/python/GafferTest/BoxTest.py
@@ -961,5 +961,28 @@ class BoxTest( GafferTest.TestCase ) :
 		self.assertEqual( len( s2["b"]["n"]["in"] ), 3 )
 		self.assertTrue( s2["b"]["n"]["in"].getInput().isSame( s2["b"]["p"] ) )
 
+	def testPromotionIncludesArbitraryMetadata( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["b"] = Gaffer.Box()
+		s["b"]["n"] = Gaffer.Node()
+		s["b"]["n"]["user"]["p"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		Gaffer.Metadata.registerPlugValue( s["b"]["n"]["user"]["p"], "testInt", 10 )
+		Gaffer.Metadata.registerPlugValue( s["b"]["n"]["user"]["p"], "testString", "test" )
+
+		p = s["b"].promotePlug( s["b"]["n"]["user"]["p"] )
+		p.setName( "p" )
+
+		self.assertEqual( Gaffer.Metadata.plugValue( p, "testInt" ), 10 )
+		self.assertEqual( Gaffer.Metadata.plugValue( p, "testString" ), "test" )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		self.assertEqual( Gaffer.Metadata.plugValue( s2["b"]["p"], "testInt" ), 10 )
+		self.assertEqual( Gaffer.Metadata.plugValue( s2["b"]["p"], "testString" ), "test" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/BoxUITest.py
+++ b/python/GafferUITest/BoxUITest.py
@@ -180,5 +180,18 @@ class BoxUITest( GafferUITest.TestCase ) :
 
 		self.assertEqual( g.nodeGadget( s["b1"] ).nodule( s["b1"]["p"] ), None )
 
+	def testPromotionIgnoresLayoutSection( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["b"] = Gaffer.Box()
+		s["b"]["n"] = Gaffer.Node()
+
+		s["b"]["n"]["user"]["p"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		Gaffer.Metadata.registerPlugValue( s["b"]["n"]["user"]["p"], "layout:section", "SomeWeirdSection" )
+
+		p = s["b"].promotePlug( s["b"]["n"]["user"]["p"] )
+		self.assertNotEqual( Gaffer.Metadata.plugValue( p, "layout:section" ), "SomeWeirdSection" )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
Except of course layout metadata, because it's really not very useful to the user if the promoted plug appears in a strange section with a frozen activator value.