### PR TITLE
Resize : Fix disabling

### DIFF
--- a/include/GafferImage/Resize.h
+++ b/include/GafferImage/Resize.h
@@ -91,6 +91,9 @@ class Resize : public ImageProcessor
 		virtual void hashFormat( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 		virtual GafferImage::Format computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const;
 
+		virtual void hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		virtual Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const;
+
 		virtual void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const;
 
@@ -99,8 +102,18 @@ class Resize : public ImageProcessor
 		Gaffer::AtomicBox2fPlug *dataWindowPlug();
 		const Gaffer::AtomicBox2fPlug *dataWindowPlug() const;
 
-		Resample *resample();
-		const Resample *resample() const;
+		// We use an internal Resample node to do all the hard
+		// work of filtering the image into a new data window,
+		// and receive the result of that through this plug.
+		ImagePlug *resampledInPlug();
+		const ImagePlug *resampledInPlug() const;
+
+		// When we're actually changing the format, we get our
+		// output from resampledInPlug(), but when the format
+		// happens to be the same as the input, we simply pass
+		// through inPlug(). This function just returns the
+		// appropriate plug.
+		const ImagePlug *source() const;
 
 		static size_t g_firstPlugIndex;
 

--- a/python/GafferImageTest/ResizeTest.py
+++ b/python/GafferImageTest/ResizeTest.py
@@ -214,5 +214,21 @@ class ResizeTest( GafferTest.TestCase ) :
 		self.assertTrue( r["out"]["format"] in dirtiedPlugs )
 		self.assertTrue( r["out"]["dataWindow"] in dirtiedPlugs )
 
+	def testDisable( self ) :
+
+		c = GafferImage.Constant()
+		c["format"].setValue( GafferImage.Format( 100, 100 ) )
+
+		r = GafferImage.Resize()
+		r["in"].setInput( c["out"] )
+		r["format"].setValue( GafferImage.Format( 200, 200 ) )
+
+		self.assertEqual( r["out"]["format"].getValue(), GafferImage.Format( 200, 200 ) )
+		self.assertEqual( r["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 200 ) ) )
+
+		r["enabled"].setValue( False )
+		self.assertEqual( r["out"]["format"].getValue(), GafferImage.Format( 100, 100 ) )
+		self.assertEqual( r["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 100 ) ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/TestCase.py
+++ b/python/GafferTest/TestCase.py
@@ -225,5 +225,11 @@ class TestCase( unittest.TestCase ) :
 				continue
 
 			for plug in node.children( Gaffer.Plug ) :
-				if plug.direction() == plug.Direction.In and isinstance( plug, Gaffer.ValuePlug ) :
-					self.assertTrue( plug.isSetToDefault(), plug.fullName() + " not at default value following construction" )
+
+				if plug.direction() != plug.Direction.In or not isinstance( plug, Gaffer.ValuePlug ) :
+					continue
+
+				if not plug.getFlags( plug.Flags.Serialisable ) :
+					continue
+
+				self.assertTrue( plug.isSetToDefault(), plug.fullName() + " not at default value following construction" )


### PR DESCRIPTION
Disabling is implemented in the ImageProcessor base class, by implementing hash() and compute() to pass through the input if enabledPlug() is false, and otherwise to call the derived class' `hash*()` and `compute*()` methods. Because we had made direct connections into our outputs from our internal Resample node, this mechanism was being bypassed.

This was probably fixable simply by connecting enabledPlug() into resample->enabledPlug() in the constructor, but I've taken the opportunity to improve things further :

- Receive resampled data on a genuine input plug of the Resize node. Before we were reading from the dangling resample()->outPlug(), which meant we had to fake our affects() implementation to account for the missing connections. This made us vulnerable to changes in Resample or the fundamentals of dirty propagation and caching, and also made the logic hard to follow.
- Simplify affects() logic. I've been finding it hard to verify the correctness of affects() implementations when they try to be clever with their conditionals, for instance by dirtying several outputs from within one conditional block. Instead here I've made exactly one conditional block per output, even if it means some inputs appear in multiple conditionals. This makes the logic extremely clear, and also prepares for a simpler time when we might have `affects*()` methods to match the `hash*()` and `compute*()` methods - each block would form the implementation of one of the `affects*()` methods. This does mean a couple of duplicated checks, but dirty propagation isn't a particularly performance critical step, and the ease of writing and verification seems to justify this approach.