### PR TITLE
Added plugsWithMetadata and nodesWithMetadata to Gaffer::Metadata

### DIFF
--- a/include/Gaffer/Metadata.h
+++ b/include/Gaffer/Metadata.h
@@ -108,7 +108,7 @@ class Metadata
 		/// Lists all node descendants of "root" with the specified metadata key. If inherit is true
 		/// then the search falls through to the base classes of the node if the node itself doesn't have a value,
 		/// and if instanceOnly is true the search is restricted to instance metadata.
-		static void nodesWithMetadata( std::vector<Node*> &components, GraphComponent *root, const std::string &key, bool inherit = true, bool instanceOnly = false );
+		static std::vector<Node*> nodesWithMetadata( GraphComponent *root, IECore::InternedString key, bool inherit = true, bool instanceOnly = false );
 
 		/// Registers a static metadata value for plugs with the specified path on the specified node type.
 		static void registerPlugValue( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, IECore::InternedString key, IECore::ConstDataPtr value );
@@ -146,7 +146,7 @@ class Metadata
 		/// Lists all plug descendants of "root" with the specified metadata key. If inherit is true
 		/// then the search falls through to the base classes of the node if the node itself doesn't have a value,
 		/// and if instanceOnly is true the search is restricted to instance metadata.
-		static void plugsWithMetadata( std::vector<Plug*> &components, GraphComponent *root, const std::string &key, bool inherit = true, bool instanceOnly = false );
+		static std::vector<Plug*> plugsWithMetadata( GraphComponent *root, IECore::InternedString key, bool inherit = true, bool instanceOnly = false );
 
 		/// @name Signals
 		/// These are emitted when the Metadata has been changed with one

--- a/include/Gaffer/Metadata.h
+++ b/include/Gaffer/Metadata.h
@@ -105,6 +105,11 @@ class Metadata
 		/// Utility method calling nodeValue( node, "description", inherit );
 		static std::string nodeDescription( const Node *node, bool inherit = true );
 
+		/// Lists all node descendants of "root" with the specified metadata key. If inherit is true
+		/// then the search falls through to the base classes of the node if the node itself doesn't have a value,
+		/// and if instanceOnly is true the search is restricted to instance metadata.
+		static void nodesWithMetadata( std::vector<Node*> &components, GraphComponent *root, const std::string &key, bool inherit = true, bool instanceOnly = false );
+
 		/// Registers a static metadata value for plugs with the specified path on the specified node type.
 		static void registerPlugValue( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, IECore::InternedString key, IECore::ConstDataPtr value );
 		/// Registers a dynamic metadata value for the specified plug. Each time the data is retrieved, the
@@ -137,6 +142,11 @@ class Metadata
 		static void registerPlugDescription( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, PlugValueFunction description );
 		/// Utility function calling plugValue( plug, "description", inherit )
 		static std::string plugDescription( const Plug *plug, bool inherit = true );
+
+		/// Lists all plug descendants of "root" with the specified metadata key. If inherit is true
+		/// then the search falls through to the base classes of the node if the node itself doesn't have a value,
+		/// and if instanceOnly is true the search is restricted to instance metadata.
+		static void plugsWithMetadata( std::vector<Plug*> &components, GraphComponent *root, const std::string &key, bool inherit = true, bool instanceOnly = false );
 
 		/// @name Signals
 		/// These are emitted when the Metadata has been changed with one

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -850,6 +850,53 @@ class MetadataTest( GafferTest.TestCase ) :
 
 		self.assertTrue( "Metadata" not in s.serialise() )
 
