### PR TITLE
Offset node and Crop "resetOrigin" plug.

### DIFF
--- a/include/GafferImage/Crop.h
+++ b/include/GafferImage/Crop.h
@@ -60,15 +60,20 @@ class Crop : public ImageProcessor
 			DisplayWindow = 2
 		};
 
-		/// Plug accessors.
 		Gaffer::IntPlug *areaSourcePlug();
 		const Gaffer::IntPlug *areaSourcePlug() const;
+
 		Gaffer::Box2iPlug *areaPlug();
 		const Gaffer::Box2iPlug *areaPlug() const;
+
 		Gaffer::BoolPlug *affectDataWindowPlug();
 		const Gaffer::BoolPlug *affectDataWindowPlug() const;
+
 		Gaffer::BoolPlug *affectDisplayWindowPlug();
 		const Gaffer::BoolPlug *affectDisplayWindowPlug() const;
+
+		Gaffer::BoolPlug *resetOriginPlug();
+		const Gaffer::BoolPlug *resetOriginPlug() const;
 
 		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
 
@@ -87,6 +92,9 @@ class Crop : public ImageProcessor
 
 		Gaffer::AtomicBox2iPlug *cropWindowPlug();
 		const Gaffer::AtomicBox2iPlug *cropWindowPlug() const;
+
+		Gaffer::V2iPlug *offsetPlug();
+		const Gaffer::V2iPlug *offsetPlug() const;
 
 		static size_t g_firstPlugIndex;
 };

--- a/include/GafferImage/Offset.h
+++ b/include/GafferImage/Offset.h
@@ -1,0 +1,79 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERIMAGE_OFFSET_H
+#define GAFFERIMAGE_OFFSET_H
+
+#include "Gaffer/CompoundNumericPlug.h"
+
+#include "GafferImage/ImageProcessor.h"
+
+namespace GafferImage
+{
+
+class Offset : public ImageProcessor
+{
+	public :
+
+		Offset( const std::string &name=defaultName<Offset>() );
+		virtual ~Offset();
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::Offset, OffsetTypeId, ImageProcessor );
+
+		Gaffer::V2iPlug *offsetPlug();
+		const Gaffer::V2iPlug *offsetPlug() const;
+
+		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+
+	protected :
+
+		virtual void hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		virtual void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+
+		virtual Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const;
+		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const;
+
+	private :
+
+		static size_t g_firstPlugIndex;
+
+};
+
+IE_CORE_DECLAREPTR( Offset )
+
+} // namespace GafferImage
+
+#endif // GAFFERIMAGE_OFFSET_H

--- a/include/GafferImage/TypeIds.h
+++ b/include/GafferImage/TypeIds.h
@@ -101,6 +101,7 @@ enum TypeId
 	CDLTypeId = 110805,
 	DisplayTransformTypeId = 110806,
 	FormatPlugTypeId = 110807,
+	OffsetTypeId = 110808,
 
 	LastTypeId = 110849
 };

--- a/include/GafferImageBindings/OffsetBinding.h
+++ b/include/GafferImageBindings/OffsetBinding.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERIMAGEBINDINGS_OFFSETBINDING_H
+#define GAFFERIMAGEBINDINGS_OFFSETBINDING_H
+
+namespace GafferImageBindings
+{
+
+void bindOffset();
+
+} // namespace GafferImageBindings
+
+#endif // GAFFERIMAGEBINDINGS_OFFSETBINDING_H

--- a/python/GafferImageTest/CropTest.py
+++ b/python/GafferImageTest/CropTest.py
@@ -162,6 +162,22 @@ class CropTest( unittest.TestCase ) :
 
 		self.assertEqual( i["out"]["format"].getValue().getDisplayWindow(), crop["out"]["dataWindow"].getValue() )
 
