### PR TITLE
"Revert to Defaults" NodeEditor menu item.

### DIFF
--- a/python/Gaffer/NodeAlgo.py
+++ b/python/Gaffer/NodeAlgo.py
@@ -67,7 +67,7 @@ def currentPreset( plug ) :
 
 	if not hasattr( plug, "getValue" ) :
 		return None
-	
+
 	value = plug.getValue()
 	failedNames = set()
 	for n in Gaffer.Metadata.registeredPlugValues( plug ) :
@@ -85,7 +85,7 @@ def currentPreset( plug ) :
 				return presetName
 
 	return None
-	
+
 ## Applies the named preset to the plug.
 def applyPreset( plug, presetName ) :
 
@@ -102,39 +102,39 @@ def applyPreset( plug, presetName ) :
 ##########################################################################
 
 def applyUserDefaults( nodeOrNodes ) :
-	
+
 	if isinstance( nodeOrNodes, list ) :
 		for node in nodeOrNodes :
 			__applyUserDefaults( node )
-	
+
 	else :
 		__applyUserDefaults( nodeOrNodes )
 
 def hasUserDefault( plug ) :
-	
+
 	return Gaffer.Metadata.plugValue( plug, "userDefault" ) is not None
 
 def isSetToUserDefault( plug ) :
-	
+
 	if not hasattr( plug, "getValue" ) :
 		return False
-	
+
 	userDefault = Gaffer.Metadata.plugValue( plug, "userDefault" )
 	if userDefault is None :
-		return False 
-	
+		return False
+
 	return userDefault == plug.getValue()
 
 def applyUserDefault( plug ) :
-	
+
 	__applyUserDefaults( plug )
 
 def __applyUserDefaults( graphComponent ) :
-	
+
 	if isinstance( graphComponent, Gaffer.Plug ) :
 		plugValue = Gaffer.Metadata.plugValue( graphComponent, "userDefault" )
 		if plugValue is not None :
 			graphComponent.setValue( plugValue )
-	
+
 	for child in graphComponent.children() :
 		__applyUserDefaults( child )


### PR DESCRIPTION
This reverts the node settings back to default values where possible (but skipping plugs which are not settable due to being read only or having an existing input). It doesn't attempt to be clever in the case of nodes which add plugs dynamically, and leaves such plugs in place (but does reset them to default values). Unless anyone has strong feelings about those choices, I'd like to release this as-is and see how it meets user expectations in practice. I'm a bit wary of the "cleverer" approaches since removing inputs and dynamic plugs is more destructive.