+	def testComponentsWithMetaData( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["n"] = GafferTest.AddNode()
+		s["n2"] = GafferTest.AddNode()
+		s["n3"] = GafferTest.AddNode()
+		s["m"] = GafferTest.MultiplyNode()
+
+		self.assertEqual( Gaffer.Metadata.nodesWithMetadata( s, "nodeData1"), [] )
+
+		# register instance node values on n and n2:
+		Gaffer.Metadata.registerNodeValue( s["n"], "nodeData1", "something" )
+		Gaffer.Metadata.registerNodeValue( s["n2"], "nodeData2", "something" )
+		Gaffer.Metadata.registerNodeValue( s["m"], "nodeData3", "something" )
+
+		# register class value on GafferTest.AddNode:
+		Gaffer.Metadata.registerNodeValue( GafferTest.AddNode, "nodeData3", "something" )
+
+		# reginster some instance plug values:
+		Gaffer.Metadata.registerPlugValue( s["n"]["op1"], "plugData1", "something" )
+		Gaffer.Metadata.registerPlugValue( s["n2"]["op2"], "plugData2", "something" )
+		Gaffer.Metadata.registerPlugValue( s["m"]["op2"], "plugData3", "something" )
+
+		# register class value on GafferTest.AddNode:
+		Gaffer.Metadata.registerPlugValue( GafferTest.AddNode, "op1", "plugData3", "somethingElse" )
+
+		# test it lists nodes with matching data:
+		self.assertEqual( Gaffer.Metadata.nodesWithMetadata( s, "nodeData1" ), [ s["n"] ] )
+		self.assertEqual( Gaffer.Metadata.nodesWithMetadata( s, "nodeData2" ), [ s["n2"] ] )
+		self.assertEqual( Gaffer.Metadata.nodesWithMetadata( s, "nodeData3" ), [ s["n"], s["n2"], s["n3"], s["m"] ] )
+		self.assertEqual( Gaffer.Metadata.nodesWithMetadata( s, "nodeData3", instanceOnly=True ), [ s["m"] ] )
+
+		# telling it to list plugs should make it return an empty list:
+		self.assertEqual( Gaffer.Metadata.plugsWithMetadata( s, "nodeData1" ), [] )
+		self.assertEqual( Gaffer.Metadata.plugsWithMetadata( s, "nodeData3" ), [] )
+
+		# test it lists plugs with matching data:
+		self.assertEqual( Gaffer.Metadata.plugsWithMetadata( s, "plugData1" ), [ s["n"]["op1"] ] )
+		self.assertEqual( Gaffer.Metadata.plugsWithMetadata( s, "plugData2" ), [ s["n2"]["op2"] ] )
+		self.assertEqual( Gaffer.Metadata.plugsWithMetadata( s, "plugData3" ), [ s["n"]["op1"], s["n2"]["op1"], s["n3"]["op1"], s["m"]["op2"] ] )
+		self.assertEqual( Gaffer.Metadata.plugsWithMetadata( s, "plugData3", instanceOnly=True ), [ s["m"]["op2"] ] )
+
+		# telling it to list nodes should make it return an empty list:
+		self.assertEqual( Gaffer.Metadata.nodesWithMetadata( s, "plugData1" ), [] )
+		self.assertEqual( Gaffer.Metadata.nodesWithMetadata( s, "plugData3" ), [] )
+
+
 if __name__ == "__main__":
 	unittest.main()
 

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -896,6 +896,12 @@ class MetadataTest( GafferTest.TestCase ) :
 		self.assertEqual( Gaffer.Metadata.nodesWithMetadata( s, "plugData1" ), [] )
 		self.assertEqual( Gaffer.Metadata.nodesWithMetadata( s, "plugData3" ), [] )
 
+		# test child removal:
+		m = s["m"]
+		s.removeChild( m )
+		self.assertEqual( Gaffer.Metadata.plugsWithMetadata( s, "plugData3", instanceOnly=True ), [] )
+		self.assertEqual( Gaffer.Metadata.nodesWithMetadata( s, "nodeData3", instanceOnly=True ), [] )
+
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -868,7 +868,7 @@ class MetadataTest( GafferTest.TestCase ) :
 		# register class value on GafferTest.AddNode:
 		Gaffer.Metadata.registerNodeValue( GafferTest.AddNode, "nodeData3", "something" )
 
-		# reginster some instance plug values:
+		# register some instance plug values:
 		Gaffer.Metadata.registerPlugValue( s["n"]["op1"], "plugData1", "something" )
 		Gaffer.Metadata.registerPlugValue( s["n2"]["op2"], "plugData2", "something" )
 		Gaffer.Metadata.registerPlugValue( s["m"]["op2"], "plugData3", "something" )

--- a/src/GafferBindings/MetadataBinding.cpp
+++ b/src/GafferBindings/MetadataBinding.cpp
@@ -279,6 +279,33 @@ list registeredPlugValues( const Plug *plug, bool inherit, bool instanceOnly, bo
 	return keysToList( keys );
 }
 
+
+list plugsWithMetadata( GraphComponent *root, const std::string &key, bool inherit, bool instanceOnly )
+{
+	std::vector<Plug*> plugs;
+	Metadata::plugsWithMetadata( plugs, root, key, inherit, instanceOnly );
+	list result;
+	for( std::vector<Plug*>::const_iterator it = plugs.begin(); it != plugs.end(); ++it )
+	{
+		result.append( PlugPtr(*it) );
+	}
+
+	return result;
+}
+
+list nodesWithMetadata( GraphComponent *root, const std::string &key, bool inherit, bool instanceOnly )
+{
+	std::vector<Node*> nodes;
+	Metadata::nodesWithMetadata( nodes, root, key, inherit, instanceOnly );
+	list result;
+	for( std::vector<Node*>::const_iterator it = nodes.begin(); it != nodes.end(); ++it )
+	{
+		result.append( NodePtr(*it) );
+	}
+
+	return result;
+}
+
 } // namespace
 
 namespace GafferBindings