+	def testAffects( self ) :
+
+		c = GafferImage.Crop()
+
+		self.assertEqual(
+			set( c.affects( c["affectDisplayWindow"] ) ),
+			{ c["out"]["format"] }
+		)
+
+		self.assertEqual(
+			set( c.affects( c["affectDataWindow"] ) ),
+			{ c["out"]["dataWindow"] }
+		)
+
+		self.assertTrue( c["out"]["dataWindow"] in set( c.affects( c["in"]["dataWindow"] ) ) )
+		self.assertTrue( c["out"]["format"] in set( c.affects( c["in"]["format"] ) ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageTest/MergeTest.py
+++ b/python/GafferImageTest/MergeTest.py
@@ -277,6 +277,7 @@ class MergeTest( GafferTest.TestCase ) :
 		aCrop["in"].setInput( a["out"] )
 		aCrop["areaSource"].setValue( aCrop.AreaSource.Custom )
 		aCrop["area"].setValue( IECore.Box2i( IECore.V2i( 50 ), IECore.V2i( 162 ) ) )
+		aCrop["affectDisplayWindow"].setValue( False )
 
 		m = GafferImage.Merge()
 		m["operation"].setValue( m.Operation.Over )
@@ -318,6 +319,7 @@ class MergeTest( GafferTest.TestCase ) :
 		bCrop["in"].setInput( b["out"] )
 		bCrop["areaSource"].setValue( bCrop.AreaSource.Custom )
 		bCrop["area"].setValue( IECore.Box2i( IECore.V2i( 50 ), IECore.V2i( 162 ) ) )
+		bCrop["affectDisplayWindow"].setValue( False )
 
 		m = GafferImage.Merge()
 		m["operation"].setValue( m.Operation.Add )

--- a/python/GafferImageTest/OffsetTest.py
+++ b/python/GafferImageTest/OffsetTest.py
@@ -1,0 +1,152 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import os
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferTest
+import GafferImage
+
+class OffsetTest( GafferTest.TestCase ) :
+
+	def testPassThrough( self ) :
+
+		c = GafferImage.ImageReader()
+		c["fileName"].setValue( os.path.dirname( __file__ ) + "/images/checker2x2.exr" )
+
+		o = GafferImage.Offset()
+		o["in"].setInput( c["out"] )
+
+		self.assertEqual( o["offset"].getValue(), IECore.V2i( 0 ) )
+		self.assertEqual( o["out"].imageHash(), c["out"].imageHash() )
+		self.assertEqual( o["out"].image(), c["out"].image() )
+
+	def testDataWindow( self ) :
+
+		c = GafferImage.ImageReader()
+		c["fileName"].setValue( os.path.dirname( __file__ ) + "/images/checker2x2.exr" )
+
+		self.assertEqual(
+			c["out"]["dataWindow"].getValue(),
+			IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 2 ) )
+		)
+
+		o = GafferImage.Offset()
+		o["in"].setInput( c["out"] )
+		o["offset"].setValue( IECore.V2i( 1 ) )
+
+		self.assertEqual(
+			o["out"]["dataWindow"].getValue(),
+			IECore.Box2i( IECore.V2i( 1 ), IECore.V2i( 3 ) )
+		)
+
+	def testChannelData( self ) :
+
+		c = GafferImage.ImageReader()
+		c["fileName"].setValue( os.path.dirname( __file__ ) + "/images/checker2x2.exr" )
+
+		o = GafferImage.Offset()
+		o["in"].setInput( c["out"] )
+		o["offset"].setValue( IECore.V2i( 1 ) )
+
+		def sample( image, channelName, pos ) :
+
+			sampler = GafferImage.Sampler( image, channelName, image["dataWindow"].getValue() )
+			return sampler.sample( pos.x, pos.y )
+
+		for yOffset in range( -10, 10 ) :
+			for xOffset in range( -10, 10 ) :
+
+				o["offset"].setValue( IECore.V2i( xOffset, yOffset ) )
+
+				for y in range( 0, 2 ) :
+					for x in range( 0, 2 ) :
+						for channelName in ( "R", "G", "B", "A" ) :
+							self.assertEqual(
+								sample( o["out"], channelName, IECore.V2i( x + xOffset, y + yOffset ) ),
+								sample( c["out"], channelName, IECore.V2i( x, y ) ),
+						)
+
+	def testMultipleOfTileSize( self ) :
+
+		c = GafferImage.ImageReader()
+		c["fileName"].setValue( os.path.dirname( __file__ ) + "/images/checker.exr" )
+
+		o = GafferImage.Offset()
+		o["in"].setInput( c["out"] )
+
+		for offset in [
+			IECore.V2i( 0, 1 ),
+			IECore.V2i( 1, 0 ),
+			IECore.V2i( 2, 0 ),
+			IECore.V2i( 2, 1 ),
+			IECore.V2i( 2, -3 ),
+			IECore.V2i( -2, 3 ),
+			IECore.V2i( -1, -1 ),
+		] :
+
+			offset *= GafferImage.ImagePlug.tileSize()
+			o["offset"].setValue( offset )
+
+			self.assertEqual(
+				o["out"].channelDataHash( "R", offset ),
+				c["out"].channelDataHash( "R", IECore.V2i( 0 ) ),
+			)
+			self.assertEqual(
+				o["out"].channelData( "R", offset ),
+				c["out"].channelData( "R", IECore.V2i( 0 ) ),
+			)
+
+	def testOffsetBack( self ) :
+
+		c = GafferImage.ImageReader()
+		c["fileName"].setValue( os.path.dirname( __file__ ) + "/images/checker.exr" )
+
+		o1 = GafferImage.Offset()
+		o1["in"].setInput( c["out"] )
+		o1["offset"].setValue( IECore.V2i( 101, -45 ) )
+
+		o2 = GafferImage.Offset()
+		o2["in"].setInput( o1["out"] )
+		o2["offset"].setValue( IECore.V2i( -101, 45 ) )
+
+		self.assertEqual( c["out"].image(), o2["out"].image() )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferImageTest/SamplerTest.py
+++ b/python/GafferImageTest/SamplerTest.py
@@ -244,6 +244,7 @@ class SamplerTest( unittest.TestCase ) :
 		crop["in"].setInput( constant["out"] )
 		crop["areaSource"].setValue( crop.AreaSource.Custom )
 		crop["area"].setValue( IECore.Box2i( IECore.V2i( 135 ), IECore.V2i( 214 ) ) )
