### PR TITLE
Lock/Unlock plug menu items

### DIFF
--- a/include/Gaffer/Plug.h
+++ b/include/Gaffer/Plug.h
@@ -146,10 +146,11 @@ class Plug : public GraphComponent
 		/// Returns true if all the flags passed are currently set.
 		bool getFlags( unsigned flags ) const;
 		/// Sets the current state of the flags.
-		/// \todo I suspect we need to make this undoable.
+		/// \undoable
 		void setFlags( unsigned flags );
 		/// Sets or unsets the specified flags depending on the enable
 		/// parameter. All other flags remain at their current values.
+		/// \undoable
 		void setFlags( unsigned flags, bool enable );
 
 		/// @name Connections
@@ -223,6 +224,8 @@ class Plug : public GraphComponent
 
 		void parentChanged();
 		static void propagateDirtinessForParentChange( Plug *plugToDirty );
+
+		void setFlagsInternal( unsigned flags );
 
 		void setInput( PlugPtr input, bool setChildInputs, bool updateParentInput );
 		void setInputInternal( PlugPtr input, bool emit );

--- a/python/GafferTest/PlugTest.py
+++ b/python/GafferTest/PlugTest.py
@@ -700,6 +700,29 @@ class PlugTest( GafferTest.TestCase ) :
 		p["in"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.In )
 		p["out"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out )
 
+	def testUndoSetFlags( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n"] = Gaffer.Node()
+		s["n"]["user"]["p"] = Gaffer.IntPlug()
+
+		self.assertFalse( s["n"]["user"]["p"].getFlags( Gaffer.Plug.Flags.ReadOnly ) )
+
+		cs = GafferTest.CapturingSlot( s["n"].plugFlagsChangedSignal() )
+		with Gaffer.UndoContext( s["n"]["user"]["p"].ancestor( Gaffer.ScriptNode ) ) :
+			s["n"]["user"]["p"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
+			self.assertTrue( s["n"]["user"]["p"].getFlags( Gaffer.Plug.Flags.ReadOnly ) )
+			self.assertEqual( len( cs ), 1 )
+
+		s.undo()
+		self.assertFalse( s["n"]["user"]["p"].getFlags( Gaffer.Plug.Flags.ReadOnly ) )
+		self.assertEqual( len( cs ), 2 )
+
+		s.redo()
+		self.assertTrue( s["n"]["user"]["p"].getFlags( Gaffer.Plug.Flags.ReadOnly ) )
+		self.assertEqual( len( cs ), 3 )
+
 if __name__ == "__main__":
 	unittest.main()
 

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -182,6 +182,9 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		assert( label is self.__label )
 
+		if self.getPlug().getFlags( Gaffer.Plug.Flags.ReadOnly ) :
+			return
+
 		if self.__editableLabel is None :
 			self.__editableLabel = GafferUI.NameWidget( self.getPlug() )
 			self.__editableLabel._qtWidget().setMinimumSize( self.label()._qtWidget().minimumSize() )

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -112,11 +112,6 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		plug = self.getPlug()
 
-		self.__label.setEnabled(
-			plug is not None and
-			not plug.getFlags( Gaffer.Plug.Flags.ReadOnly )
-		)
-
 		valueChanged = plug.getInput() is not None
 		if not valueChanged and isinstance( plug, Gaffer.ValuePlug ) :
 			with self.getContext() :

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -239,12 +239,12 @@ class PlugValueWidget( GafferUI.Widget ) :
 		# but we try to cover all our bases by connecting to both.
 
 		self.__popupMenuConnections.append(
-			widget.buttonPressSignal().connect( IECore.curry( Gaffer.WeakMethod( self.__buttonPress ), buttonMask = buttons ) )
+			widget.buttonPressSignal().connect( functools.partial( Gaffer.WeakMethod( self.__buttonPress ), buttonMask = buttons ) )
 		)
 
 		if buttons & GafferUI.ButtonEvent.Buttons.Right :
 			self.__popupMenuConnections.append(
-				widget.contextMenuSignal().connect( IECore.curry( Gaffer.WeakMethod( self.__contextMenu ) ) )
+				widget.contextMenuSignal().connect( functools.partial( Gaffer.WeakMethod( self.__contextMenu ) ) )
 			)
 
 	## Returns a definition for the popup menu - this is called each time the menu is displayed
@@ -289,7 +289,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 		if hasattr( self.getPlug(), "defaultValue" ) and self.getPlug().direction() == Gaffer.Plug.Direction.In :
 			menuDefinition.append(
 				"/Default", {
-					"command" : IECore.curry( Gaffer.WeakMethod( self.__setValue ), self.getPlug().defaultValue() ),
+					"command" : functools.partial( Gaffer.WeakMethod( self.__setValue ), self.getPlug().defaultValue() ),
 					"active" : self._editable()
 				}
 			)
@@ -571,7 +571,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 		for presetName in Gaffer.NodeAlgo.presets( self.getPlug() ) :
 			result.append(
 				presetName, {
-					"command" : IECore.curry( Gaffer.WeakMethod( self.__applyPreset ), presetName ),
+					"command" : functools.partial( Gaffer.WeakMethod( self.__applyPreset ), presetName ),
 					"active" : self._editable(),
 					"checkBox" : presetName == currentPreset,
 				}


### PR DESCRIPTION
This makes the Plug::ReadOnly flag (that we've had behind the scenes for a long time) user visible for the first time, via a menu item for locking/unlocking the plug.