### PR TITLE
Unit test temp file tidyup

### DIFF
--- a/python/GafferAppleseedTest/AppleseedRenderTest.py
+++ b/python/GafferAppleseedTest/AppleseedRenderTest.py
@@ -37,7 +37,6 @@
 import os
 import unittest
 import subprocess32 as subprocess
-import shutil
 
 import IECore
 

--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -36,7 +36,6 @@
 ##########################################################################
 
 import os
-import shutil
 import unittest
 import subprocess32 as subprocess
 

--- a/python/GafferCortexTest/ObjectWriterTest.py
+++ b/python/GafferCortexTest/ObjectWriterTest.py
@@ -46,9 +46,13 @@ import GafferTest
 
 class ObjectWriterTest( GafferTest.TestCase ) :
 
-	__exrFileName = "/tmp/checker.exr"
-	__tifFileName = "/tmp/checker.tif"
-	__exrSequence = IECore.FileSequence( "/tmp/checker.####.exr 1-4" )
+	def setUp( self ) :
+
+		GafferTest.TestCase.setUp( self )
+
+		self.__exrFileName = self.temporaryDirectory() + "/checker.exr"
+		self.__tifFileName = self.temporaryDirectory() + "/checker.tif"
+		self.__exrSequence = IECore.FileSequence( self.temporaryDirectory() + "/checker.####.exr 1-4" )
 
 	def test( self ) :
 
@@ -164,15 +168,6 @@ class ObjectWriterTest( GafferTest.TestCase ) :
 		# output varies by time since the file name does
 		s["n"]["fileName"].setValue( self.__exrSequence.fileName )
 		self.assertNotEqual( s["n"].hash( c ), s["n"].hash( c2 ) )
-
-	def tearDown( self ) :
-
-		for f in [
-			self.__tifFileName,
-			self.__exrFileName,
-		] + self.__exrSequence.fileNames() :
-			if os.path.exists( f ) :
-				os.remove( f )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferCortexTest/ParameterisedHolderTest.py
+++ b/python/GafferCortexTest/ParameterisedHolderTest.py
@@ -105,10 +105,10 @@ class ParameterisedHolderTest( GafferTest.TestCase ) :
 		with n.parameterModificationContext() as parameters :
 
 			parameters["multiply"].setNumericValue( 10 )
-			parameters["dst"].setTypedValue( "/tmp/s.####.exr" )
+			parameters["dst"].setTypedValue( self.temporaryDirectory() + "/s.####.exr" )
 
 		self.assertEqual( n["parameters"]["multiply"].getValue(), 10 )
-		self.assertEqual( n["parameters"]["dst"].getValue(), "/tmp/s.####.exr" )
+		self.assertEqual( n["parameters"]["dst"].getValue(), self.temporaryDirectory() + "/s.####.exr" )
 
 		n["parameters"]["multiply"].setValue( 20 )
 		n["parameters"]["dst"].setValue( "lalalal.##.tif" )

--- a/python/GafferImageTest/ResampleTest.py
+++ b/python/GafferImageTest/ResampleTest.py
@@ -84,7 +84,7 @@ class ResampleTest( GafferTest.TestCase ) :
 			crop["in"].setInput( resample["out"] )
 			crop["area"].setValue( IECore.Box2i( IECore.V2i( 0 ), size ) )
 
-			outputFileName = "/tmp/gafferImageResampleTest/%s_%dx%d_%s.exr" % ( os.path.splitext( fileName )[0], size.x, size.y, filter )
+			outputFileName = self.temporaryDirectory() + "/%s_%dx%d_%s.exr" % ( os.path.splitext( fileName )[0], size.x, size.y, filter )
 			writer = GafferImage.ImageWriter()
 			writer["in"].setInput( crop["out"] )
 			writer["fileName"].setValue( outputFileName )
@@ -143,11 +143,6 @@ class ResampleTest( GafferTest.TestCase ) :
 
 		for args in tests :
 			__test( *args )
-
-	def tearDown( self ) :
-
-		if os.path.isdir( "/tmp/gafferImageResampleTest" ) :
-			shutil.rmtree( "/tmp/gafferImageResampleTest" )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferOSLTest/OSLImageTest.py
+++ b/python/GafferOSLTest/OSLImageTest.py
@@ -229,22 +229,15 @@ class OSLImageTest( GafferOSLTest.OSLTestCase ) :
 		p = s["b"].promotePlug( s["b"]["i"]["shader"] )
 		p.setName( "p" )
 
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s["r"] = Gaffer.Reference()
-		s["r"].load( "/tmp/test.grf" )
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		s["s"] = GafferOSL.OSLShader()
 		s["s"].loadShader( "ImageProcessing/OutImage" )
 
 		s["r"]["p"].setInput( s["s"]["out"] )
-
-	def tearDown( self ) :
-
-		GafferOSLTest.OSLTestCase.tearDown( self )
-
-		if os.path.exists( "/tmp/test.grf" ) :
-			os.remove( "/tmp/test.grf" )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferOSLTest/OSLObjectTest.py
+++ b/python/GafferOSLTest/OSLObjectTest.py
@@ -180,22 +180,15 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 		p = s["b"].promotePlug( s["b"]["o"]["shader"] )
 		p.setName( "p" )
 
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s["r"] = Gaffer.Reference()
-		s["r"].load( "/tmp/test.grf" )
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		s["s"] = GafferOSL.OSLShader()
 		s["s"].loadShader( "ObjectProcessing/OutObject" )
 
 		s["r"]["p"].setInput( s["s"]["out"] )
-
-	def tearDown( self ) :
-
-		GafferOSLTest.OSLTestCase.tearDown( self )
-
-		if os.path.exists( "/tmp/test.grf" ) :
-			os.remove( "/tmp/test.grf" )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferRenderManTest/RenderManLightTest.py
+++ b/python/GafferRenderManTest/RenderManLightTest.py
@@ -42,8 +42,9 @@ import IECore
 import Gaffer
 import GafferScene
 import GafferRenderMan
+import GafferRenderManTest
 
-class RenderManLightTest( unittest.TestCase ) :
+class RenderManLightTest( GafferRenderManTest.RenderManTestCase ) :
 
 	def test( self ) :
 
@@ -85,7 +86,7 @@ class RenderManLightTest( unittest.TestCase ) :
 		s["a"]["shader"].setInput( s["s"]["out"] )
 
 		s["d"] = GafferScene.Outputs()
-		s["d"].addOutput( "beauty", IECore.Display( "/tmp/testRenderManLight.exr", "exr", "rgba", { "quantize" : IECore.FloatVectorData( [ 0, 0, 0, 0 ] ) } ) )
+		s["d"].addOutput( "beauty", IECore.Display( self.temporaryDirectory() + "/testRenderManLight.exr", "exr", "rgba", { "quantize" : IECore.FloatVectorData( [ 0, 0, 0, 0 ] ) } ) )
 		s["d"]["in"].setInput( s["a"]["out"] )
 
 		s["o"] = GafferScene.StandardOptions()
@@ -94,19 +95,19 @@ class RenderManLightTest( unittest.TestCase ) :
 		s["o"]["in"].setInput( s["d"]["out"] )
 
 		s["r"] = GafferRenderMan.RenderManRender()
-		s["r"]["ribFileName"].setValue( "/tmp/testRenderManLight.rib" )
+		s["r"]["ribFileName"].setValue( self.temporaryDirectory() + "/testRenderManLight.rib" )
 		s["r"]["in"].setInput( s["o"]["out"] )
 
 		# must save the script for the procedural to load it
 		# in the render process. if we were using a dispatcher,
 		# that would have saved the script for us, but we're
 		# calling execute() directly so it is our responsibility.
-		s["fileName"].setValue( "/tmp/testRenderManLight.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/testRenderManLight.gfr" )
 		s.save()
 
 		s["r"].execute()
 
-		i = IECore.EXRImageReader( "/tmp/testRenderManLight.exr" ).read()
+		i = IECore.EXRImageReader( self.temporaryDirectory() + "/testRenderManLight.exr" ).read()
 		e = IECore.ImagePrimitiveEvaluator( i )
 		r = e.createResult()
 		e.pointAtUV( IECore.V2f( 0.5 ), r )
@@ -114,16 +115,6 @@ class RenderManLightTest( unittest.TestCase ) :
 		self.assertEqual( r.floatPrimVar( e.R() ), 1 )
 		self.assertEqual( r.floatPrimVar( e.G() ), 0.5 )
 		self.assertEqual( r.floatPrimVar( e.B() ), 0.25 )
-
-	def tearDown( self ) :
-
-		for f in [
-			"/tmp/testRenderManLight.gfr",
-			"/tmp/testRenderManLight.exr",
-			"/tmp/testRenderManLight.rib",
-		] :
-			if os.path.exists( f ) :
-				os.remove( f )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferRenderManTest/RenderManRenderTest.py
+++ b/python/GafferRenderManTest/RenderManRenderTest.py
@@ -49,8 +49,6 @@ import GafferRenderManTest
 
 class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 
-	__scriptFileName = "/tmp/test.gfr"
-
 	def testBoundsAndImageOutput( self ) :
 
 		s = Gaffer.ScriptNode()