+		crop["affectDisplayWindow"].setValue( False )
 
 		sampler = GafferImage.Sampler( crop["out"], "R", IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 50 ) ), boundingMode = GafferImage.Sampler.BoundingMode.Clamp )
 		self.assertEqual( sampler.sample( 0, 0 ), 1 )

--- a/python/GafferImageTest/__init__.py
+++ b/python/GafferImageTest/__init__.py
@@ -77,6 +77,7 @@ from CDLTest import CDLTest
 from ImageAlgoTest import ImageAlgoTest
 from DisplayTransformTest import DisplayTransformTest
 from FormatPlugTest import FormatPlugTest
+from OffsetTest import OffsetTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferImageUI/CropUI.py
+++ b/python/GafferImageUI/CropUI.py
@@ -36,9 +36,10 @@
 ##########################################################################
 
 import IECore
+
 import Gaffer
-import GafferImage
 import GafferUI
+import GafferImage
 
 ## A function suitable as the postCreator in a NodeMenu.append() call. It
 # sets the area for the node to cover the entire format.
@@ -64,6 +65,7 @@ Gaffer.Metadata.registerNode(
 	""",
 
 	"layout:activator:areaSourceIsCustom", lambda node : node["areaSource"].getValue() == GafferImage.Crop.AreaSource.Custom,
+	"layout:activator:affectDisplayWindowIsOn", lambda node : node["affectDisplayWindow"].getValue(),
 
 	plugs = {
 
@@ -119,6 +121,18 @@ Gaffer.Metadata.registerNode(
 			""",
 
 		],
+
+		"resetOrigin" : [
+
+			"description",
+			"""
+			Shifts the cropped image area back to the origin, so that
+			the bottom left of the display window is at ( 0, 0 ).
+			""",
+
+			"layout:activator", "affectDisplayWindowIsOn",
+
+		]
 
 	}
 

--- a/python/GafferImageUI/OffsetUI.py
+++ b/python/GafferImageUI/OffsetUI.py
@@ -1,7 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2012, John Haddon. All rights reserved.
-#  Copyright (c) 2012-2015, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -35,46 +34,33 @@
 #
 ##########################################################################
 
-from _GafferImageUI import *
+import Gaffer
+import GafferUI
+import GafferImage
 
