### PR TITLE
fixed internal connection inconsistency in serialized switch nodes

### DIFF
--- a/include/Gaffer/Switch.h
+++ b/include/Gaffer/Switch.h
@@ -115,6 +115,7 @@ class Switch : public BaseType
 
 		void childAdded( GraphComponent *child );
 		void plugSet( Plug *plug );
+		void plugDirtied( Plug *plug );
 		void plugInputChanged( Plug *plug );
 		size_t inputIndex() const;
 

--- a/include/Gaffer/Switch.inl
+++ b/include/Gaffer/Switch.inl
@@ -84,6 +84,7 @@ void Switch<BaseType>::init( bool expectBaseClassPlugs )
 		BaseType::childAddedSignal().connect( boost::bind( &Switch::childAdded, this, ::_2 ) );
 	}
 
+	BaseType::plugDirtiedSignal().connect( boost::bind( &Switch::plugDirtied, this, ::_1 ) );
 	BaseType::plugSetSignal().connect( boost::bind( &Switch::plugSet, this, ::_1 ) );
 	BaseType::plugInputChangedSignal().connect( boost::bind( &Switch::plugInputChanged, this, ::_1 ) );
 }
@@ -291,6 +292,15 @@ void Switch<BaseType>::computeInternal( ValuePlug *output, const Context *contex
 
 template<typename BaseType>
 void Switch<BaseType>::plugSet( Plug *plug )
+{
+	if( plug == indexPlug() || plug == enabledPlug() )
+	{
+		updateInternalConnection();
+	}
+}
+
+template<typename BaseType>
+void Switch<BaseType>::plugDirtied( Plug *plug )
 {
 	if( plug == indexPlug() || plug == enabledPlug() )
 	{


### PR DESCRIPTION
Serializing/deserializing the network in the unit test used to leave FilterSwitch.out connected to FilterSwitch.in.in0, when it should have been connected to FilterSwitch.in.in1