### PR TITLE
ScriptNode : Fix undo merging for CompoundNumericPlugs.

### DIFF
--- a/include/Gaffer/UndoContext.h
+++ b/include/Gaffer/UndoContext.h
@@ -69,10 +69,10 @@ class UndoContext : DirtyPropagationScope
 		///
 		/// If mergeGroup is specified and matches the group used by
 		/// the previous UndoContext, then the actions performed will
-		/// be merged with the previous entry on the undo stack if
-		/// possible. This can be used by UI elements to compress a
-		/// series of individual editing events into a single item
-		/// on the undo stack.
+		/// be merged with the previous entry on the undo stack. This
+		/// can be used by UI elements to compress a series of individual
+		/// editing events such as an interactively updated drag into
+		/// a single item on the undo stack.
 		UndoContext( ScriptNodePtr script, State state=Enabled, const std::string &mergeGroup=std::string() );
 		~UndoContext();
 

--- a/python/GafferTest/CompoundNumericPlugTest.py
+++ b/python/GafferTest/CompoundNumericPlugTest.py
@@ -398,6 +398,32 @@ class CompoundNumericPlugTest( GafferTest.TestCase ) :
 		self.assertEqual( s["n"]["p"].getValue(), IECore.V3f( 0 ) )
 		self.assertFalse( s.undoAvailable() )
 
+	def testUndoMergingWithUnchangingComponents( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["n"] = Gaffer.Node()
+		s["n"]["p"] = Gaffer.V3fPlug()
+
+		self.assertEqual( s["n"]["p"].getValue(), IECore.V3f( 0 ) )
+		self.assertFalse( s.undoAvailable() )
+
+		with Gaffer.UndoContext( s, mergeGroup="test" ) :
+			s["n"]["p"].setValue( IECore.V3f( 1, 2, 0 ) )
+
+		self.assertEqual( s["n"]["p"].getValue(), IECore.V3f( 1, 2, 0 ) )
+		self.assertTrue( s.undoAvailable() )
+
+		with Gaffer.UndoContext( s, mergeGroup="test" ) :
+			s["n"]["p"].setValue( IECore.V3f( 2, 4, 0 ) )
+
+		self.assertEqual( s["n"]["p"].getValue(), IECore.V3f( 2, 4, 0 ) )
+		self.assertTrue( s.undoAvailable() )
+
+		s.undo()
+
+		self.assertEqual( s["n"]["p"].getValue(), IECore.V3f( 0 ) )
+		self.assertFalse( s.undoAvailable() )
+
 	def testSerialisationVerbosity( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/python/GafferTest/NumericPlugTest.py
+++ b/python/GafferTest/NumericPlugTest.py
@@ -373,7 +373,7 @@ class NumericPlugTest( GafferTest.TestCase ) :
 		self.assertEqual( s["n"]["p"].getValue(), 0 )
 		self.assertFalse( s.undoAvailable() )
 
-	def testNoUndoMergingForDifferentPlugs( self ) :
+	def testUndoMergingForDifferentPlugs( self ) :
 
 		s = Gaffer.ScriptNode()
 		s["n"] = Gaffer.Node()
@@ -395,12 +395,6 @@ class NumericPlugTest( GafferTest.TestCase ) :
 		self.assertTrue( s.undoAvailable() )
 		self.assertEqual( s["n"]["p1"].getValue(), 20 )
 		self.assertEqual( s["n"]["p2"].getValue(), 30 )
-
-		s.undo()
-
-		self.assertTrue( s.undoAvailable() )
-		self.assertEqual( s["n"]["p1"].getValue(), 20 )
-		self.assertEqual( s["n"]["p2"].getValue(), 0 )
 
 		s.undo()
 

--- a/src/Gaffer/ScriptNode.cpp
+++ b/src/Gaffer/ScriptNode.cpp
@@ -141,33 +141,40 @@ class ScriptNode::CompoundAction : public Gaffer::Action
 				return false;
 			}
 
-			if( m_mergeGroup != compoundAction->m_mergeGroup )
-			{
-				return false;
-			}
-
-			if( m_actions.size() != compoundAction->m_actions.size() )
-			{
-				return false;
-			}
-
-			for( size_t i = 0, e = m_actions.size(); i < e; ++i )
-			{
-				if( !m_actions[i]->canMerge( compoundAction->m_actions[i].get() ) )
-				{
-					return false;
-				}
-			}
-
-			return true;
+			return m_mergeGroup == compoundAction->m_mergeGroup;
 		}
 
 		virtual void merge( const Action *other )
 		{
 			const CompoundAction *compoundAction = static_cast<const CompoundAction *>( other );
-			for( size_t i = 0, e = m_actions.size(); i < e; ++i )
+
+			bool canMergeChildActions = false;
+			if( m_actions.size() == compoundAction->m_actions.size() )
 			{
-				m_actions[i]->merge( compoundAction->m_actions[i].get() );
+				canMergeChildActions = true;
+				for( size_t i = 0, e = m_actions.size(); i < e; ++i )
+				{
+					if( !m_actions[i]->canMerge( compoundAction->m_actions[i].get() ) )
+					{
+						canMergeChildActions = false;
+						break;
+					}
+				}
+			}
+
+			if( canMergeChildActions )
+			{
+				for( size_t i = 0, e = m_actions.size(); i < e; ++i )
+				{
+					m_actions[i]->merge( compoundAction->m_actions[i].get() );
+				}
+			}
+			else
+			{
+				for( std::vector<ActionPtr>::const_iterator it = compoundAction->m_actions.begin(), eIt = compoundAction->m_actions.end(); it != eIt; ++it )
+				{
+					m_actions.push_back( *it );
+				}
 			}
 		}
 


### PR DESCRIPTION
Previously we were refusing to merge undo events when requested if the two CompoundActions being merged didn't have perfectly corresponding child actions which could be merged smartly. This meant that when dragging a hue slider, the undo merging would break into several steps at the points where the hue transitioned from affecting one plug to another. We fix this by doing a less smart merging instead when necessary, just appending the actions from one CompoundAction onto the other.

Fixes #422.