### PR TITLE
Fixed InputGenerator compatibility config for non-ValuePlugs.

### DIFF
--- a/startup/Gaffer/inputGeneratorCompatibility.py
+++ b/startup/Gaffer/inputGeneratorCompatibility.py
@@ -99,14 +99,14 @@ def __arrayPlugGetItem( self, key ) :
 def __arrayPlugHash( self ) :
 
 	if getattr( self, "enableInputGeneratorCompatibility", False ) :
-		return self[0].hash()
+		return self[0].hash() if isinstance( self[0], Gaffer.ValuePlug ) else None
 
 	raise AttributeError( "'ArrayPlug' object has no attribute 'hash'" )
 
 def __arrayPlugGetValue( self ) :
 
 	if getattr( self, "enableInputGeneratorCompatibility", False ) :
-		return self[0].getValue()
+		return self[0].getValue() if isinstance( self[0], Gaffer.ValuePlug ) else None
 
 	raise AttributeError( "'ArrayPlug' object has no attribute 'getValue'" )
 


### PR DESCRIPTION
This was previosuly throwing for code such as:

```
if hasattr( plug, 'getValue' ) :
	value = plug.getValue()
```

because the config is injecting ArrayPlug.getValue() regardless of whether the array children are ValuePlugs (e.g an array of RequirementsPlugs).