### PR TITLE
Added method to retrieve a Serialiser based on TypeId.

### DIFF
--- a/include/GafferBindings/Serialisation.h
+++ b/include/GafferBindings/Serialisation.h
@@ -119,6 +119,8 @@ class Serialisation
 		/// Serialisers do not have state, so this method may return the same Serialiser from
 		/// different calls even when the objects are different.
 		static const Serialiser *acquireSerialiser( const Gaffer::GraphComponent *graphComponent );
+		/// Returns a Serialiser suitable for serialisation of the specified type of object.
+		static const Serialiser *registeredSerialiser( IECore::TypeId targetType );
 
 	private :
 

--- a/python/GafferTest/SerialisationTest.py
+++ b/python/GafferTest/SerialisationTest.py
@@ -56,7 +56,7 @@ class SerialisationTest( GafferTest.TestCase ) :
 
 	def testCustomSerialiser( self ) :
 
-		class CustomSerialiser( Gaffer.Serialisation.Serialiser ) :
+		class CustomSerialiser( type(Gaffer.Serialisation.registeredSerialiser( Gaffer.Node )) ) :
 
 			def moduleDependencies( self, node ) :
 
@@ -85,7 +85,7 @@ class SerialisationTest( GafferTest.TestCase ) :
 				elif isinstance( child, Gaffer.Plug ) :
 					return child.getFlags( Gaffer.Plug.Flags.Serialisable )
 
-				return False
+				return super( CustomSerialiser, self ).childNeedsSerialisation( child )
 
 			def childNeedsConstruction( self, child ) :
 
@@ -94,7 +94,7 @@ class SerialisationTest( GafferTest.TestCase ) :
 				elif isinstance( child, Gaffer.Plug ) :
 					return child.getFlags( Gaffer.Plug.Flags.Dynamic )
 
-				return False
+				return super( CustomSerialiser, self ).childNeedsConstruction( child )
 
 		customSerialiser = CustomSerialiser()
 		Gaffer.Serialisation.registerSerialiser( self.SerialisationTestNode, customSerialiser )

--- a/src/GafferBindings/Serialisation.cpp
+++ b/src/GafferBindings/Serialisation.cpp
@@ -286,16 +286,20 @@ void Serialisation::registerSerialiser( IECore::TypeId targetType, SerialiserPtr
 
 const Serialisation::Serialiser *Serialisation::acquireSerialiser( const GraphComponent *graphComponent )
 {
+	return registeredSerialiser( graphComponent->typeId() );
+}
+
+const Serialisation::Serialiser *Serialisation::registeredSerialiser( IECore::TypeId targetType )
+{
 	const SerialiserMap &m = serialiserMap();
-	IECore::TypeId t = graphComponent->typeId();
-	while( t != IECore::InvalidTypeId )
+	while( targetType != IECore::InvalidTypeId )
 	{
-		SerialiserMap::const_iterator it = m.find( t );
+		SerialiserMap::const_iterator it = m.find( targetType );
 		if( it != m.end() )
 		{
 			return it->second.get();
 		}
-		t = IECore::RunTimeTyped::baseTypeId( t );
+		targetType = IECore::RunTimeTyped::baseTypeId( targetType );
 	}
 
 	assert( NULL );
@@ -527,6 +531,8 @@ void GafferBindings::bindSerialisation()
 		.staticmethod( "registerSerialiser" )
 		.def( "acquireSerialiser", &Serialisation::acquireSerialiser, return_value_policy<reference_existing_object>() )
 		.staticmethod( "acquireSerialiser" )
+		.def( "registeredSerialiser", &Serialisation::registeredSerialiser, return_value_policy<reference_existing_object>() )
+		.staticmethod( "registeredSerialiser" )
 	;
 
 	IECorePython::RefCountedClass<Serialisation::Serialiser, IECore::RefCounted, SerialiserWrapper>( "Serialiser" )


### PR DESCRIPTION
This allows python Serialisers to find their base Serialiser in order to implement proper fallbacks.