-import DisplayUI
-from FormatPlugValueWidget import FormatPlugValueWidget
-from FilterPlugValueWidget import FilterPlugValueWidget
-from ChannelMaskPlugValueWidget import ChannelMaskPlugValueWidget
+Gaffer.Metadata.registerNode(
 
-import ImageReaderUI
-import ImageViewToolbar
-import ImageTransformUI
-import ConstantUI
-import ImageSwitchUI
-import ColorSpaceUI
-import ImageContextVariablesUI
-import ImageStatsUI
-import DeleteChannelsUI
-import ReformatUI
-import ObjectToImageUI
-import ClampUI
-import ImageWriterUI
-import GradeUI
-import ImageTimeWarpUI
-import ImageSamplerUI
-import MergeUI
-import ImageNodeUI
-import ChannelDataProcessorUI
-import ImageProcessorUI
-import ImageMetadataUI
-import DeleteImageMetadataUI
-import CopyImageMetadataUI
-import ImageLoopUI
-import ShuffleUI
-import PremultiplyUI
-import UnpremultiplyUI
-import CropUI
-import ResizeUI
-import ResampleUI
-import LUTUI
-import CDLUI
-import DisplayTransformUI
-import OffsetUI
+	GafferImage.Offset,
 
-__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", {}, subdirectory = "GafferImageUI" )
+	"description",
+	"""
+	Offsets (translates) the image in integer increments. Because
+	the increments may only be whole numbers, no filtering is necessary,
+	and this node has improved performance compared to the equivalent
+	ImageTransform.
+	""",
+
+	plugs = {
+
+		"offset" : [
+
+			"description",
+			"""
+			The amount to offset the image by.
+			""",
+
+		],
+
+	}
+
+)

--- a/src/GafferImage/Crop.cpp
+++ b/src/GafferImage/Crop.cpp
@@ -36,6 +36,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "GafferImage/Crop.h"
+#include "GafferImage/ImageAlgo.h"
 
 using namespace Gaffer;
 using namespace IECore;
@@ -120,17 +121,21 @@ void Crop::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs )
 {
 	ImageProcessor::affects( input, outputs );
 
-	if ( areaPlug()->isAncestorOf( input ) ||
-	     input == areaSourcePlug() ||
-	     input == inPlug()->dataWindowPlug() ||
-	     input == inPlug()->formatPlug() )
+	if(
+		areaPlug()->isAncestorOf( input ) ||
+		input == areaSourcePlug() ||
+		input == inPlug()->dataWindowPlug() ||
+		input == inPlug()->formatPlug()
+	)
 	{
 		outputs.push_back( cropWindowPlug() );
 	}
-	else if ( input == cropWindowPlug() ||
-	          input == affectDataWindowPlug() ||
-	          input == affectDisplayWindowPlug() ||
-	          input == inPlug()->dataWindowPlug() )
+	else if(
+		input == cropWindowPlug() ||
+		input == affectDataWindowPlug() ||
+		input == affectDisplayWindowPlug() ||
+		input == inPlug()->dataWindowPlug()
+	)
 	{
 		outputs.push_back( outPlug()->formatPlug() );
 		outputs.push_back( outPlug()->dataWindowPlug() );
@@ -193,19 +198,10 @@ Imath::Box2i Crop::computeDataWindow( const Gaffer::Context *context, const Imag
 		return inPlug()->dataWindowPlug()->getValue();
 	}
 
-	Imath::Box2i cropWindow = cropWindowPlug()->getValue();
-	Imath::Box2i dataWindow = inPlug()->dataWindowPlug()->getValue();
+	const Imath::Box2i cropWindow = cropWindowPlug()->getValue();
+	const Imath::Box2i dataWindow = inPlug()->dataWindowPlug()->getValue();
 
-	return Imath::Box2i(
-		Imath::V2i(
-			std::max( dataWindow.min.x, cropWindow.min.x ),
-			std::max( dataWindow.min.y, cropWindow.min.y )
-		),
-		Imath::V2i(
-			std::min( dataWindow.max.x, cropWindow.max.x ),
-			std::min( dataWindow.max.y, cropWindow.max.y )
-		)
-	);
+	return intersection( cropWindow, dataWindow );
 }
 
 void Crop::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const

--- a/src/GafferImage/Crop.cpp
+++ b/src/GafferImage/Crop.cpp
@@ -37,9 +37,11 @@
 
 #include "GafferImage/Crop.h"
 #include "GafferImage/ImageAlgo.h"
+#include "GafferImage/Offset.h"
 
-using namespace Gaffer;
+using namespace Imath;
 using namespace IECore;
+using namespace Gaffer;
 using namespace GafferImage;
 
 IE_CORE_DEFINERUNTIMETYPED( Crop );
@@ -54,13 +56,21 @@ Crop::Crop( const std::string &name )
 	addChild( new Box2iPlug( "area" ) );
 	addChild( new BoolPlug( "affectDataWindow", Gaffer::Plug::In, true ) );
 	addChild( new BoolPlug( "affectDisplayWindow", Gaffer::Plug::In, true ) );
+	addChild( new BoolPlug( "resetOrigin", Gaffer::Plug::In, true ) );
 
 	addChild( new AtomicBox2iPlug( "__cropWindow", Gaffer::Plug::Out ) );
+	addChild( new V2iPlug( "__offset", Gaffer::Plug::Out ) );
+
+	OffsetPtr offset = new Offset( "__offset" );
+	addChild( offset );
+	offset->inPlug()->setInput( inPlug() );
+	offset->enabledPlug()->setInput( enabledPlug() );
+	offset->offsetPlug()->setInput( offsetPlug() );
+	outPlug()->channelDataPlug()->setInput( offset->outPlug()->channelDataPlug() );
 
 	// We don't ever want to change these, so we make pass-through connections.
 	outPlug()->metadataPlug()->setInput( inPlug()->metadataPlug() );
 	outPlug()->channelNamesPlug()->setInput( inPlug()->channelNamesPlug() );
-	outPlug()->channelDataPlug()->setInput( inPlug()->channelDataPlug() );
 }
 
 Crop::~Crop()
