### PR TITLE
SceneView : Fix over-zealous camera restoration.

### DIFF
--- a/python/GafferSceneUITest/SceneViewTest.py
+++ b/python/GafferSceneUITest/SceneViewTest.py
@@ -176,6 +176,72 @@ class SceneViewTest( GafferUITest.TestCase ) :
 		self.assertEqual( getExpandedPaths(), set( [ "/", "/A", "/A/C" ] ) )
 		self.assertEqual( getSelection(), set( [ "/A/C/E" ] ) )
 
+	def testLookThrough( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["sphere"] = GafferScene.Sphere()
+		script["camera"] = GafferScene.Camera()
+		script["camera"]["transform"]["translate"].setValue( IECore.V3f( 1, 0, 0 ) )
+
+		script["group"] = GafferScene.Group()
+		script["group"]["in"][0].setInput( script["sphere"]["out"] )
+		script["group"]["in"][1].setInput( script["camera"]["out"] )
+
+		with GafferUI.Window() as window :
+			viewer = GafferUI.Viewer( script )
+
+		window.setVisible( True )
+
+		viewer.setNodeSet( Gaffer.StandardSet( [ script["group"] ] ) )
+		view = viewer.view()
+		self.assertTrue( isinstance( view, GafferSceneUI.SceneView ) )
+
+		def setViewCameraTransform( matrix ) :
+
+			camera = view.viewportGadget().getCamera()
+			camera.getTransform().matrix = matrix
+			view.viewportGadget().setCamera( camera )
+
+		def getViewCameraTransform() :
+
+			return view.viewportGadget().getCamera().getTransform().transform()
+
+		# Simulate the user translating the camera.
+		setViewCameraTransform( IECore.M44f.createTranslated( IECore.V3f( 100, 0, 0 ) ) )
+		self.assertEqual( getViewCameraTransform(), IECore.M44f.createTranslated( IECore.V3f( 100, 0, 0 ) ) )
+
+		# Set the path for the look-through camera, but don't activate it - nothing should have changed.
+		view["lookThrough"]["camera"].setValue( "/group/camera" )
+		self.assertEqual( getViewCameraTransform(), IECore.M44f.createTranslated( IECore.V3f( 100, 0, 0 ) ) )
+
+		# Enable the look-through - the camera should update.
+		view["lookThrough"]["enabled"].setValue( True )
+		self.waitForIdle()
+		self.assertEqual( getViewCameraTransform(), script["group"]["out"].transform( "/group/camera" ) )
+
+		# Disable the look-through - the camera should revert to its previous position.
+		view["lookThrough"]["enabled"].setValue( False )
+		self.waitForIdle()
+		self.assertEqual( getViewCameraTransform(), IECore.M44f.createTranslated( IECore.V3f( 100, 0, 0 ) ) )
+
+		# Simulate the user moving the viewport camera, and then move the (now disabled) look-through
+		# camera. The user movement should win out.
+		setViewCameraTransform( IECore.M44f.createTranslated( IECore.V3f( 200, 0, 0 ) ) )
+		self.assertEqual( getViewCameraTransform(), IECore.M44f.createTranslated( IECore.V3f( 200, 0, 0 ) ) )
+		script["camera"]["transform"]["translate"].setValue( IECore.V3f( 2, 0, 0 ) )
+		self.waitForIdle()
+		self.assertEqual( getViewCameraTransform(), IECore.M44f.createTranslated( IECore.V3f( 200, 0, 0 ) ) )
+
+		# Change the viewer context - since look-through is disabled the user camera should not move.
+		viewer.getContext().setFrame( 10 )
+		self.waitForIdle()
+		self.assertEqual( getViewCameraTransform(), IECore.M44f.createTranslated( IECore.V3f( 200, 0, 0 ) ) )
+
+		# Work around "Internal C++ object (PySide.QtGui.QWidget) already deleted" error. In an
+		# ideal world we'll fix this, but it's unrelated to what we're testing here.
+		window.removeChild( viewer )
+
 if __name__ == "__main__":
 	unittest.main()
 

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -732,12 +732,21 @@ class SceneView::LookThrough
 		{
 			if( !boost::starts_with( name.value(), "ui:" ) )
 			{
-				m_lookThroughCameraDirty = m_viewportCameraDirty = true;
+				if( enabledPlug()->getValue() )
+				{
+					m_lookThroughCameraDirty = m_viewportCameraDirty = true;
+				}
 			}
 		}
 
 		void plugDirtied( Gaffer::Plug *plug )
 		{
+			if( plug != enabledPlug() && !enabledPlug()->getValue() )
+			{
+				// No need to do anything if we're turned off.
+				return;
+			}
+
 			if(
 				plug == scenePlug()->childNamesPlug() ||
 				plug == scenePlug()->globalsPlug() ||
@@ -750,7 +759,7 @@ class SceneView::LookThrough
 				m_lookThroughCameraDirty = m_viewportCameraDirty = true;
 				if( plug == enabledPlug() && enabledPlug()->getValue() )
 				{
-					m_originalCamera = m_view->viewportGadget()->getCamera();
+					m_originalCamera = m_view->viewportGadget()->getCamera()->copy();
 				}
 				m_view->viewportGadget()->renderRequestSignal()( m_view->viewportGadget() );
 			}


### PR DESCRIPTION
The problematic sequence of events was as follows :

- Turn on look-through
	- Current viewport camera is stashed for later restoration
- Turn off look-through
	- Previous viewport camera is restored
- Move the viewport camera
- Tweak the scene
	- Previous (out of date!) viewport camera is restored

This is fixed by skipping updates when look-through is disabled.