### PR TITLE
Osl Object Trace Hacking

### DIFF
--- a/include/GafferOSL/OSLObject.h
+++ b/include/GafferOSL/OSLObject.h
@@ -57,6 +57,9 @@ class OSLObject : public GafferScene::SceneElementProcessor
 		Gaffer::Plug *shaderPlug();
 		const Gaffer::Plug *shaderPlug() const;
 
+		GafferScene::ScenePlug *traceGeometryPlug();
+		const GafferScene::ScenePlug *traceGeometryPlug() const;
+
 		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
 
 	protected :

--- a/include/GafferOSL/OSLRenderer.h
+++ b/include/GafferOSL/OSLRenderer.h
@@ -153,6 +153,7 @@ class OSLRenderer : public IECore::Renderer
 	private :
 
 		class RenderState;
+		class TraceData;
 		class RendererServices;
 		class ShadingResults;
 

--- a/include/GafferOSL/OSLRenderer.h
+++ b/include/GafferOSL/OSLRenderer.h
@@ -41,6 +41,8 @@
 
 #include "IECore/Renderer.h"
 #include "IECore/Shader.h"
+#include "IECore/Primitive.h"
+#include "IECore/PrimitiveEvaluator.h"
 
 #include "GafferOSL/TypeIds.h"
 
@@ -59,6 +61,7 @@ class OSLRenderer : public IECore::Renderer
 {
 
 	public :
+		class TraceData;
 
 		OSLRenderer();
 		virtual ~OSLRenderer();
@@ -125,6 +128,39 @@ class OSLRenderer : public IECore::Renderer
 		virtual void editBegin( const std::string &editType, const IECore::CompoundDataMap &parameters );
 		virtual void editEnd();
 
+		struct PrimitiveListEntry
+		{
+			PrimitiveListEntry( IECore::PrimitivePtr p, Imath::M44f t ):
+				primitive( p ), transform( t ) {};
+			IECore::PrimitivePtr primitive;
+			Imath::M44f transform;
+		};
+		typedef std::vector<PrimitiveListEntry> PrimitiveList;
+
+		class TraceEngine : public IECore::RefCounted
+		{
+
+			public :
+
+				IE_CORE_DECLAREMEMBERPTR( TraceEngine )
+
+				bool trace( Imath::V3f &origin, Imath::V3f &direction, TraceData *result, float maxDistance = Imath::limits<float>::max() ) const;
+
+			private :
+
+				friend class OSLRenderer;
+
+				TraceEngine( const PrimitiveList &primList );
+
+				struct PrimitiveIntersectorListEntry
+				{
+					IECore::PrimitiveEvaluatorPtr primitiveEvaluator;
+					Imath::M44f transform;
+				};
+				std::vector<PrimitiveIntersectorListEntry> m_primitiveIntersectorList;
+		};
+		IE_CORE_DECLAREPTR( TraceEngine )
+
 		class ShadingEngine : public IECore::RefCounted
 		{
 
@@ -132,7 +168,7 @@ class OSLRenderer : public IECore::Renderer
 
 				IE_CORE_DECLAREMEMBERPTR( ShadingEngine )
 
-				IECore::CompoundDataPtr shade( const IECore::CompoundData *points ) const;
+				IECore::CompoundDataPtr shade( const IECore::CompoundData *points, TraceEnginePtr traceEngine = NULL  ) const;
 
 			private :
 
@@ -150,10 +186,14 @@ class OSLRenderer : public IECore::Renderer
 		/// Returns a shading engine set up using the current attribute state.
 		ShadingEnginePtr shadingEngine() const;
 
+		/// Returns a trace engine set up using the current geometry
+		TraceEnginePtr traceEngine() const;
+
 	private :
+		void addPrimitive( const IECore::PrimitivePtr primitive );
+
 
 		class RenderState;
-		class TraceData;
 		class RendererServices;
 		class ShadingResults;
 
@@ -166,6 +206,7 @@ class OSLRenderer : public IECore::Renderer
 		struct EmissionParameters;
 		struct DebugParameters;
 
+		RendererServices *m_rendererServices;
 		boost::shared_ptr<OSL::ShadingSystem> m_shadingSystem;
 
 		struct State
@@ -182,6 +223,10 @@ class OSLRenderer : public IECore::Renderer
 
 		StateStack m_stateStack;
 
+		typedef std::stack<Imath::M44f> TransformStack;
+		TransformStack m_transformStack;
+
+		PrimitiveList m_primitiveList;
 };
 
 IE_CORE_DECLAREPTR( OSLRenderer );


### PR DESCRIPTION
This pull request is definitely not ready for merging yet - it's just a proof of concept rather than something fully functional ( among other things, it doesn't deal correctly with transforms ).

It is however sufficient to demonstrate that implementing this seems like a nice solution to this IE ticket:
http://shotgun.image-engine.com/detail/Ticket/8033

I don't want to put more time into this before we get the overall architecture nailed down, since this approach doesn't feel quite right yet - I had a brief email conversation with John before I threw this together, but we'll probably want to think it through farther now that we see what it looks like.

Things that are a bit weird:
* One instance of OSLRenderer is just use to store an OSL::ShadingSystem, another is used just to convert from a scenePlug to a TraceEngine - there is no real reason why these need to be the same class
* Converting from scenePlug to TraceEngine doesn't have anything to do with OSL really - it should probably be somewhere more reusable ( and eventually we should build it on top of a ( presumably ) faster raytracing engine from Appleseed or Embree, instead of using the basic Cortex primitive evaluator )
* Ugliest of all, I currently call m_renderer->m_rendererServices->setTraceEngine right before calling m_renderer->m_shadingSystem->execute, because the TraceEngine is passed in as an argument to shade(), but it need to be accessible from the RendererServices.

John, feel free to reply here or offline on how you think we should actually design this.