@@ -107,14 +117,34 @@ const Gaffer::BoolPlug *Crop::affectDisplayWindowPlug() const
 	return getChild<BoolPlug>( g_firstPlugIndex+3 );
 }
 
+Gaffer::BoolPlug *Crop::resetOriginPlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 4 );
+}
+
+const Gaffer::BoolPlug *Crop::resetOriginPlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 4 );
+}
+
 Gaffer::AtomicBox2iPlug *Crop::cropWindowPlug()
 {
-	return getChild<AtomicBox2iPlug>( g_firstPlugIndex+4 );
+	return getChild<AtomicBox2iPlug>( g_firstPlugIndex + 5 );
 }
 
 const Gaffer::AtomicBox2iPlug *Crop::cropWindowPlug() const
 {
-	return getChild<AtomicBox2iPlug>( g_firstPlugIndex+4 );
+	return getChild<AtomicBox2iPlug>( g_firstPlugIndex + 5 );
+}
+
+Gaffer::V2iPlug *Crop::offsetPlug()
+{
+	return getChild<V2iPlug>( g_firstPlugIndex + 6 );
+}
+
+const Gaffer::V2iPlug *Crop::offsetPlug() const
+{
+	return getChild<V2iPlug>( g_firstPlugIndex + 6 );
 }
 
 void Crop::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
@@ -134,6 +164,7 @@ void Crop::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs )
 	if(
 		input == cropWindowPlug() ||
 		input == affectDisplayWindowPlug() ||
+		input == resetOriginPlug() ||
 		input == inPlug()->formatPlug()
 	)
 	{
@@ -142,12 +173,25 @@ void Crop::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs )
 
 	if(
 		input == cropWindowPlug() ||
+		input == affectDisplayWindowPlug() ||
 		input == affectDataWindowPlug() ||
+		input == resetOriginPlug() ||
 		input == inPlug()->dataWindowPlug()
 	)
 	{
 		outputs.push_back( outPlug()->dataWindowPlug() );
 	}
+
+	if(
+		input == affectDisplayWindowPlug() ||
+		input == resetOriginPlug() ||
+		input == cropWindowPlug()
+	)
+	{
+		outputs.push_back( offsetPlug()->getChild( 0 ) );
+		outputs.push_back( offsetPlug()->getChild( 1 ) );
+	}
+
 }
 
 void Crop::hashFormat( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const
@@ -164,6 +208,7 @@ void Crop::hashFormat( const GafferImage::ImagePlug *parent, const Gaffer::Conte
 
 	inPlug()->formatPlug()->hash( h );
 	cropWindowPlug()->hash( h );
+	resetOriginPlug()->hash( h );
 }
 
 GafferImage::Format Crop::computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const
@@ -175,41 +220,44 @@ GafferImage::Format Crop::computeFormat( const Gaffer::Context *context, const I
 		return inPlug()->formatPlug()->getValue();
 	}
 
-	Imath::Box2i cropWindow = cropWindowPlug()->getValue();
+	Imath::Box2i displayWindow = cropWindowPlug()->getValue();
+	if( resetOriginPlug()->getValue() )
+	{
+		displayWindow.max -= displayWindow.min;
+		displayWindow.min = V2i( 0 );
+	}
 
-	return Format( cropWindow, inPlug()->formatPlug()->getValue().getPixelAspect() );
+	return Format( displayWindow, inPlug()->formatPlug()->getValue().getPixelAspect() );
 }
 
 
 void Crop::hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	if ( ! affectDataWindowPlug()->getValue() )
