### PR TITLE
Time support in Expressions

### DIFF
--- a/python/Gaffer/PythonExpressionEngine.py
+++ b/python/Gaffer/PythonExpressionEngine.py
@@ -213,6 +213,11 @@ class _Parser( ast.NodeVisitor ) :
 					# it's a method call on the context
 					if node.func.attr == "getFrame" :
 						self.contextReads.add( "frame" )
+					elif node.func.attr == "getTime" :
+						self.contextReads.add( "frame" )
+						self.contextReads.add( "framesPerSecond" )
+					elif node.func.attr == "getFramesPerSecond" :
+						self.contextReads.add( "framesPerSecond" )
 					elif node.func.attr == "get" :
 						if not isinstance( node.args[0], ast.Str ) :
 							raise SyntaxError( "Context name must be a string" )

--- a/python/GafferOSLTest/OSLExpressionEngineTest.py
+++ b/python/GafferOSLTest/OSLExpressionEngineTest.py
@@ -331,5 +331,39 @@ class OSLExpressionEngineTest( GafferOSLTest.OSLTestCase ) :
 
 		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/test.txt" ) )
 
+	def testTimeGlobalVariable( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n"] = Gaffer.Node()
+		s["n"]["user"]["f"] = Gaffer.FloatPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression( "parent.n.user.f = time", "OSL" )
+
+		with Gaffer.Context() as c :
+			c.setTime( 1 )
+			self.assertEqual( s["n"]["user"]["f"].getValue(), 1 )
+			c.setTime( 2 )
+			self.assertEqual( s["n"]["user"]["f"].getValue(), 2 )
+
+	def testHashIgnoresTimeWhenTimeNotReferenced( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n"] = Gaffer.Node()
+		s["n"]["user"]["f"] = Gaffer.FloatPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression( "parent.n.user.f = 1", "OSL" )
+
+		with Gaffer.Context() as c :
+			c.setTime( 1 )
+			h1 = s["n"]["user"]["f"].hash()
+			c.setTime( 2 )
+			h2 = s["n"]["user"]["f"].hash()
+
+		self.assertEqual( h1, h2 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/ExpressionTest.py
+++ b/python/GafferTest/ExpressionTest.py
@@ -1029,5 +1029,55 @@ class ExpressionTest( GafferTest.TestCase ) :
 		s["e"].setExpression( 'parent["n"]["user"]["i"] = 20' )
 		self.assertEqual( len( cs ), 2 )
 
+	def testTime( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n"] = Gaffer.Node()
+		s["n"]["user"]["f"] = Gaffer.FloatPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression( 'parent["n"]["user"]["f"] = context.getTime()' )
+
+		with Gaffer.Context() as c :
+			c.setTime( 1 )
+			self.assertEqual( s["n"]["user"]["f"].getValue(), 1 )
+			c.setTime( 2 )
+			self.assertEqual( s["n"]["user"]["f"].getValue(), 2 )
+
+	def testFramesPerSecond( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n"] = Gaffer.Node()
+		s["n"]["user"]["f"] = Gaffer.FloatPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression( 'parent["n"]["user"]["f"] = context.getFramesPerSecond()' )
+
+		with Gaffer.Context() as c :
+			c.setFramesPerSecond( 24 )
+			self.assertEqual( s["n"]["user"]["f"].getValue(), 24 )
+			c.setFramesPerSecond( 48 )
+			self.assertEqual( s["n"]["user"]["f"].getValue(), 48 )
+
+	def testHashIgnoresTimeWhenTimeNotReferenced( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n"] = Gaffer.Node()
+		s["n"]["user"]["f"] = Gaffer.FloatPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression( 'parent["n"]["user"]["f"] = 1' )
+
+		with Gaffer.Context() as c :
+			c.setTime( 1 )
+			h1 = s["n"]["user"]["f"].hash()
+			c.setTime( 2 )
+			h2 = s["n"]["user"]["f"].hash()
+
+		self.assertEqual( h1, h2 )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This adds proper support for time in both the Python and OSL expression engines (previously we only supported the current frame in python, and nothing in OSL).