@@ -388,6 +415,26 @@ void bindMetadata()
 
 		.def( "plugValueChangedSignal", &Metadata::plugValueChangedSignal, return_value_policy<reference_existing_object>() )
 		.staticmethod( "plugValueChangedSignal" )
+		
+		.def( "plugsWithMetadata", &plugsWithMetadata,
+			(
+				boost::python::arg( "root" ),
+				boost::python::arg( "key" ),
+				boost::python::arg( "inherit" ) = true,
+				boost::python::arg( "instanceOnly" ) = false
+			)
+		)
+		.staticmethod( "plugsWithMetadata" )
+		
+		.def( "nodesWithMetadata", &nodesWithMetadata,
+			(
+				boost::python::arg( "root" ),
+				boost::python::arg( "key" ),
+				boost::python::arg( "inherit" ) = true,
+				boost::python::arg( "instanceOnly" ) = false
+			)
+		)
+		.staticmethod( "nodesWithMetadata" )
 	;
 
 	SignalClass<Metadata::NodeValueChangedSignal, DefaultSignalCaller<Metadata::NodeValueChangedSignal>, ValueChangedSlotCaller>( "NodeValueChangedSignal" );

--- a/src/GafferBindings/MetadataBinding.cpp
+++ b/src/GafferBindings/MetadataBinding.cpp
@@ -282,8 +282,7 @@ list registeredPlugValues( const Plug *plug, bool inherit, bool instanceOnly, bo
 
 list plugsWithMetadata( GraphComponent *root, const std::string &key, bool inherit, bool instanceOnly )
 {
-	std::vector<Plug*> plugs;
-	Metadata::plugsWithMetadata( plugs, root, key, inherit, instanceOnly );
+	std::vector<Plug*> plugs = Metadata::plugsWithMetadata( root, key, inherit, instanceOnly );
 	list result;
 	for( std::vector<Plug*>::const_iterator it = plugs.begin(); it != plugs.end(); ++it )
 	{
@@ -295,8 +294,7 @@ list plugsWithMetadata( GraphComponent *root, const std::string &key, bool inher
 
 list nodesWithMetadata( GraphComponent *root, const std::string &key, bool inherit, bool instanceOnly )
 {
-	std::vector<Node*> nodes;
-	Metadata::nodesWithMetadata( nodes, root, key, inherit, instanceOnly );
+	std::vector<Node*> nodes = Metadata::nodesWithMetadata( root, key, inherit, instanceOnly );
 	list result;
 	for( std::vector<Node*>::const_iterator it = nodes.begin(); it != nodes.end(); ++it )
 	{


### PR DESCRIPTION
I'm doing some asset management stuff where I flag assetized StringPlugs (eg plugs pointing to caches on our asset management system) with a special metadata key. The asset management system needs to scan for all plugs with this data in the scene, and it seems this is the most efficient way of doing that. I haven't tried a brute force search in python, but a brute force search in c++ takes 0.1 seconds in a reasonably sized scene I tried. That latency's kind of ok, but I wouldn't be surprised if I saw scenes ten times as big and a 1 second latency could get pretty annoying. On the other hand, if I use plugsWithMetadata with the special instanceOnly case, the search takes 1.e-5 seconds for my test scene, which is a lot better.