-	{
-		// No-op because we are not applying this
-		// crop to the data window
-		h = inPlug()->dataWindowPlug()->hash();
-		return;
-	}
-
 	ImageProcessor::hashDataWindow( parent, context, h );
 
 	inPlug()->dataWindowPlug()->hash( h );
 	cropWindowPlug()->hash( h );
+	affectDataWindowPlug()->hash( h );
+	affectDisplayWindowPlug()->hash( h );
+	resetOriginPlug()->hash( h );
 }
 
 Imath::Box2i Crop::computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const
 {
-	if ( ! affectDataWindowPlug()->getValue() )
+	Box2i result = inPlug()->dataWindowPlug()->getValue();
+	const Box2i cropWindow = cropWindowPlug()->getValue();
+	if( affectDataWindowPlug()->getValue() )
 	{
-		// No-op because we are not applying this
-		// crop to the data window
-		return inPlug()->dataWindowPlug()->getValue();
+		result = intersection( result, cropWindow );
 	}
 
-	const Imath::Box2i cropWindow = cropWindowPlug()->getValue();
-	const Imath::Box2i dataWindow = inPlug()->dataWindowPlug()->getValue();
+	if( affectDisplayWindowPlug()->getValue() && resetOriginPlug()->getValue() )
+	{
+		result.min -= cropWindow.min;
+		result.max -= cropWindow.min;
+	}
 
-	return intersection( cropWindow, dataWindow );
+	return result;
 }
 
 void Crop::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const
@@ -238,6 +286,12 @@ void Crop::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context
 				break;
 			}
 		}
+	}
+	else if( output->parent<Plug>() == offsetPlug() )
+	{
+		affectDisplayWindowPlug()->hash( h );
+		resetOriginPlug()->hash( h );
+		cropWindowPlug()->hash( h );
 	}
 }
 
@@ -268,6 +322,17 @@ void Crop::compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) 
 		}
 
 		static_cast<Gaffer::AtomicBox2iPlug *>( output )->setValue( cropWindow );
+	}
+	else if( output->parent<Plug>() == offsetPlug() )
+	{
+		V2i offset( 0 );
+		if( affectDisplayWindowPlug()->getValue() && resetOriginPlug()->getValue() )
+		{
+			offset -= cropWindowPlug()->getValue().min;
+		}
+		static_cast<IntPlug *>( output )->setValue(
+			output == offsetPlug()->getChild( 0 ) ? offset[0] : offset[1]
+		);
 	}
 	else
 	{

--- a/src/GafferImage/Crop.cpp
+++ b/src/GafferImage/Crop.cpp
@@ -130,14 +130,22 @@ void Crop::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs )
 	{
 		outputs.push_back( cropWindowPlug() );
 	}
-	else if(
+
+	if(
 		input == cropWindowPlug() ||
-		input == affectDataWindowPlug() ||
 		input == affectDisplayWindowPlug() ||
-		input == inPlug()->dataWindowPlug()
+		input == inPlug()->formatPlug()
 	)
 	{
 		outputs.push_back( outPlug()->formatPlug() );
+	}
+
+	if(
+		input == cropWindowPlug() ||
+		input == affectDataWindowPlug() ||
+		input == inPlug()->dataWindowPlug()
+	)
+	{
 		outputs.push_back( outPlug()->dataWindowPlug() );
 	}
 }