@@ -62,7 +60,7 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 		s["outputs"].addOutput(
 			"beauty",
 			IECore.Display(
-				"/tmp/test.tif",
+				self.temporaryDirectory() + "/test.tif",
 				"tiff",
 				"rgba",
 				{}
@@ -74,17 +72,17 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 		s["render"]["in"].setInput( s["outputs"]["out"] )
 		s["render"]["mode"].setValue( "generate" )
 
-		s["render"]["ribFileName"].setValue( "/tmp/test.rib" )
+		s["render"]["ribFileName"].setValue( self.temporaryDirectory() + "/test.rib" )
 
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s.save()
 
 		s["render"].execute()
 
-		self.assertTrue( os.path.exists( "/tmp/test.rib" ) )
+		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/test.rib" ) )
 
 		p = subprocess.Popen(
-			"renderdl " + "/tmp/test.rib",
+			"renderdl " + self.temporaryDirectory() + "/test.rib",
 			shell = True,
 			stderr = subprocess.PIPE
 		)
@@ -92,7 +90,7 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		self.failIf( "exceeded its bounds" in "".join( p.stderr.readlines() ) )
 
-		self.assertTrue( os.path.exists( "/tmp/test.tif" ) )
+		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/test.tif" ) )
 
 	def testCameraMotionBlur( self ) :
 
@@ -112,18 +110,18 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 		s["render"]["in"].setInput( s["options"]["out"] )
 		s["render"]["mode"].setValue( "generate" )
 
-		s["render"]["ribFileName"].setValue( "/tmp/test.rib" )
+		s["render"]["ribFileName"].setValue( self.temporaryDirectory() + "/test.rib" )
 
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s.save()
 
 		s["render"].execute()
 
-		self.assertTrue( os.path.exists( "/tmp/test.rib" ) )
+		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/test.rib" ) )
 
 		# camera motion off, we should have no motion statements
 
-		r = "".join( file( "/tmp/test.rib" ).readlines() )
+		r = "".join( file( self.temporaryDirectory() + "/test.rib" ).readlines() )
 		self.failIf( "MotionBegin" in r )
 
 		# camera motion on, we should have no motion statements
@@ -133,7 +131,7 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		s["render"].execute()
 
-		r = "".join( file( "/tmp/test.rib" ).readlines() )
+		r = "".join( file( self.temporaryDirectory() + "/test.rib" ).readlines() )
 		self.failUnless( "MotionBegin" in r )
 
 		# motion disabled on camera object, we should have no motion statements
@@ -144,7 +142,7 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		s["render"].execute()
 
-		r = "".join( file( "/tmp/test.rib" ).readlines() )
+		r = "".join( file( self.temporaryDirectory() + "/test.rib" ).readlines() )
 		self.failIf( "MotionBegin" in r )
 
 		# motion enabled on camera object, with extra samples specified. we should
@@ -166,7 +164,7 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 
 			return []
 
-		self.assertEqual( len( motionTimes( "/tmp/test.rib" ) ), 6 )
+		self.assertEqual( len( motionTimes( self.temporaryDirectory() + "/test.rib" ) ), 6 )
 
 		# different shutter times
 
@@ -175,13 +173,13 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		s["render"].execute()
 
-		self.assertEqual( motionTimes( "/tmp/test.rib" ), [ 0.75, 1.25 ] )
+		self.assertEqual( motionTimes( self.temporaryDirectory() + "/test.rib" ), [ 0.75, 1.25 ] )
 
 		s["options"]["options"]["shutter"]["value"].setValue( IECore.V2f( -0.1, 0.3 ) )
 
 		s["render"].execute()
 
-		self.assertEqual( motionTimes( "/tmp/test.rib" ), [ 0.9, 1.3 ] )
+		self.assertEqual( motionTimes( self.temporaryDirectory() + "/test.rib" ), [ 0.9, 1.3 ] )
 
 	def testDynamicLoadProcedural( self ) :
 
@@ -193,24 +191,24 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 		s["render"]["in"].setInput( s["plane"]["out"] )
 		s["render"]["mode"].setValue( "generate" )
 
-		s["render"]["ribFileName"].setValue( "/tmp/test.rib" )
+		s["render"]["ribFileName"].setValue( self.temporaryDirectory() + "/test.rib" )
 
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s.save()
 
 		s["render"].execute()
 
-		self.assertTrue( os.path.exists( "/tmp/test.rib" ) )
+		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/test.rib" ) )
 
-		rib = "\n".join( file( "/tmp/test.rib" ).readlines() )
+		rib = "\n".join( file( self.temporaryDirectory() + "/test.rib" ).readlines() )
 		self.assertTrue( "DynamicLoad" in rib )
 		self.assertFalse( "Polygon" in rib )
 
 	def testDirectoryCreation( self ) :
 
 		s = Gaffer.ScriptNode()
-		s["variables"].addMember( "renderDirectory", "/tmp/renderTests" )
-		s["variables"].addMember( "ribDirectory", "/tmp/ribTests" )
+		s["variables"].addMember( "renderDirectory", self.temporaryDirectory() + "/renderTests" )
+		s["variables"].addMember( "ribDirectory", self.temporaryDirectory() + "/ribTests" )
 
 		s["plane"] = GafferScene.Plane()
 
@@ -231,27 +229,27 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 		s["render"]["ribFileName"].setValue( "$ribDirectory/test.####.rib" )
 		s["render"]["mode"].setValue( "generate" )
 
-		self.assertFalse( os.path.exists( "/tmp/renderTests" ) )
-		self.assertFalse( os.path.exists( "/tmp/ribTests" ) )
-		self.assertFalse( os.path.exists( "/tmp/ribTests/test.0001.rib" ) )
+		self.assertFalse( os.path.exists( self.temporaryDirectory() + "/renderTests" ) )
+		self.assertFalse( os.path.exists( self.temporaryDirectory() + "/ribTests" ) )
+		self.assertFalse( os.path.exists( self.temporaryDirectory() + "/ribTests/test.0001.rib" ) )
 
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 
 		with s.context() :
 			s["render"].execute()
 
-		self.assertTrue( os.path.exists( "/tmp/renderTests" ) )
-		self.assertTrue( os.path.exists( "/tmp/ribTests" ) )
-		self.assertTrue( os.path.exists( "/tmp/ribTests/test.0001.rib" ) )
+		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/renderTests" ) )
+		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/ribTests" ) )
+		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/ribTests/test.0001.rib" ) )
 
 		# check that having the directories already exist is ok too
 
 		with s.context() :
 			s["render"].execute()
 
-		self.assertTrue( os.path.exists( "/tmp/renderTests" ) )
-		self.assertTrue( os.path.exists( "/tmp/ribTests" ) )
-		self.assertTrue( os.path.exists( "/tmp/ribTests/test.0001.rib" ) )
+		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/renderTests" ) )
+		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/ribTests" ) )
+		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/ribTests/test.0001.rib" ) )
 
 	def testTypeNamePrefixes( self ) :
 
@@ -271,7 +269,7 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 	def testCropWindow( self ) :
 
 		s = Gaffer.ScriptNode()
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 
 		s["p"] = GafferScene.Plane()
 
@@ -282,12 +280,12 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		s["r"] = GafferRenderMan.RenderManRender()
 		s["r"]["mode"].setValue( "generate" )
-		s["r"]["ribFileName"].setValue( "/tmp/test.rib" )
+		s["r"]["ribFileName"].setValue( self.temporaryDirectory() + "/test.rib" )
 		s["r"]["in"].setInput( s["o"]["out"] )
 
 		s["r"].execute()
 
-		rib = "\n".join( file( "/tmp/test.rib" ).readlines() )
+		rib = "\n".join( file( self.temporaryDirectory() + "/test.rib" ).readlines() )
 		self.assertTrue( "CropWindow 0 1 0.5 1" in rib )
 
 	def testHash( self ) :
@@ -316,12 +314,12 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		# output varies by new Context entries
 		current = s["render"].hash( c )
-		c["renderDirectory"] = "/tmp/renderTests"
+		c["renderDirectory"] = self.temporaryDirectory() + "/renderTests"
 		self.assertNotEqual( s["render"].hash( c ), current )
 
 		# output varies by changed Context entries
 		current = s["render"].hash( c )
-		c["renderDirectory"] = "/tmp/renderTests2"
+		c["renderDirectory"] = self.temporaryDirectory() + "/renderTests2"
 		self.assertNotEqual( s["render"].hash( c ), current )
 
 		# output doesn't vary by ui Context entries
@@ -337,19 +335,19 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 	def testCoordinateSystem( self ) :
 
 		s = Gaffer.ScriptNode()
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 
 		s["c"] = GafferScene.CoordinateSystem()
 		s["c"]["name"].setValue( "myCoordSys" )
 
 		s["r"] = GafferRenderMan.RenderManRender()
 		s["r"]["mode"].setValue( "generate" )
-		s["r"]["ribFileName"].setValue( "/tmp/test.rib" )
+		s["r"]["ribFileName"].setValue( self.temporaryDirectory() + "/test.rib" )
 		s["r"]["in"].setInput( s["c"]["out"] )
 
 		s["r"].execute()
 
-		rib = "\n".join( file( "/tmp/test.rib" ).readlines() )
+		rib = "\n".join( file( self.temporaryDirectory() + "/test.rib" ).readlines() )
 		self.assertTrue( "CoordinateSystem \"/myCoordSys\"" in rib )
 
 	def testRenderToDisplayViaForegroundDispatch( self ) :
@@ -389,17 +387,17 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 		)
 
 		s["render"] = GafferRenderMan.RenderManRender()
-		s["render"]["ribFileName"].setValue( "/tmp/test.rib" )
+		s["render"]["ribFileName"].setValue( self.temporaryDirectory() + "/test.rib" )
 		s["render"]["in"].setInput( s["outputs"]["out"] )
 
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s.save()
 
 		# dispatch the render on the foreground thread. if we don't manage
 		# the GIL appropriately, we'll get a deadlock when the Display signals
 		# above try to enter python on the background thread.
 		dispatcher = Gaffer.LocalDispatcher()
-		dispatcher["jobsDirectory"].setValue( "/tmp/testJobDirectory" )
+		dispatcher["jobsDirectory"].setValue( self.temporaryDirectory() + "/testJobDirectory" )
 		dispatcher["framesMode"].setValue( Gaffer.Dispatcher.FramesMode.CurrentFrame )
 		dispatcher["executeInBackground"].setValue( False )
 
@@ -431,14 +429,14 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 		s["outputs"]["in"].setInput( s["sphere"]["out"] )
 
 		s["display"] = GafferImage.Display()
-	
+
 		s["render"] = GafferRenderMan.RenderManRender()
-		s["render"]["ribFileName"].setValue( "/tmp/test.rib" )
+		s["render"]["ribFileName"].setValue( self.temporaryDirectory() + "/test.rib" )
 		s["render"]["in"].setInput( s["outputs"]["out"] )
 
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s.save()
-		
+
 		# render a full frame and get the data window
 		s["render"].execute()
 		dataWindow1 = s["display"]["out"].image().dataWindow
@@ -456,14 +454,14 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 		s.context()["size"] = 0.25
 		with s.context() :
 			s["render"].execute()
-		
+
 		dataWindow3 = s["display"]["out"].image().dataWindow
 		self.assertEqual( dataWindow3.size(), dataWindow1.size() / 4 )
-		
+
 	def testOptions( self ) :
 
 		s = Gaffer.ScriptNode()
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 
 		s["p"] = GafferScene.Plane()
 
@@ -474,12 +472,12 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		s["r"] = GafferRenderMan.RenderManRender()
 		s["r"]["mode"].setValue( "generate" )
-		s["r"]["ribFileName"].setValue( "/tmp/test.rib" )
+		s["r"]["ribFileName"].setValue( self.temporaryDirectory() + "/test.rib" )
 		s["r"]["in"].setInput( s["o"]["out"] )
 
 		s["r"].execute()
 
-		rib = "\n".join( file( "/tmp/test.rib" ).readlines() )
+		rib = "\n".join( file( self.temporaryDirectory() + "/test.rib" ).readlines() )
 		self.assertTrue( "PixelSamples 2 3" in rib )
 
 	def testFrameBlock( self ) :
@@ -490,14 +488,14 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		s["r"] = GafferRenderMan.RenderManRender()
 		s["r"]["mode"].setValue( "generate" )
-		s["r"]["ribFileName"].setValue( "/tmp/test.rib" )
+		s["r"]["ribFileName"].setValue( self.temporaryDirectory() + "/test.rib" )
 		s["r"]["in"].setInput( s["p"]["out"] )
 
 		with Gaffer.Context( s.context() ) as context :
 			for i in range( 0, 10 ) :
 				context.setFrame( i )
 				s["r"].execute()
-				rib = "\n".join( file( "/tmp/test.rib" ).readlines() )
+				rib = "\n".join( file( self.temporaryDirectory() + "/test.rib" ).readlines() )
 				self.assertTrue( "FrameBegin %d" % i in rib )
 
 	def testMultipleCameras( self ) :
@@ -527,14 +525,14 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 		s["render"]["in"].setInput( s["options"]["out"] )
 		s["render"]["mode"].setValue( "generate" )
 
-		s["render"]["ribFileName"].setValue( "/tmp/test.rib" )
+		s["render"]["ribFileName"].setValue( self.temporaryDirectory() + "/test.rib" )
 
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s.save()
 
 		s["render"].execute()
 
-		rib = "\n".join( file( "/tmp/test.rib" ).readlines() )
+		rib = "\n".join( file( self.temporaryDirectory() + "/test.rib" ).readlines() )
 
 		self.assertTrue( "Camera \"/group/camera1\"" in rib )
 		self.assertTrue( "Camera \"/group/camera2\"" in rib )
@@ -546,7 +544,7 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 	def testHiddenCoordinateSystem( self ) :
 
 		s = Gaffer.ScriptNode()
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 
 		s["c"] = GafferScene.CoordinateSystem()
 		s["c"]["name"].setValue( "myCoordSys" )
@@ -571,29 +569,29 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		s["r"] = GafferRenderMan.RenderManRender()
 		s["r"]["mode"].setValue( "generate" )
-		s["r"]["ribFileName"].setValue( "/tmp/test.rib" )
+		s["r"]["ribFileName"].setValue( self.temporaryDirectory() + "/test.rib" )
 		s["r"]["in"].setInput( s["a2"]["out"] )
 
 		s["r"].execute()
-		rib = "\n".join( file( "/tmp/test.rib" ).readlines() )
+		rib = "\n".join( file( self.temporaryDirectory() + "/test.rib" ).readlines() )
 		self.assertTrue( "CoordinateSystem \"/group/myCoordSys\"" in rib )
 
 		s["f1"]["paths"].setValue( IECore.StringVectorData( [ "/group" ] ) ) # hide group
 
 		s["r"].execute()
-		rib = "\n".join( file( "/tmp/test.rib" ).readlines() )
+		rib = "\n".join( file( self.temporaryDirectory() + "/test.rib" ).readlines() )
 		self.assertTrue( "CoordinateSystem" not in rib )
 
 		s["f2"]["paths"].setValue( IECore.StringVectorData( [ "/group/myCoordSys" ] ) ) # show coordsys (but parent still hidden)
 
 		s["r"].execute()
-		rib = "\n".join( file( "/tmp/test.rib" ).readlines() )
+		rib = "\n".join( file( self.temporaryDirectory() + "/test.rib" ).readlines() )
 		self.assertTrue( "CoordinateSystem" not in rib )
 
 	def testHiddenLight( self ) :
 
 		s = Gaffer.ScriptNode()
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 
 		s["l"] = GafferRenderMan.RenderManLight()
 		s["l"]["name"].setValue( "myLight" )
@@ -619,23 +617,23 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		s["r"] = GafferRenderMan.RenderManRender()
 		s["r"]["mode"].setValue( "generate" )
-		s["r"]["ribFileName"].setValue( "/tmp/test.rib" )
+		s["r"]["ribFileName"].setValue( self.temporaryDirectory() + "/test.rib" )
 		s["r"]["in"].setInput( s["a2"]["out"] )
 
 		s["r"].execute()
-		rib = "\n".join( file( "/tmp/test.rib" ).readlines() )
+		rib = "\n".join( file( self.temporaryDirectory() + "/test.rib" ).readlines() )
 		self.assertTrue( "LightSource \"pointlight\"" in rib )
 
 		s["f1"]["paths"].setValue( IECore.StringVectorData( [ "/group" ] ) ) # hide group
 
 		s["r"].execute()
-		rib = "\n".join( file( "/tmp/test.rib" ).readlines() )
+		rib = "\n".join( file( self.temporaryDirectory() + "/test.rib" ).readlines() )
 		self.assertTrue( "LightSource \"pointlight\"" not in rib )
 
 		s["f2"]["paths"].setValue( IECore.StringVectorData( [ "/group/myLight" ] ) ) # show coordsys (but parent still hidden)
 
 		s["r"].execute()
-		rib = "\n".join( file( "/tmp/test.rib" ).readlines() )
+		rib = "\n".join( file( self.temporaryDirectory() + "/test.rib" ).readlines() )
 		self.assertTrue( "LightSource \"pointlight\"" not in rib )
 
 	def testClippingPlane( self ) :
@@ -646,12 +644,12 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		s["r"] = GafferRenderMan.RenderManRender()
 		s["r"]["mode"].setValue( "generate" )
-		s["r"]["ribFileName"].setValue( "/tmp/test.rib" )
+		s["r"]["ribFileName"].setValue( self.temporaryDirectory() + "/test.rib" )
 		s["r"]["in"].setInput( s["c"]["out"] )
 
 		s["r"].execute()
 
-		rib = "\n".join( file( "/tmp/test.rib" ).readlines() )
+		rib = "\n".join( file( self.temporaryDirectory() + "/test.rib" ).readlines() )
 		self.assertTrue( "ClippingPlane" in rib )
 
 	@unittest.skipIf( "TRAVIS" in os.environ, "Unknown problem running on Travis" )
@@ -675,7 +673,7 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 		s["outputs"].addOutput(
 			"beauty",
 			IECore.Display(
-				"/tmp/${wedge:value}.tif",
+				self.temporaryDirectory() + "/${wedge:value}.tif",
 				"tiff",
 				"rgba",
 				{
@@ -685,7 +683,7 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 		s["outputs"]["in"].setInput( s["attributes"]["out"] )
 
 		s["render"] = GafferRenderMan.RenderManRender()
-		s["render"]["ribFileName"].setValue( "/tmp/test.rib" )
+		s["render"]["ribFileName"].setValue( self.temporaryDirectory() + "/test.rib" )
 		s["render"]["in"].setInput( s["outputs"]["out"] )
 
 		s["wedge"] = Gaffer.Wedge()
@@ -693,21 +691,21 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 		s["wedge"]["strings"].setValue( IECore.StringVectorData( [ "visible", "hidden" ] ) )
 		s["wedge"]["requirements"][0].setInput( s["render"]["requirement"] )
 
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s.save()
 
 		dispatcher = Gaffer.LocalDispatcher()
-		dispatcher["jobsDirectory"].setValue( "/tmp/testJobDirectory" )
+		dispatcher["jobsDirectory"].setValue( self.temporaryDirectory() + "/testJobDirectory" )
 		dispatcher["framesMode"].setValue( Gaffer.Dispatcher.FramesMode.CurrentFrame )
 		dispatcher["executeInBackground"].setValue( False )
 
 		dispatcher.dispatch( [ s["wedge"] ] )
 
 		hidden = GafferImage.ImageReader()
-		hidden["fileName"].setValue( "/tmp/hidden.tif" )
+		hidden["fileName"].setValue( self.temporaryDirectory() + "/hidden.tif" )
 
 		visible = GafferImage.ImageReader()
-		visible["fileName"].setValue( "/tmp/visible.tif" )
+		visible["fileName"].setValue( self.temporaryDirectory() + "/visible.tif" )
 
 		hiddenStats = GafferImage.ImageStats()
 		hiddenStats["in"].setInput( hidden["out"] )
@@ -719,7 +717,7 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 		self.assertGreater( visibleStats["average"].getValue()[0], .35 )
 
 	def testPreWorldRenderables( self ):
-		
+
 		s = Gaffer.ScriptNode()
 
 		s["g"] = GafferSceneTest.CompoundObjectSource()
@@ -734,37 +732,15 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		s["r"] = GafferRenderMan.RenderManRender()
 		s["r"]["mode"].setValue( "generate" )
-		s["r"]["ribFileName"].setValue( "/tmp/test.rib" )
+		s["r"]["ribFileName"].setValue( self.temporaryDirectory() + "/test.rib" )
 		s["r"]["in"].setInput( s["g"]["out"] )
 
 		s["r"].execute()
 
 		# node should have inserted a ClippingPlane into the rib by putting it
 		# in the options:
-		rib = "\n".join( file( "/tmp/test.rib" ).readlines() )
+		rib = "\n".join( file( self.temporaryDirectory() + "/test.rib" ).readlines() )
 		self.assertTrue( "ClippingPlane" in rib )
-		
-	def setUp( self ) :
-
-		for f in (
-			"/tmp/test.tif",
-			"/tmp/hidden.tif",
-			"/tmp/visible.tif",
-			"/tmp/test.rib",
-			"/tmp/test.gfr",
-			"/tmp/renderTests",
-			"/tmp/ribTests/test.0001.rib",
-			"/tmp/ribTests",
-			"default.tif"
-		) :
-			if os.path.isfile( f ) :
-				os.remove( f )
-			elif os.path.isdir( f ) :
-				os.rmdir( f )
-
-	def tearDown( self ) :
-
-		self.setUp()
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferRenderManTest/RenderManShaderTest.py
+++ b/python/GafferRenderManTest/RenderManShaderTest.py
@@ -1634,19 +1634,12 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		self.assertTrue( s["b"]["p"].acceptsInput( s["c"]["out"] ) )
 
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s["r"] = Gaffer.Reference()
-		s["r"].load( "/tmp/test.grf" )
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		self.assertTrue( s["r"]["p"].acceptsInput( s["c"]["out"] ) )
-
-	def tearDown( self ) :
-
-		GafferRenderManTest.RenderManTestCase.tearDown( self )
-
-		if os.path.exists( "/tmp/test.grf" ) :
-			os.remove( "/tmp/test.grf" )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferRenderManTest/RenderManTestCase.py
+++ b/python/GafferRenderManTest/RenderManTestCase.py
@@ -41,10 +41,6 @@ import GafferRenderMan
 
 class RenderManTestCase( GafferSceneTest.SceneTestCase ) :
 
-	def setUp( self ) :
-
-		self.__compiledShaders = set()
-
 	def compileShader( self, sourceFileName, shaderName=None ) :
 
 		# perhaps one day we'll need to implement this for other renderman
@@ -53,16 +49,8 @@ class RenderManTestCase( GafferSceneTest.SceneTestCase ) :
 
 		if shaderName is None :
 			shaderName = os.path.splitext( os.path.basename( sourceFileName ) )[0]
-		outputFileName = "/tmp/" + shaderName + ".sdl"
+		outputFileName = self.temporaryDirectory() + "/" + shaderName + ".sdl"
 
 		os.system( "shaderdl -o %s %s" % ( outputFileName, sourceFileName ) )
 
-		self.__compiledShaders.add( outputFileName )
-
 		return os.path.splitext( outputFileName )[0]
-
-	def tearDown( self ) :
-
-		for f in self.__compiledShaders :
-			if os.path.exists( f ) :
-				os.remove( f )

--- a/python/GafferSceneTest/AlembicSourceTest.py
+++ b/python/GafferSceneTest/AlembicSourceTest.py
@@ -112,25 +112,24 @@ class AlembicSourceTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( a["out"].fullTransform( "/group1/pCube1" ), IECore.M44f.createTranslated( IECore.V3f( -1, 0, 0 ) )  * a["out"].fullTransform( "/group1" ) )
 		self.assertEqual( a["out"].fullTransform( "/group1/pCube1/pCubeShape1" ), a["out"].fullTransform( "/group1/pCube1" ) )
 
-	__refreshTestFileName = "/tmp/refreshTest.abc"
-
 	def testRefresh( self ) :
 
-		shutil.copyfile( os.path.dirname( __file__ ) + "/alembicFiles/cube.abc", self.__refreshTestFileName )
+		fileName = self.temporaryDirectory() + "/refreshTest.abc"
+		shutil.copyfile( os.path.dirname( __file__ ) + "/alembicFiles/cube.abc", fileName )
 
 		a = GafferScene.AlembicSource()
-		a["fileName"].setValue( self.__refreshTestFileName )
-		a["refreshCount"].setValue( self.uniqueInt( self.__refreshTestFileName ) )
+		a["fileName"].setValue( fileName )
+		a["refreshCount"].setValue( self.uniqueInt( fileName ) )
 
 		self.assertSceneValid( a["out"] )
 		self.assertEqual( a["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "group1" ] ) )
 
-		shutil.copyfile( os.path.dirname( __file__ ) + "/alembicFiles/animatedCube.abc", self.__refreshTestFileName )
+		shutil.copyfile( os.path.dirname( __file__ ) + "/alembicFiles/animatedCube.abc", fileName )
 
 		self.assertSceneValid( a["out"] )
 		self.assertEqual( a["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "group1" ] ) )
 
-		a["refreshCount"].setValue( self.uniqueInt( self.__refreshTestFileName ) )
+		a["refreshCount"].setValue( self.uniqueInt( fileName ) )
 
 		# We have to skip the test of built in sets, because our alembic file contains cameras
 		# and alembic doesn't provide a means of flagging them upfront.
@@ -151,14 +150,6 @@ class AlembicSourceTest( GafferSceneTest.SceneTestCase ) :
 		a["fileName"].setValue( "nonexistent.abc" )
 
 		self.assertRaises( RuntimeError, a["out"].childNames, "/" )
-
-	def tearDown( self ) :
-
-		for f in [
-			self.__refreshTestFileName,
-		] :
-			if os.path.exists( f ) :
-				os.remove( f )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/RenderTest.py
+++ b/python/GafferSceneTest/RenderTest.py
@@ -59,7 +59,7 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 	def testLightOutput( self ) :
 
 		s = Gaffer.ScriptNode()
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 
 		s["l"] = GafferSceneTest.TestLight()
 		s["g"] = GafferScene.Group()
@@ -84,7 +84,7 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 	def testLightVisibility( self ) :
 
 		s = Gaffer.ScriptNode()
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 
 		s["l"] = GafferSceneTest.TestLight()
 		s["g"] = GafferScene.Group()
@@ -122,7 +122,7 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 	def testLightAttributes( self ) :
 
 		s = Gaffer.ScriptNode()
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 
 		s["l"] = GafferSceneTest.TestLight()
 
@@ -147,7 +147,7 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 	def testLightName( self ) :
 
 		s = Gaffer.ScriptNode()
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 
 		s["l"] = GafferSceneTest.TestLight()
 		s["g"] = GafferScene.Group()
@@ -216,7 +216,7 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 	def testOptions( self ) :
 
 		s = Gaffer.ScriptNode()
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 
 		s["p"] = GafferScene.Plane()
 		s["o"] = GafferScene.CustomOptions()

--- a/python/GafferSceneTest/SceneReaderTest.py
+++ b/python/GafferSceneTest/SceneReaderTest.py
@@ -45,7 +45,11 @@ import GafferSceneTest
 
 class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 
-	__testFile = "/tmp/test.scc"
+	def setUp( self ) :
+
+		GafferSceneTest.SceneTestCase.setUp( self )
+
+		self.__testFile = self.temporaryDirectory() + "/test.scc"
 
 	def testFileRefreshProblem( self ) :
 
@@ -487,11 +491,6 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 		# this used to cause a crash:
 		r1 = GafferScene.SceneReader()
 		self.assertEqual( r1["out"].set( "blahblah" ).value.paths(), [] )
-
-	def tearDown( self ) :
-
-		if os.path.exists( self.__testFile ) :
-			os.remove( self.__testFile )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/ShaderAssignmentTest.py
+++ b/python/GafferSceneTest/ShaderAssignmentTest.py
@@ -35,7 +35,6 @@
 #
 ##########################################################################
 
-import os
 import unittest
 
 import IECore
@@ -45,7 +44,7 @@ import GafferTest
 import GafferScene
 import GafferSceneTest
 
-class ShaderAssignmentTest( unittest.TestCase ) :
+class ShaderAssignmentTest( GafferSceneTest.SceneTestCase ) :
 
 	def testFilter( self ) :
 
@@ -262,10 +261,10 @@ class ShaderAssignmentTest( unittest.TestCase ) :
 		s["b"] = Gaffer.Box()
 		s["b"]["a"] = GafferScene.ShaderAssignment()
 		p = s["b"].promotePlug( s["b"]["a"]["filter"] )
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s["r"] = Gaffer.Reference()
-		s["r"].load( "/tmp/test.grf" )
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		self.assertTrue( s["r"]["a"]["filter"].getInput().isSame( s["r"][p.getName()] ) )
 
@@ -282,10 +281,10 @@ class ShaderAssignmentTest( unittest.TestCase ) :
 		s["b"]["a"]["filter"].setInput( s["b"]["d"]["out"] )
 
 		p = s["b"].promotePlug( s["b"]["d"]["in"] )
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s["r"] = Gaffer.Reference()
-		s["r"].load( "/tmp/test.grf" )
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		self.assertTrue( s["r"]["a"]["filter"].source().isSame( s["r"][p.getName()] ) )
 
@@ -300,17 +299,12 @@ class ShaderAssignmentTest( unittest.TestCase ) :
 		s["b"]["a"] = GafferScene.ShaderAssignment()
 		p = s["b"].promotePlug( s["b"]["a"]["shader"] )
 
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s["r"] = Gaffer.Reference()
-		s["r"].load( "/tmp/test.grf" )
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		self.assertTrue( s["r"]["a"]["shader"].getInput().node().isSame( s["r"] ) )
-
-	def tearDown( self ) :
-
-		if os.path.exists( "/tmp/test.grf" ) :
-			os.remove( "/tmp/test.grf" )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/UnionFilterTest.py
+++ b/python/GafferSceneTest/UnionFilterTest.py
@@ -202,10 +202,10 @@ class UnionFilterTest( GafferSceneTest.SceneTestCase ) :
 		p = s["b"].promotePlug( s["b"]["f"]["in"][0] )
 		p.setName( "p" )
 
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s["r"] = Gaffer.Reference()
-		s["r"].load( "/tmp/test.grf" )
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		s["f"] = GafferScene.PathFilter()
 
@@ -220,13 +220,6 @@ class UnionFilterTest( GafferSceneTest.SceneTestCase ) :
 		self.assertTrue( s["UnionFilter"]["in"][0].getInput().isSame( s["PathFilter"]["out"] ) )
 		self.assertTrue( s["UnionFilter"]["in"][1].getInput().isSame( s["PathFilter1"]["out"] ) )
 		self.assertTrue( s["UnionFilter"]["in"][2].getInput().isSame( s["PathFilter2"]["out"] ) )
-
-	def tearDown( self ) :
-
-		GafferSceneTest.SceneTestCase.tearDown( self )
-
-		if os.path.exists( "/tmp/test.grf" ) :
-			os.remove( "/tmp/test.grf" )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/ExecutableNodeTest.py
+++ b/python/GafferTest/ExecutableNodeTest.py
@@ -325,10 +325,10 @@ class ExecutableNodeTest( GafferTest.TestCase ) :
 		p = s["b"].promotePlug( s["b"]["e"]["requirements"][0] )
 		p.setName( "p" )
 
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s["r"] = Gaffer.Reference()
-		s["r"].load( "/tmp/test.grf" )
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		s["e"] = GafferTest.TextWriter()
 
@@ -343,10 +343,10 @@ class ExecutableNodeTest( GafferTest.TestCase ) :
 		p = s["b"].promotePlug( s["b"]["e"]["requirements"] )
 		p.setName( "p" )
 
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s["r"] = Gaffer.Reference()
-		s["r"].load( "/tmp/test.grf" )
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		s["e"] = GafferTest.TextWriter()
 
@@ -364,14 +364,7 @@ class ExecutableNodeTest( GafferTest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 		s["fileName"].setValue( os.path.dirname( __file__ ) + "/scripts/promotedRequirementsNetworkVersion-0.15.0.0.gfr" )
-		s.load()	
-
-	def tearDown( self ) :
-
-		GafferTest.TestCase.tearDown( self )
-
-		if os.path.exists( "/tmp/test.grf" ) :
-			os.remove( "/tmp/test.grf" )
+		s.load()
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/ExecuteApplicationTest.py
+++ b/python/GafferTest/ExecuteApplicationTest.py
@@ -46,10 +46,14 @@ import GafferTest
 
 class ExecuteApplicationTest( GafferTest.TestCase ) :
 
-	__scriptFileName = "/tmp/executeScript.gfr"
-	__scriptFileNameWithSpecialCharacters = "/tmp/executeScript-10.tmp.gfr"
-	__outputTextFile = "/tmp/executeOutput.txt"
-	__outputFileSeq = IECore.FileSequence( "/tmp/sphere.####.cob" )
+	def setUp( self ) :
+
+		GafferTest.TestCase.setUp( self )
+
+		self.__scriptFileName = self.temporaryDirectory() + "/executeScript.gfr"
+		self.__scriptFileNameWithSpecialCharacters = self.temporaryDirectory() + "/executeScript-10.tmp.gfr"
+		self.__outputTextFile = self.temporaryDirectory() + "/executeOutput.txt"
+		self.__outputFileSeq = IECore.FileSequence( self.temporaryDirectory() + "/sphere.####.cob" )
 
 	def testErrorReturnStatusForMissingScript( self ) :
 
@@ -246,17 +250,6 @@ class ExecuteApplicationTest( GafferTest.TestCase ) :
 
 		self.assertEqual( p.returncode, 0 )
 		self.assertTrue( os.path.exists( self.__outputTextFile ) )
-
-	def tearDown( self ) :
-
-		files = [ self.__scriptFileName, self.__scriptFileNameWithSpecialCharacters, self.__outputTextFile ]
-		seq = IECore.ls( self.__outputFileSeq.fileName, minSequenceSize = 1 )
-		if seq :
-			files.extend( seq.fileNames() )
-
-		for f in files :
-			if os.path.exists( f ) :
-				os.remove( f )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/FileSystemPathTest.py
+++ b/python/GafferTest/FileSystemPathTest.py
@@ -38,7 +38,6 @@
 from __future__ import with_statement
 
 import unittest
-import shutil
 import time
 import datetime
 import pwd

--- a/python/GafferTest/PathFilterTest.py
+++ b/python/GafferTest/PathFilterTest.py
@@ -36,9 +36,7 @@
 ##########################################################################
 
 import unittest
-import shutil
 import glob
-import os
 
 import IECore
 

--- a/python/GafferTest/ScriptNodeTest.py
+++ b/python/GafferTest/ScriptNodeTest.py
@@ -190,11 +190,11 @@ class ScriptNodeTest( GafferTest.TestCase ) :
 		s["a2"]["op1"].setInput( s["a1"]["sum"] )
 		s["a2"]["op2"].setValue( 10 )
 
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s.save()
 
 		s2 = Gaffer.ScriptNode()
-		s2["fileName"].setValue( "/tmp/test.gfr" )
+		s2["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s2.load()
 
 		self.assert_( s2["a2"]["op1"].getInput().isSame( s2["a1"]["sum"] ) )
@@ -204,7 +204,7 @@ class ScriptNodeTest( GafferTest.TestCase ) :
 		s = Gaffer.ScriptNode()
 		s["a1"] = GafferTest.AddNode()
 
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s.save()
 
 		s.load()
@@ -406,11 +406,11 @@ a = A()"""
 		self.assertEqual( s["frameRange"]["start"].getValue(), 110 )
 		self.assertEqual( s["frameRange"]["end"].getValue(), 200 )
 
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s.save()
 
 		s2 = Gaffer.ScriptNode()
-		s2["fileName"].setValue( "/tmp/test.gfr" )
+		s2["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s2.load()
 
 		self.assertEqual( s2["frameRange"]["start"].getValue(), 110 )
@@ -624,11 +624,11 @@ a = A()"""
 		s["customSetting"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		s["customSetting"].setValue( 100 )
 
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s.save()
 
 		s2 = Gaffer.ScriptNode()
-		s2["fileName"].setValue( "/tmp/test.gfr" )
+		s2["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s2.load()
 
 		self.assertEqual( s2["customSetting"].getValue(), 100 )
@@ -829,16 +829,16 @@ a = A()"""
 		s = Gaffer.ScriptNode()
 		s["n"] = Gaffer.Node()
 
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s.save()
 
-		shutil.move( "/tmp/test.gfr", "/tmp/test2.gfr" )
+		shutil.move( self.temporaryDirectory() + "/test.gfr", self.temporaryDirectory() + "/test2.gfr" )
 
 		s = Gaffer.ScriptNode()
-		s["fileName"].setValue( "/tmp/test2.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test2.gfr" )
 		s.load()
 
-		self.assertEqual( s["fileName"].getValue(), "/tmp/test2.gfr" )
+		self.assertEqual( s["fileName"].getValue(), self.temporaryDirectory() + "/test2.gfr" )
 
 	def testUnsavedChanges( self ) :
 
@@ -856,7 +856,7 @@ a = A()"""
 			s["node"] = GafferTest.AddNode()
 		self.assertEqual( s["unsavedChanges"].getValue(), True )
 
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s.save()
 		self.assertEqual( s["unsavedChanges"].getValue(), False )
 
@@ -911,20 +911,20 @@ a = A()"""
 		s["n2"] = GafferTest.AddNode()
 		s["n2"]["op1"].setInput( s["n1"]["sum"] )
 
-		s.serialiseToFile( "/tmp/test.gfr" )
+		s.serialiseToFile( self.temporaryDirectory() + "/test.gfr" )
 
 		s2 = Gaffer.ScriptNode()
-		s2["fileName"].setValue( "/tmp/test.gfr" )
+		s2["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s2.load()
 
 		self.assertTrue( "n1" in s2 )
 		self.assertTrue( "n2" in s2 )
 		self.assertTrue( s2["n2"]["op1"].getInput().isSame( s2["n1"]["sum"] ) )
 
-		s.serialiseToFile( "/tmp/test.gfr", filter = Gaffer.StandardSet( [ s["n2"] ] ) )
+		s.serialiseToFile( self.temporaryDirectory() + "/test.gfr", filter = Gaffer.StandardSet( [ s["n2"] ] ) )
 
 		s3 = Gaffer.ScriptNode()
-		s3["fileName"].setValue( "/tmp/test.gfr" )
+		s3["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s3.load()
 
 		self.assertTrue( "n1" not in s3 )
@@ -938,13 +938,13 @@ a = A()"""
 		s["n2"] = GafferTest.AddNode()
 		s["n2"]["op1"].setInput( s["n1"]["sum"] )
 
-		s.serialiseToFile( "/tmp/test.gfr" )
+		s.serialiseToFile( self.temporaryDirectory() + "/test.gfr" )
 
 		s2 = Gaffer.ScriptNode()
 
 		self.assertRaises( RuntimeError, s2.executeFile, "thisFileDoesntExist.gfr" )
 
-		s2.executeFile( "/tmp/test.gfr" )
+		s2.executeFile( self.temporaryDirectory() + "/test.gfr" )
 
 		self.assertTrue( s2["n2"]["op1"].getInput().isSame( s2["n1"]["sum"] ) )
 
@@ -1010,11 +1010,11 @@ a = A()"""
 		p["value"].setValue( 20 )
 		self.assertEqual( s.context().get( "test" ), 20 )
 
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s.save()
 
 		s2 = Gaffer.ScriptNode()
-		s2["fileName"].setValue( "/tmp/test.gfr" )
+		s2["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s2.load()
 
 		self.assertEqual( s2["variables"][p.getName()]["value"].getValue(), 20 )
@@ -1025,7 +1025,7 @@ a = A()"""
 		s = Gaffer.ScriptNode()
 		self.assertEqual( s.context().get( "script:name" ), "" )
 
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		self.assertEqual( s.context().get( "script:name" ), "test" )
 
 	def testReloadWithCustomVariables( self ) :
@@ -1033,7 +1033,7 @@ a = A()"""
 		s = Gaffer.ScriptNode()
 		s["variables"].addMember( "test", IECore.IntData( 10 ) )
 
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s.save()
 
 		s["variables"][0]["value"].setValue( 100 )
@@ -1049,11 +1049,11 @@ a = A()"""
 		p = s["variables"].addMember( "test", IECore.IntData( 10 ) )
 		self.assertEqual( s.context().get( "test" ), 10 )
 
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s.save()
 
 		s2 = Gaffer.ScriptNode()
-		s2["fileName"].setValue( "/tmp/test.gfr" )
+		s2["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s2.load()
 
 		self.assertEqual( s2["variables"][p.getName()]["value"].getValue(), 10 )
@@ -1192,7 +1192,7 @@ a = A()"""
 		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:minorVersion" ), None )
 		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:patchVersion" ), None )
 
-		s.serialiseToFile( "/tmp/test.gfr" )
+		s.serialiseToFile( self.temporaryDirectory() + "/test.gfr" )
 
 		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:milestoneVersion" ), None )
 		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:majorVersion" ), None )
@@ -1200,7 +1200,7 @@ a = A()"""
 		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:patchVersion" ), None )
 
 		s2 = Gaffer.ScriptNode()
-		s2["fileName"].setValue( "/tmp/test.gfr" )
+		s2["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s2.load()
 
 		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:milestoneVersion" ), Gaffer.About.milestoneVersion() )
@@ -1208,7 +1208,7 @@ a = A()"""
 		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:minorVersion" ), Gaffer.About.minorVersion() )
 		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:patchVersion" ), Gaffer.About.patchVersion() )
 
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s.save()
 
 		s2.load()
@@ -1229,26 +1229,17 @@ a = A()"""
 		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:minorVersion" ), 0 )
 		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:patchVersion" ), 0 )
 
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s.save()
 
 		s2 = Gaffer.ScriptNode()
-		s2["fileName"].setValue( "/tmp/test.gfr" )
+		s2["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s2.load()
 
 		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:milestoneVersion" ), Gaffer.About.milestoneVersion() )
 		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:majorVersion" ), Gaffer.About.majorVersion() )
 		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:minorVersion" ), Gaffer.About.minorVersion() )
 		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:patchVersion" ), Gaffer.About.patchVersion() )
-
-	def tearDown( self ) :
-
-		for f in (
-			"/tmp/test.gfr",
-			"/tmp/test2.gfr",
-		) :
-			if os.path.exists( f ) :
-				os.remove( f )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/SystemCommandTest.py
+++ b/python/GafferTest/SystemCommandTest.py
@@ -47,32 +47,32 @@ class SystemCommandTest( GafferTest.TestCase ) :
 	def test( self ) :
 
 		n = Gaffer.SystemCommand()
-		n["command"].setValue( "touch /tmp/systemCommandTest.txt" )
+		n["command"].setValue( "touch " + self.temporaryDirectory() + "/systemCommandTest.txt" )
 
 		n.execute()
 
-		self.assertTrue( os.path.exists( "/tmp/systemCommandTest.txt" ) )
+		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/systemCommandTest.txt" ) )
 
 	def testEnvironmentVariables( self ) :
 
 		n = Gaffer.SystemCommand()
-		n["command"].setValue( "env > /tmp/systemCommandTest.txt" )
+		n["command"].setValue( "env > " + self.temporaryDirectory() + "/systemCommandTest.txt" )
 		n["environmentVariables"].addMember( "GAFFER_SYSTEMCOMMAND_TEST", IECore.StringData( "test" ) )
 
 		n.execute()
 
-		env = "".join( open( "/tmp/systemCommandTest.txt" ).readlines() )
+		env = "".join( open( self.temporaryDirectory() + "/systemCommandTest.txt" ).readlines() )
 		self.assertTrue( "GAFFER_SYSTEMCOMMAND_TEST=test" in env )
 
 	def testSubstitutions( self ) :
 
 		n = Gaffer.SystemCommand()
-		n["command"].setValue( "echo {adjective} {noun} > /tmp/systemCommandTest.txt" )
+		n["command"].setValue( "echo {adjective} {noun} > " + self.temporaryDirectory() + "/systemCommandTest.txt" )
 		n["substitutions"].addMember( "adjective", IECore.StringData( "red" ) )
 		n["substitutions"].addMember( "noun", IECore.StringData( "truck" ) )
 
 		n.execute()
-		self.assertEqual( "red truck\n", open( "/tmp/systemCommandTest.txt" ).readlines()[0] )
+		self.assertEqual( "red truck\n", open( self.temporaryDirectory() + "/systemCommandTest.txt" ).readlines()[0] )
 
 	def testHash( self ) :
 
@@ -95,16 +95,6 @@ class SystemCommandTest( GafferTest.TestCase ) :
 
 		# check that all hashes are unique
 		self.assertEqual( len( hashes ), len( set( hashes ) ) )
-
-	def setUp( self ) :
-
-		for f in [ "/tmp/systemCommandTest.txt" ] :
-			if os.path.exists( f ) :
-				os.remove( f )
-
-	def tearDown( self ) :
-
-		self.setUp()
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/TaskContextVariablesTest.py
+++ b/python/GafferTest/TaskContextVariablesTest.py
@@ -34,9 +34,7 @@
 #
 ##########################################################################
 
-import os
 import glob
-import shutil
 import unittest
 
 import Gaffer
@@ -47,7 +45,7 @@ class TaskContextVariablesTest( GafferTest.TestCase ) :
 	def __dispatcher( self, frameRange = None ) :
 
 		result = Gaffer.LocalDispatcher( jobPool = Gaffer.LocalDispatcher.JobPool() )
-		result["jobsDirectory"].setValue( "/tmp/gafferTaskContextVariablesTest/jobs" )
+		result["jobsDirectory"].setValue( self.temporaryDirectory() + "/jobs" )
 
 		return result
 
@@ -56,7 +54,7 @@ class TaskContextVariablesTest( GafferTest.TestCase ) :
 		script = Gaffer.ScriptNode()
 
 		script["writer"] = GafferTest.TextWriter()
-		script["writer"]["fileName"].setValue( "/tmp/gafferTaskContextVariablesTest/${name}.txt" )
+		script["writer"]["fileName"].setValue( self.temporaryDirectory() + "/${name}.txt" )
 
 		script["variables"] = Gaffer.TaskContextVariables()
 		script["variables"]["requirements"][0].setInput( script["writer"]["requirement"] )
@@ -65,10 +63,10 @@ class TaskContextVariablesTest( GafferTest.TestCase ) :
 		self.__dispatcher().dispatch( [ script["variables"] ] )
 
 		self.assertEqual(
-			set( glob.glob( "/tmp/gafferTaskContextVariablesTest/*.txt" ) ),
+			set( glob.glob( self.temporaryDirectory() + "/*.txt" ) ),
 			{
-				"/tmp/gafferTaskContextVariablesTest/jimbob.txt",
-				
+				self.temporaryDirectory() + "/jimbob.txt",
+
 			}
 		)
 
@@ -77,7 +75,7 @@ class TaskContextVariablesTest( GafferTest.TestCase ) :
 		script = Gaffer.ScriptNode()
 
 		script["writer"] = GafferTest.TextWriter()
-		script["writer"]["fileName"].setValue( "/tmp/gafferTaskContextVariablesTest/${name1}${name2}.txt" )
+		script["writer"]["fileName"].setValue( self.temporaryDirectory() + "/${name1}${name2}.txt" )
 
 		script["variables"] = Gaffer.TaskContextVariables()
 		script["variables"]["requirements"][0].setInput( script["writer"]["requirement"] )
@@ -87,10 +85,10 @@ class TaskContextVariablesTest( GafferTest.TestCase ) :
 		self.__dispatcher().dispatch( [ script["variables"] ] )
 
 		self.assertEqual(
-			set( glob.glob( "/tmp/gafferTaskContextVariablesTest/*.txt" ) ),
+			set( glob.glob( self.temporaryDirectory() + "/*.txt" ) ),
 			{
-				"/tmp/gafferTaskContextVariablesTest/bob.txt",
-				
+				self.temporaryDirectory() + "/bob.txt",
+
 			}
 		)
 
@@ -99,7 +97,7 @@ class TaskContextVariablesTest( GafferTest.TestCase ) :
 		script = Gaffer.ScriptNode()
 
 		script["writer"] = GafferTest.TextWriter()
-		script["writer"]["fileName"].setValue( "/tmp/gafferTaskContextVariablesTest/${name}.txt" )
+		script["writer"]["fileName"].setValue( self.temporaryDirectory() + "/${name}.txt" )
 
 		script["variables"] = Gaffer.TaskContextVariables()
 		script["variables"]["requirements"][0].setInput( script["writer"]["requirement"] )
@@ -113,18 +111,11 @@ class TaskContextVariablesTest( GafferTest.TestCase ) :
 		self.assertEqual( len( dispatcher.jobPool().failedJobs() ), 0 )
 
 		self.assertEqual(
-			set( glob.glob( "/tmp/gafferTaskContextVariablesTest/*.txt" ) ),
+			set( glob.glob( self.temporaryDirectory() + "/*.txt" ) ),
 			{
-				"/tmp/gafferTaskContextVariablesTest/jimbob.txt",
+				self.temporaryDirectory() + "/jimbob.txt",
 			}
 		)
-
-	def tearDown( self ) :
-
-		GafferTest.TestCase.tearDown( self )
-
-		if os.path.exists( "/tmp/gafferTaskContextVariablesTest" ) :
-			shutil.rmtree( "/tmp/gafferTaskContextVariablesTest" )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/TaskListTest.py
+++ b/python/GafferTest/TaskListTest.py
@@ -34,7 +34,6 @@
 #
 ##########################################################################
 
-import os
 import unittest
 
 import IECore
@@ -51,20 +50,10 @@ class TaskListTest( GafferTest.TestCase ) :
 		c2 = Gaffer.Context()
 		c2["frame"] = 10.0
 		self.assertEqual( n.hash( c ), n.hash( c2 ) )
-		
+
 		n2 = Gaffer.TaskList( "TaskList2" )
 		self.assertEqual( n.hash( c ), n2.hash( c ) )
 		self.assertEqual( n.hash( c2 ), n2.hash( c2 ) )
-	
-	def setUp( self ) :
-
-		for f in [ "/tmp/systemCommandTest.txt" ] :
-			if os.path.exists( f ) :
-				os.remove( f )
-
-	def tearDown( self ) :
-
-		self.setUp()
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/WedgeTest.py
+++ b/python/GafferTest/WedgeTest.py
@@ -36,7 +36,6 @@
 
 import os
 import glob
-import shutil
 import unittest
 
 import IECore
@@ -49,7 +48,7 @@ class WedgeTest( GafferTest.TestCase ) :
 	def __dispatcher( self, frameRange = None ) :
 
 		result = Gaffer.LocalDispatcher()
-		result["jobsDirectory"].setValue( "/tmp/gafferWedgeTest/jobs" )
+		result["jobsDirectory"].setValue( self.temporaryDirectory() + "/jobs" )
 
 		if frameRange is not None :
 			result["framesMode"].setValue( result.FramesMode.CustomRange )
@@ -62,7 +61,7 @@ class WedgeTest( GafferTest.TestCase ) :
 		script = Gaffer.ScriptNode()
 
 		script["writer"] = GafferTest.TextWriter()
-		script["writer"]["fileName"].setValue( "/tmp/gafferWedgeTest/${name}.txt" )
+		script["writer"]["fileName"].setValue( self.temporaryDirectory() + "/${name}.txt" )
 
 		script["wedge"] = Gaffer.Wedge()
 		script["wedge"]["requirements"][0].setInput( script["writer"]["requirement"] )
@@ -73,11 +72,11 @@ class WedgeTest( GafferTest.TestCase ) :
 		self.__dispatcher().dispatch( [ script["wedge"] ] )
 
 		self.assertEqual(
-			set( glob.glob( "/tmp/gafferWedgeTest/*.txt" ) ),
+			set( glob.glob( self.temporaryDirectory() + "/*.txt" ) ),
 			{
-				"/tmp/gafferWedgeTest/tom.txt",
-				"/tmp/gafferWedgeTest/dick.txt",
-				"/tmp/gafferWedgeTest/harry.txt",
+				self.temporaryDirectory() + "/tom.txt",
+				self.temporaryDirectory() + "/dick.txt",
+				self.temporaryDirectory() + "/harry.txt",
 			}
 		)
 
@@ -86,7 +85,7 @@ class WedgeTest( GafferTest.TestCase ) :
 		script = Gaffer.ScriptNode()
 
 		script["writer"] = GafferTest.TextWriter()
-		script["writer"]["fileName"].setValue( "/tmp/gafferWedgeTest/${wedge:value}.txt" )
+		script["writer"]["fileName"].setValue( self.temporaryDirectory() + "/${wedge:value}.txt" )
 
 		script["wedge"] = Gaffer.Wedge()
 		script["wedge"]["requirements"][0].setInput( script["writer"]["requirement"] )
@@ -96,11 +95,11 @@ class WedgeTest( GafferTest.TestCase ) :
 		self.__dispatcher().dispatch( [ script["wedge"] ] )
 
 		self.assertEqual(
-			set( glob.glob( "/tmp/gafferWedgeTest/*.txt" ) ),
+			set( glob.glob( self.temporaryDirectory() + "/*.txt" ) ),
 			{
-				"/tmp/gafferWedgeTest/1.txt",
-				"/tmp/gafferWedgeTest/21.txt",
-				"/tmp/gafferWedgeTest/44.txt",
+				self.temporaryDirectory() + "/1.txt",
+				self.temporaryDirectory() + "/21.txt",
+				self.temporaryDirectory() + "/44.txt",
 			}
 		)
 
@@ -109,7 +108,7 @@ class WedgeTest( GafferTest.TestCase ) :
 		script = Gaffer.ScriptNode()
 
 		script["writer"] = GafferTest.TextWriter()
-		script["writer"]["fileName"].setValue( "/tmp/gafferWedgeTest/${wedge:index}.txt" )
+		script["writer"]["fileName"].setValue( self.temporaryDirectory() + "/${wedge:index}.txt" )
 		script["writer"]["text"].setValue( "${wedge:value}" )
 
 		script["wedge"] = Gaffer.Wedge()
@@ -120,24 +119,24 @@ class WedgeTest( GafferTest.TestCase ) :
 		self.__dispatcher().dispatch( [ script["wedge"] ] )
 
 		self.assertEqual(
-			set( glob.glob( "/tmp/gafferWedgeTest/*.txt" ) ),
+			set( glob.glob( self.temporaryDirectory() + "/*.txt" ) ),
 			{
-				"/tmp/gafferWedgeTest/0.txt",
-				"/tmp/gafferWedgeTest/1.txt",
-				"/tmp/gafferWedgeTest/2.txt",
+				self.temporaryDirectory() + "/0.txt",
+				self.temporaryDirectory() + "/1.txt",
+				self.temporaryDirectory() + "/2.txt",
 			}
 		)
 
-		self.assertEqual( next( open( "/tmp/gafferWedgeTest/0.txt" ) ), "1.25" )
-		self.assertEqual( next( open( "/tmp/gafferWedgeTest/1.txt" ) ), "2.75" )
-		self.assertEqual( next( open( "/tmp/gafferWedgeTest/2.txt" ) ), "44" )
+		self.assertEqual( next( open( self.temporaryDirectory() + "/0.txt" ) ), "1.25" )
+		self.assertEqual( next( open( self.temporaryDirectory() + "/1.txt" ) ), "2.75" )
+		self.assertEqual( next( open( self.temporaryDirectory() + "/2.txt" ) ), "44" )
 
 	def testIntRange( self ) :
 
 		script = Gaffer.ScriptNode()
 
 		script["writer"] = GafferTest.TextWriter()
-		script["writer"]["fileName"].setValue( "/tmp/gafferWedgeTest/${number}.txt" )
+		script["writer"]["fileName"].setValue( self.temporaryDirectory() + "/${number}.txt" )
 
 		script["wedge"] = Gaffer.Wedge()
 		script["wedge"]["requirements"][0].setInput( script["writer"]["requirement"] )
@@ -150,11 +149,11 @@ class WedgeTest( GafferTest.TestCase ) :
 		self.__dispatcher().dispatch( [ script["wedge"] ] )
 
 		self.assertEqual(
-			set( glob.glob( "/tmp/gafferWedgeTest/*.txt" ) ),
+			set( glob.glob( self.temporaryDirectory() + "/*.txt" ) ),
 			{
-				"/tmp/gafferWedgeTest/3.txt",
-				"/tmp/gafferWedgeTest/5.txt",
-				"/tmp/gafferWedgeTest/7.txt",
+				self.temporaryDirectory() + "/3.txt",
+				self.temporaryDirectory() + "/5.txt",
+				self.temporaryDirectory() + "/7.txt",
 			}
 		)
 
@@ -163,7 +162,7 @@ class WedgeTest( GafferTest.TestCase ) :
 		script = Gaffer.ScriptNode()
 
 		script["writer"] = GafferTest.TextWriter()
-		script["writer"]["fileName"].setValue( "/tmp/gafferWedgeTest/${wedge:index}.txt" )
+		script["writer"]["fileName"].setValue( self.temporaryDirectory() + "/${wedge:index}.txt" )
 		script["writer"]["text"].setValue( "${wedge:value}" )
 
 		script["wedge"] = Gaffer.Wedge()
@@ -176,28 +175,28 @@ class WedgeTest( GafferTest.TestCase ) :
 		self.__dispatcher().dispatch( [ script["wedge"] ] )
 
 		self.assertEqual(
-			set( glob.glob( "/tmp/gafferWedgeTest/*.txt" ) ),
+			set( glob.glob( self.temporaryDirectory() + "/*.txt" ) ),
 			{
-				"/tmp/gafferWedgeTest/0.txt",
-				"/tmp/gafferWedgeTest/1.txt",
-				"/tmp/gafferWedgeTest/2.txt",
-				"/tmp/gafferWedgeTest/3.txt",
-				"/tmp/gafferWedgeTest/4.txt",
+				self.temporaryDirectory() + "/0.txt",
+				self.temporaryDirectory() + "/1.txt",
+				self.temporaryDirectory() + "/2.txt",
+				self.temporaryDirectory() + "/3.txt",
+				self.temporaryDirectory() + "/4.txt",
 			}
 		)
 
-		self.assertEqual( next( open( "/tmp/gafferWedgeTest/0.txt" ) ), "0" )
-		self.assertEqual( next( open( "/tmp/gafferWedgeTest/1.txt" ) ), "0.25" )
-		self.assertEqual( next( open( "/tmp/gafferWedgeTest/2.txt" ) ), "0.5" )
-		self.assertEqual( next( open( "/tmp/gafferWedgeTest/3.txt" ) ), "0.75" )
-		self.assertEqual( next( open( "/tmp/gafferWedgeTest/4.txt" ) ), "1" )
+		self.assertEqual( next( open( self.temporaryDirectory() + "/0.txt" ) ), "0" )
+		self.assertEqual( next( open( self.temporaryDirectory() + "/1.txt" ) ), "0.25" )
+		self.assertEqual( next( open( self.temporaryDirectory() + "/2.txt" ) ), "0.5" )
+		self.assertEqual( next( open( self.temporaryDirectory() + "/3.txt" ) ), "0.75" )
+		self.assertEqual( next( open( self.temporaryDirectory() + "/4.txt" ) ), "1" )
 
 	def testFloatByPointOne( self ) :
 
 		script = Gaffer.ScriptNode()
 
 		script["writer"] = GafferTest.TextWriter()
-		script["writer"]["fileName"].setValue( "/tmp/gafferWedgeTest/${wedge:index}.txt" )
+		script["writer"]["fileName"].setValue( self.temporaryDirectory() + "/${wedge:index}.txt" )
 		script["writer"]["text"].setValue( "${wedge:value}" )
 
 		script["wedge"] = Gaffer.Wedge()
@@ -210,40 +209,40 @@ class WedgeTest( GafferTest.TestCase ) :
 		self.__dispatcher().dispatch( [ script["wedge"] ] )
 
 		self.assertEqual(
-			set( glob.glob( "/tmp/gafferWedgeTest/*.txt" ) ),
+			set( glob.glob( self.temporaryDirectory() + "/*.txt" ) ),
 			{
-				"/tmp/gafferWedgeTest/0.txt",
-				"/tmp/gafferWedgeTest/1.txt",
-				"/tmp/gafferWedgeTest/2.txt",
-				"/tmp/gafferWedgeTest/3.txt",
-				"/tmp/gafferWedgeTest/4.txt",
-				"/tmp/gafferWedgeTest/5.txt",
-				"/tmp/gafferWedgeTest/6.txt",
-				"/tmp/gafferWedgeTest/7.txt",
-				"/tmp/gafferWedgeTest/8.txt",
-				"/tmp/gafferWedgeTest/9.txt",
-				"/tmp/gafferWedgeTest/10.txt",
+				self.temporaryDirectory() + "/0.txt",
+				self.temporaryDirectory() + "/1.txt",
+				self.temporaryDirectory() + "/2.txt",
+				self.temporaryDirectory() + "/3.txt",
+				self.temporaryDirectory() + "/4.txt",
+				self.temporaryDirectory() + "/5.txt",
+				self.temporaryDirectory() + "/6.txt",
+				self.temporaryDirectory() + "/7.txt",
+				self.temporaryDirectory() + "/8.txt",
+				self.temporaryDirectory() + "/9.txt",
+				self.temporaryDirectory() + "/10.txt",
 			}
 		)
 
-		self.assertAlmostEqual( float( next( open( "/tmp/gafferWedgeTest/0.txt" ) ) ), 0 )
-		self.assertAlmostEqual( float( next( open( "/tmp/gafferWedgeTest/1.txt" ) ) ), 0.1 )
-		self.assertAlmostEqual( float( next( open( "/tmp/gafferWedgeTest/2.txt" ) ) ), 0.2 )
-		self.assertAlmostEqual( float( next( open( "/tmp/gafferWedgeTest/3.txt" ) ) ), 0.3 )
-		self.assertAlmostEqual( float( next( open( "/tmp/gafferWedgeTest/4.txt" ) ) ), 0.4 )	
-		self.assertAlmostEqual( float( next( open( "/tmp/gafferWedgeTest/5.txt" ) ) ), 0.5 )	
-		self.assertAlmostEqual( float( next( open( "/tmp/gafferWedgeTest/6.txt" ) ) ), 0.6 )	
-		self.assertAlmostEqual( float( next( open( "/tmp/gafferWedgeTest/7.txt" ) ) ), 0.7 )	
-		self.assertAlmostEqual( float( next( open( "/tmp/gafferWedgeTest/8.txt" ) ) ), 0.8 )	
-		self.assertAlmostEqual( float( next( open( "/tmp/gafferWedgeTest/9.txt" ) ) ), 0.9 )	
-		self.assertAlmostEqual( float( next( open( "/tmp/gafferWedgeTest/10.txt" ) ) ), 1 )	
+		self.assertAlmostEqual( float( next( open( self.temporaryDirectory() + "//0.txt" ) ) ), 0 )
+		self.assertAlmostEqual( float( next( open( self.temporaryDirectory() + "//1.txt" ) ) ), 0.1 )
+		self.assertAlmostEqual( float( next( open( self.temporaryDirectory() + "//2.txt" ) ) ), 0.2 )
+		self.assertAlmostEqual( float( next( open( self.temporaryDirectory() + "//3.txt" ) ) ), 0.3 )
+		self.assertAlmostEqual( float( next( open( self.temporaryDirectory() + "//4.txt" ) ) ), 0.4 )
+		self.assertAlmostEqual( float( next( open( self.temporaryDirectory() + "//5.txt" ) ) ), 0.5 )
+		self.assertAlmostEqual( float( next( open( self.temporaryDirectory() + "//6.txt" ) ) ), 0.6 )
+		self.assertAlmostEqual( float( next( open( self.temporaryDirectory() + "//7.txt" ) ) ), 0.7 )
+		self.assertAlmostEqual( float( next( open( self.temporaryDirectory() + "//8.txt" ) ) ), 0.8 )
+		self.assertAlmostEqual( float( next( open( self.temporaryDirectory() + "//9.txt" ) ) ), 0.9 )
+		self.assertAlmostEqual( float( next( open( self.temporaryDirectory() + "//10.txt" ) ) ), 1 )
 
 	def testColorRange( self ) :
 
 		script = Gaffer.ScriptNode()
 
 		script["writer"] = GafferTest.TextWriter()
-		script["writer"]["fileName"].setValue( "/tmp/gafferWedgeTest/${wedge:index}.txt" )
+		script["writer"]["fileName"].setValue( self.temporaryDirectory() + "/${wedge:index}.txt" )
 
 		script["expression"] = Gaffer.Expression()
 		script["expression"]["engine"].setValue( "python" )
@@ -257,24 +256,24 @@ class WedgeTest( GafferTest.TestCase ) :
 		self.__dispatcher().dispatch( [ script["wedge"] ] )
 
 		self.assertEqual(
-			set( glob.glob( "/tmp/gafferWedgeTest/*.txt" ) ),
+			set( glob.glob( self.temporaryDirectory() + "/*.txt" ) ),
 			{
-				"/tmp/gafferWedgeTest/0.txt",
-				"/tmp/gafferWedgeTest/1.txt",
-				"/tmp/gafferWedgeTest/2.txt",
+				self.temporaryDirectory() + "/0.txt",
+				self.temporaryDirectory() + "/1.txt",
+				self.temporaryDirectory() + "/2.txt",
 			}
 		)
 
-		self.assertEqual( next( open( "/tmp/gafferWedgeTest/0.txt" ) ), "0.0 0.0 0.0" )
-		self.assertEqual( next( open( "/tmp/gafferWedgeTest/1.txt" ) ), "0.5 0.5 0.5" )
-		self.assertEqual( next( open( "/tmp/gafferWedgeTest/2.txt" ) ), "1.0 1.0 1.0" )
+		self.assertEqual( next( open( self.temporaryDirectory() + "/0.txt" ) ), "0.0 0.0 0.0" )
+		self.assertEqual( next( open( self.temporaryDirectory() + "/1.txt" ) ), "0.5 0.5 0.5" )
+		self.assertEqual( next( open( self.temporaryDirectory() + "/2.txt" ) ), "1.0 1.0 1.0" )
 
 	def test2DRange( self ) :
 
 		script = Gaffer.ScriptNode()
 
 		script["writer"] = GafferTest.TextWriter()
-		script["writer"]["fileName"].setValue( "/tmp/gafferWedgeTest/${wedge:x}.${wedge:y}.txt" )
+		script["writer"]["fileName"].setValue( self.temporaryDirectory() + "/${wedge:x}.${wedge:y}.txt" )
 
 		script["wedgeX"] = Gaffer.Wedge()
 		script["wedgeX"]["requirements"][0].setInput( script["writer"]["requirement"] )
@@ -295,14 +294,14 @@ class WedgeTest( GafferTest.TestCase ) :
 		self.__dispatcher().dispatch( [ script["wedgeY"] ] )
 
 		self.assertEqual(
-			set( glob.glob( "/tmp/gafferWedgeTest/*.txt" ) ),
+			set( glob.glob( self.temporaryDirectory() + "/*.txt" ) ),
 			{
-				"/tmp/gafferWedgeTest/1.1.txt",
-				"/tmp/gafferWedgeTest/1.2.txt",
-				"/tmp/gafferWedgeTest/2.1.txt",
-				"/tmp/gafferWedgeTest/2.2.txt",
-				"/tmp/gafferWedgeTest/3.1.txt",
-				"/tmp/gafferWedgeTest/3.2.txt",
+				self.temporaryDirectory() + "/1.1.txt",
+				self.temporaryDirectory() + "/1.2.txt",
+				self.temporaryDirectory() + "/2.1.txt",
+				self.temporaryDirectory() + "/2.2.txt",
+				self.temporaryDirectory() + "/3.1.txt",
+				self.temporaryDirectory() + "/3.2.txt",
 			}
 		)
 
@@ -311,7 +310,7 @@ class WedgeTest( GafferTest.TestCase ) :
 		script = Gaffer.ScriptNode()
 
 		script["writer"] = GafferTest.TextWriter()
-		script["writer"]["fileName"].setValue( "/tmp/gafferWedgeTest/${name}.####.txt" )
+		script["writer"]["fileName"].setValue( self.temporaryDirectory() + "/${name}.####.txt" )
 
 		script["wedge"] = Gaffer.Wedge()
 		script["wedge"]["requirements"][0].setInput( script["writer"]["requirement"] )
@@ -322,14 +321,14 @@ class WedgeTest( GafferTest.TestCase ) :
 		self.__dispatcher( frameRange = "21-22" ).dispatch( [ script["wedge"] ] )
 
 		self.assertEqual(
-			set( glob.glob( "/tmp/gafferWedgeTest/*.txt" ) ),
+			set( glob.glob( self.temporaryDirectory() + "/*.txt" ) ),
 			{
-				"/tmp/gafferWedgeTest/tom.0021.txt",
-				"/tmp/gafferWedgeTest/tom.0022.txt",
-				"/tmp/gafferWedgeTest/dick.0021.txt",
-				"/tmp/gafferWedgeTest/dick.0022.txt",
-				"/tmp/gafferWedgeTest/harry.0021.txt",
-				"/tmp/gafferWedgeTest/harry.0022.txt",
+				self.temporaryDirectory() + "/tom.0021.txt",
+				self.temporaryDirectory() + "/tom.0022.txt",
+				self.temporaryDirectory() + "/dick.0021.txt",
+				self.temporaryDirectory() + "/dick.0022.txt",
+				self.temporaryDirectory() + "/harry.0021.txt",
+				self.temporaryDirectory() + "/harry.0022.txt",
 			}
 		)
 
@@ -341,7 +340,7 @@ class WedgeTest( GafferTest.TestCase ) :
 
 		script["writer"] = GafferTest.TextWriter()
 		script["writer"]["requirements"][0].setInput( script["constant"]["requirement"] )
-		script["writer"]["fileName"].setValue( "/tmp/gafferWedgeTest/${name}.txt" )
+		script["writer"]["fileName"].setValue( self.temporaryDirectory() + "/${name}.txt" )
 
 		script["wedge"] = Gaffer.Wedge()
 		script["wedge"]["requirements"][0].setInput( script["writer"]["requirement"] )
@@ -352,11 +351,11 @@ class WedgeTest( GafferTest.TestCase ) :
 		self.__dispatcher().dispatch( [ script["wedge"] ] )
 
 		self.assertEqual(
-			set( glob.glob( "/tmp/gafferWedgeTest/*.txt" ) ),
+			set( glob.glob( self.temporaryDirectory() + "/*.txt" ) ),
 			{
-				"/tmp/gafferWedgeTest/tom.txt",
-				"/tmp/gafferWedgeTest/dick.txt",
-				"/tmp/gafferWedgeTest/harry.txt",
+				self.temporaryDirectory() + "/tom.txt",
+				self.temporaryDirectory() + "/dick.txt",
+				self.temporaryDirectory() + "/harry.txt",
 			}
 		)
 
@@ -364,13 +363,6 @@ class WedgeTest( GafferTest.TestCase ) :
 		# it should only execute once because it doesn't reference
 		# the wedge variable at all.
 		self.assertEqual( script["constant"].executionCount, 1 )
-
-	def tearDown( self ) :
-
-		GafferTest.TestCase.tearDown( self )
-
-		if os.path.exists( "/tmp/gafferWedgeTest" ) :
-			shutil.rmtree( "/tmp/gafferWedgeTest" )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/ReferenceUITest.py
+++ b/python/GafferUITest/ReferenceUITest.py
@@ -59,16 +59,11 @@ class ReferenceUITest( GafferUITest.TestCase ) :
 		g = GafferUI.GraphGadget( s )
 		self.assertTrue( g.nodeGadget( s["b"] ).nodule( s["b"]["p"] ) is None )
 
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 		s["r"] = Gaffer.Reference()
-		s["r"].load( "/tmp/test.grf" )
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		self.assertTrue( g.nodeGadget( s["r"] ).nodule( s["r"]["p"] ) is None )
-
-	def tearDown( self ) :
-
-		if os.path.exists( "/tmp/test.grf" ) :
-			os.remove( "/tmp/test.grf" )
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This is a mindless rejigging of the unit tests to use the new TestCase.temporaryDirectory() method rather than manually clean things up (or not clean things up at all as was the case for some tests). Since it touches so many files, it's likely to have a few conflicts - I'd rather fix those here than in a more complex branch like the expressions one, so let's merge this when we've got the big stuff merged.