### PR TITLE
Box : Transfer metadata for children of promoted plugs too.

### DIFF
--- a/python/GafferRenderManUITest/RenderManAttributesUITest.py
+++ b/python/GafferRenderManUITest/RenderManAttributesUITest.py
@@ -34,9 +34,20 @@
 #
 ##########################################################################
 
-from DocumentationTest import DocumentationTest
-from RenderManShaderUITest import RenderManShaderUITest
-from RenderManAttributesUITest import RenderManAttributesUITest
+import Gaffer
+import GafferRenderMan
+import GafferRenderManTest
+import GafferRenderManUI
+
+class RenderManAttributesUITest( GafferRenderManTest.RenderManTestCase ) :
+
+	def testPromotedCameraHitMode( self ) :
+
+		b = Gaffer.Box()
+		b["a"] = GafferRenderMan.RenderManAttributes()
+
+		p = b.promotePlug( b["a"]["attributes"]["cameraHitMode"] )
+		self.assertEqual( Gaffer.NodeAlgo.presets( p["value" ] ), [ "Shader", "Primitive" ] )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/BoxTest.py
+++ b/python/GafferTest/BoxTest.py
@@ -984,5 +984,29 @@ class BoxTest( GafferTest.TestCase ) :
 		self.assertEqual( Gaffer.Metadata.plugValue( s2["b"]["p"], "testInt" ), 10 )
 		self.assertEqual( Gaffer.Metadata.plugValue( s2["b"]["p"], "testString" ), "test" )
 
+	def testPromotionIncludesArbitraryChildMetadata( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["b"] = Gaffer.Box()
+		s["b"]["n"] = Gaffer.Node()
+		s["b"]["n"]["user"]["p"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["b"]["n"]["user"]["p"]["i"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		Gaffer.Metadata.registerPlugValue( s["b"]["n"]["user"]["p"], "testInt", 10 )
+		Gaffer.Metadata.registerPlugValue( s["b"]["n"]["user"]["p"]["i"], "testString", "test" )
+
+		p = s["b"].promotePlug( s["b"]["n"]["user"]["p"] )
+		p.setName( "p" )
+
+		self.assertEqual( Gaffer.Metadata.plugValue( p, "testInt" ), 10 )
+		self.assertEqual( Gaffer.Metadata.plugValue( p["i"], "testString" ), "test" )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		self.assertEqual( Gaffer.Metadata.plugValue( s2["b"]["p"], "testInt" ), 10 )
+		self.assertEqual( Gaffer.Metadata.plugValue( s2["b"]["p"]["i"], "testString" ), "test" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/Box.cpp
+++ b/src/Gaffer/Box.cpp
@@ -503,4 +503,12 @@ void Box::copyMetadata( const Plug *from, Plug *to )
 		}
 		Metadata::registerPlugValue( to, *it, Metadata::plugValue<IECore::Data>( from, *it ) );
 	}
+
+	for( PlugIterator it( from ); it != it.end(); ++it )
+	{
+		if( Plug *childTo = to->getChild<Plug>( (*it)->getName() ) )
+		{
+			copyMetadata( it->get(), childTo );
+		}
+	}
 }


### PR DESCRIPTION
This fixes a problem whereby presets were not being transferred when promoting a compound plug on a RenderManAttributes node.

Fixes #1468