--- a/src/GafferImage/Offset.cpp
+++ b/src/GafferImage/Offset.cpp
@@ -1,0 +1,222 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Gaffer/Context.h"
+
+#include "GafferImage/Offset.h"
+#include "GafferImage/ImageAlgo.h"
+
+using namespace std;
+using namespace Imath;
+using namespace IECore;
+using namespace Gaffer;
+using namespace GafferImage;
+
+//////////////////////////////////////////////////////////////////////////
+// Utilities
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+// Index of pixel within a buffer.
+/// \todo Move to ImageAlgo?
+size_t bufferIndex( const V2i &p, const Box2i &b )
+{
+	assert( contains( b, p ) );
+	return
+		( p.y - b.min.y ) * b.size().x +
+		( p.x - b.min.x );
+}
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// Offset node
+//////////////////////////////////////////////////////////////////////////
+
+IE_CORE_DEFINERUNTIMETYPED( Offset );
+
+size_t Offset::g_firstPlugIndex = 0;
+
+Offset::Offset( const std::string &name )
+	:	ImageProcessor( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+	addChild( new V2iPlug( "offset" ) );
+
+	outPlug()->formatPlug()->setInput( inPlug()->formatPlug() );
+	outPlug()->metadataPlug()->setInput( inPlug()->metadataPlug() );
+	outPlug()->channelNamesPlug()->setInput( inPlug()->channelNamesPlug() );
+}
+
+Offset::~Offset()
+{
+}
+
+Gaffer::V2iPlug *Offset::offsetPlug()
+{
+	return getChild<V2iPlug>( g_firstPlugIndex );
+}
+
+const Gaffer::V2iPlug *Offset::offsetPlug() const
+{
+	return getChild<V2iPlug>( g_firstPlugIndex );
+}
+
+void Offset::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
+{
+	ImageProcessor::affects( input, outputs );
+
+	if( input->parent<Plug>() == offsetPlug() )
+	{
+		outputs.push_back( outPlug()->dataWindowPlug() );
+		outputs.push_back( outPlug()->channelDataPlug() );
+	}
+}
+
+void Offset::hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	const V2i offset = offsetPlug()->getValue();
+	if( offset == V2i( 0 ) )
+	{
+		h = inPlug()->dataWindowPlug()->hash();
+	}
+	else
+	{
+		ImageProcessor::hashDataWindow( parent, context, h );
+		inPlug()->dataWindowPlug()->hash( h );
+		offsetPlug()->hash( h );
+	}
+}
+
+Imath::Box2i Offset::computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const
+{
+	Box2i dataWindow = inPlug()->dataWindowPlug()->getValue();
+	const V2i offset = offsetPlug()->getValue();
+	dataWindow.min += offset;
+	dataWindow.max += offset;
+	return dataWindow;
+}
+
+void Offset::hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	ContextPtr offsetContext = new Context( *context, Context::Borrowed );
+	Context::Scope scope( offsetContext.get() );
+
+	const V2i offset = offsetPlug()->getValue();
+	const V2i tileOrigin = context->get<V2i>( ImagePlug::tileOriginContextName );
+	if( offset.x % ImagePlug::tileSize() == 0 && offset.y % ImagePlug::tileSize() == 0 )
+	{
+		offsetContext->set( ImagePlug::tileOriginContextName, tileOrigin - offset );
+		h = inPlug()->channelDataPlug()->hash();
+	}
+	else
+	{
+		ImageProcessor::hashChannelData( parent, context, h );
+
+		const Box2i outTileBound( tileOrigin, tileOrigin + V2i( ImagePlug::tileSize() ) );
+		const Box2i inBound( outTileBound.min - offset, outTileBound.max - offset );
+
+		V2i inTileOrigin;
+		for( inTileOrigin.y = ImagePlug::tileOrigin( inBound.min ).y; inTileOrigin.y < inBound.max.y; inTileOrigin.y += ImagePlug::tileSize() )
+		{
+			for( inTileOrigin.x = ImagePlug::tileOrigin( inBound.min ).x; inTileOrigin.x < inBound.max.x; inTileOrigin.x += ImagePlug::tileSize() )
+			{
+				offsetContext->set( ImagePlug::tileOriginContextName, inTileOrigin );
+				inPlug()->channelDataPlug()->hash( h );
+			}
+		}
+
+		h.append( offset );
+	}
+}
+
+IECore::ConstFloatVectorDataPtr Offset::computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const
+{
+	ContextPtr offsetContext = new Context( *context, Context::Borrowed );
+	Context::Scope scope( offsetContext.get() );
+
+	const V2i offset = offsetPlug()->getValue();
+	if( offset.x % ImagePlug::tileSize() == 0 && offset.y % ImagePlug::tileSize() == 0 )
+	{
+		offsetContext->set( ImagePlug::tileOriginContextName, tileOrigin - offset );
+		return inPlug()->channelDataPlug()->getValue();
+	}
+	else
+	{
+		const Box2i outTileBound( tileOrigin, tileOrigin + V2i( ImagePlug::tileSize() ) );
+		const Box2i inBound( outTileBound.min - offset, outTileBound.max - offset );
+
+		FloatVectorDataPtr outData = new FloatVectorData;
+		outData->writable().resize( ImagePlug::tileSize() * ImagePlug::tileSize() );
+		float *out = &outData->writable().front();
+
+		V2i inTileOrigin;
+		for( inTileOrigin.y = ImagePlug::tileOrigin( inBound.min ).y; inTileOrigin.y < inBound.max.y; inTileOrigin.y += ImagePlug::tileSize() )
+		{
+			for( inTileOrigin.x = ImagePlug::tileOrigin( inBound.min ).x; inTileOrigin.x < inBound.max.x; inTileOrigin.x += ImagePlug::tileSize() )
+			{
+				offsetContext->set( ImagePlug::tileOriginContextName, inTileOrigin );
+				ConstFloatVectorDataPtr inData = inPlug()->channelDataPlug()->getValue();
+				const float *in = &inData->readable().front();
+
+				const Box2i inTileBound( inTileOrigin, inTileOrigin + V2i( ImagePlug::tileSize() ) );
+				const Box2i inRegion = intersection(
+					inBound,
+					inTileBound
+				);
+
+				V2i inScanlineOrigin = inRegion.min;
+				const size_t scanlineLength = inRegion.size().x;
+				while( inScanlineOrigin.y < inRegion.max.y )
+				{
+					memcpy(
+						// to
+						out + bufferIndex( inScanlineOrigin + offset, outTileBound ),
+						// from
+						in + bufferIndex( inScanlineOrigin, inTileBound ),
+						sizeof( float ) * scanlineLength
+					);
+					++inScanlineOrigin.y;
+				}
+			}
+		}
+
+		return outData;
+	}
+}
+

