### PR TITLE
Output attributes to the renderer before other state

### DIFF
--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -331,6 +331,17 @@ void createDisplayDirectories( const IECore::CompoundObject *globals )
 
 void outputAttributes( const IECore::CompoundObject *attributes, IECore::Renderer *renderer )
 {
+	// Output attributes before other state
+	// This covers a special case in 3delight:  when reading attributes in the construct() of a shader, they will only be visible
+	// if they are declared before the shader
+	for( CompoundObject::ObjectMap::const_iterator it = attributes->members().begin(), eIt = attributes->members().end(); it != eIt; it++ )
+	{
+		if( const Data *d = runTimeCast<const Data>( it->second.get() ) )
+		{
+			renderer->setAttribute( it->first, d );
+		}
+	}
+
 	for( CompoundObject::ObjectMap::const_iterator it = attributes->members().begin(), eIt = attributes->members().end(); it != eIt; it++ )
 	{
 		if( const StateRenderable *s = runTimeCast<const StateRenderable>( it->second.get() ) )
@@ -347,10 +358,6 @@ void outputAttributes( const IECore::CompoundObject *attributes, IECore::Rendere
 					s->render( renderer );
 				}
 			}
-		}
-		else if( const Data *d = runTimeCast<const Data>( it->second.get() ) )
-		{
-			renderer->setAttribute( it->first, d );
 		}
 	}
 }


### PR DESCRIPTION
This is a pretty simple pull request that fixes the potential for inconsistent behaviour that currently exists.

In RenderMan, shaders can only read attributes that are declared before them, so currently, if you have a shader and an attribute at the same scope in Gaffer, whether or not the shader can see the attribute depends on the random ordering of the state elements.

This seems like a fairly reasonable change - it affects all renderers, but I can't picture any renderer having a problem with attributes coming before other state.  My one question for John is what the best place to test this would be - I guess probably with a set of nodes that build a scene and then check it with a capturing renderer in GafferSceneTest/RenderTest?

I have already confirmed that this fixes some weirdness I was seeing when I tried to roll out: http://shotgun/detail/Ticket/5892

Hopefully the approach seems reasonable.