### PR TITLE
StandardNodeGadget : Don't emit noduleRemovedSignal()( NULL ).

### DIFF
--- a/python/GafferUITest/GraphGadgetTest.py
+++ b/python/GafferUITest/GraphGadgetTest.py
@@ -1202,5 +1202,19 @@ class GraphGadgetTest( GafferUITest.TestCase ) :
 		self.assertTrue( g.connectionGadget( script["n2"]["in"] ) is not None )
 		self.assertTrue( g.connectionGadget( script["n2"]["in"] ).srcNodule() is not None )
 
+	def testRemoveNonNodulePlug( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n"] = Gaffer.Node()
+		s["n"]["p"] = Gaffer.Plug()
+		Gaffer.Metadata.registerPlugValue( s["n"]["p"], "nodule:type", "" )
+
+		g = GafferUI.GraphGadget( s )
+		self.assertTrue( g.nodeGadget( s["n"] ).nodule( s["n"]["p"] ) is None )
+
+		# Once upon a time, this would crash.
+		del s["n"]["p"]
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -1486,7 +1486,7 @@ void GraphGadget::addConnectionGadgets( Gaffer::GraphComponent *nodeOrPlug )
 					ConnectionGadget *connection = findConnectionGadget( *oIt );
 					if( connection && !connection->srcNodule() )
 					{
-						assert( connection->dstNodule()->plug()->getInput<Gaffer::Plug>() == *pIt );
+						assert( connection->dstNodule()->plug()->getInput<Gaffer::Plug>() == plug );
 						connection->setNodules( srcNodule, connection->dstNodule() );
 					}
 				}

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -800,7 +800,10 @@ void StandardNodeGadget::updateNodules( std::vector<Nodule *> &nodules, std::vec
 		NoduleMap::iterator next = it; next++;
 		if( it->first->parent<Node>() != node() )
 		{
-			removed.push_back( it->second.nodule );
+			if( it->second.nodule )
+			{
+				removed.push_back( it->second.nodule );
+			}
 			m_nodules.erase( it );
 		}
 		it = next;


### PR DESCRIPTION
This was causing the GraphGadget to crash when a non-nodule plug was removed from a node.

This should fix IE internal ticket 8158.