### PR TITLE
Fixed issue where non-ValuePlugs were not syncing during setPlugValue().

### DIFF
--- a/src/GafferCortex/CompoundParameterHandler.cpp
+++ b/src/GafferCortex/CompoundParameterHandler.cpp
@@ -194,6 +194,10 @@ void CompoundParameterHandler::setPlugValue()
 					h->setPlugValue();
 				}
 			}
+			else
+			{
+				h->setPlugValue();
+			}
 		}
 	}
 }


### PR DESCRIPTION
So the change I introduced in Gaffer 0.16.0.0 to prevent GafferCortex from trying to set non-settable plugs also introduced a bug where ParameterHandlers for non-ValuePlugs were not longer calling setPlugValue at all.

It maybe seems a bit odd to have a ParameterHandler associated with a non-ValuePlug, but Jabuka does this in several scenarios, and this fix seems simple enough to justify changing back to our previous behaviour.