--- a/src/GafferImageBindings/OffsetBinding.cpp
+++ b/src/GafferImageBindings/OffsetBinding.cpp
@@ -1,0 +1,52 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "GafferBindings/DependencyNodeBinding.h"
+
+#include "GafferImage/Offset.h"
+#include "GafferImageBindings/OffsetBinding.h"
+
+using namespace GafferImage;
+
+namespace GafferImageBindings
+{
+
+void bindOffset()
+{
+	GafferBindings::DependencyNodeClass<Offset>();
+}
+
+} // namespace GafferImageBindings

--- a/src/GafferImageModule/GafferImageModule.cpp
+++ b/src/GafferImageModule/GafferImageModule.cpp
@@ -86,6 +86,7 @@
 #include "GafferImageBindings/ResizeBinding.h"
 #include "GafferImageBindings/LUTBinding.h"
 #include "GafferImageBindings/ImageAlgoBinding.h"
+#include "GafferImageBindings/OffsetBinding.h"
 
 using namespace boost::python;
 using namespace GafferImage;
@@ -142,5 +143,6 @@ BOOST_PYTHON_MODULE( _GafferImage )
 	GafferImageBindings::bindResize();
 	GafferImageBindings::bindLUT();
 	GafferImageBindings::bindImageAlgo();
+	GafferImageBindings::bindOffset();
 }
 

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -288,6 +288,7 @@ nodeMenu.append( "/Image/Merge/Switch", GafferImage.ImageSwitch, searchText = "I
 nodeMenu.append( "/Image/Transform/Resize", GafferImage.Resize )
 nodeMenu.append( "/Image/Transform/Transform", GafferImage.ImageTransform, searchText = "ImageTransform" )
 nodeMenu.append( "/Image/Transform/Crop", GafferImage.Crop, postCreator = GafferImageUI.CropUI.postCreate )
+nodeMenu.append( "/Image/Transform/Offset", GafferImage.Offset )
 nodeMenu.append( "/Image/Channels/Shuffle", GafferImageUI.ShuffleUI.nodeMenuCreateCommand, searchText = "Shuffle" )
 nodeMenu.append( "/Image/Channels/Delete", GafferImage.DeleteChannels, searchText = "DeleteChannels" )
 nodeMenu.append( "/Image/Context/Time Warp", GafferImage.ImageTimeWarp, searchText = "ImageTimeWarp" )


### PR DESCRIPTION
This does two things :

1. Adds an Offset node, which is specialised to do integer-only translations. It differs from ImageTransform in that it is faster, does no filtering, and is able to do perfect pass-throughs for offsets which are multiples of the tile size.
2. Adds a "resetOrigin" plug to the Crop node, so that when using a crop to redefine the displayWindow, it may be shifted back so the display window is till anchored at the origin despite having a new size. This appears to be the intuitively expected behaviour, so we've made it default on even though it changes behaviour.