### PR TITLE
Support indirect connections to Switch index

### DIFF
--- a/include/Gaffer/Node.h
+++ b/include/Gaffer/Node.h
@@ -83,8 +83,9 @@ class Node : public GraphComponent
 		/// \note Passive observers of the plug value should use plugDirtiedSignal()
 		/// rather than plugSetSignal().
 		UnaryPlugSignal &plugSetSignal();
-		/// Emitted immediately when the input changes on a plug of this node.
-		/// As with plugSetSignal(), it is acceptable for slots connected to
+		/// Emitted immediately when a plug's input is changed. Also emitted
+		/// for all outputs of such plugs, as in effect their input is being changed
+		/// too. As with plugSetSignal(), it is acceptable for slots connected to
 		/// this signal to rewire the node graph.
 		UnaryPlugSignal &plugInputChangedSignal();
 		/// Emitted when a plug of this node is dirtied - this signifies that any

--- a/include/Gaffer/Plug.h
+++ b/include/Gaffer/Plug.h
@@ -231,6 +231,7 @@ class Plug : public GraphComponent
 
 		void setInput( PlugPtr input, bool setChildInputs, bool updateParentInput );
 		void setInputInternal( PlugPtr input, bool emit );
+		void emitInputChanged();
 
 		void updateInputFromChildInputs( Plug *checkFirst );
 

--- a/python/GafferTest/PlugTest.py
+++ b/python/GafferTest/PlugTest.py
@@ -759,6 +759,41 @@ class PlugTest( GafferTest.TestCase ) :
 		p2["y"].setInput( p1["x"] )
 		self.assertTrue( p2.getInput() is None )
 
+	def testIndirectInputChangedSignal( self ) :
+
+		n = Gaffer.Node()
+		n["p1"] = Gaffer.Plug()
+		n["p2"] = Gaffer.Plug()
+		n["p3"] = Gaffer.Plug()
+		n["p4"] = Gaffer.Plug()
+
+		cs = GafferTest.CapturingSlot( n.plugInputChangedSignal() )
+
+		n["p4"].setInput( n["p3"] )
+		self.assertEqual( len( cs ), 1 )
+		self.assertEqual( cs[0], ( n["p4"], ) )
+
+		del cs[:]
+
+		# When the input to the input of a plug
+		# changes, we emit inputChangedSignal()
+		# for the whole chain, because the
+		# effective source for all downstream
+		# plugs has changed.
+
+		n["p3"].setInput( n["p2"] )
+		self.assertEqual( len( cs ), 2 )
+		self.assertEqual( cs[0], ( n["p3"], ) )
+		self.assertEqual( cs[1], ( n["p4"], ) )
+
+		del cs[:]
+
+		n["p2"].setInput( n["p1"] )
+		self.assertEqual( len( cs ), 3 )
+		self.assertEqual( cs[0], ( n["p2"], ) )
+		self.assertEqual( cs[1], ( n["p3"], ) )
+		self.assertEqual( cs[2], ( n["p4"], ) )
+
 if __name__ == "__main__":
 	unittest.main()
 

--- a/python/GafferTest/SwitchTest.py
+++ b/python/GafferTest/SwitchTest.py
@@ -335,6 +335,35 @@ class SwitchTest( GafferTest.TestCase ) :
 		self.assertTrue( n["enabled"].acceptsInput( None ) )
 		self.assertTrue( n["index"].acceptsInput( None ) )
 
+	def testIndirectInputsToIndex( self ) :
+
+		n = Gaffer.SwitchDependencyNode()
+		n["in"] = Gaffer.ArrayPlug( element = Gaffer.Plug(), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		n["out"] = Gaffer.Plug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic  )
+
+		input0 = Gaffer.Plug()
+		input1 = Gaffer.Plug()
+		input2 = Gaffer.Plug()
+
+		n["in"][0].setInput( input0 )
+		n["in"][1].setInput( input1 )
+		n["in"][2].setInput( input2 )
+
+		self.assertTrue( n["out"].source().isSame( input0 ) )
+
+		indexInput = Gaffer.IntPlug()
+		n["index"].setInput( indexInput )
+		self.assertTrue( n["out"].source().isSame( input0 ) )
+
+		indirectIndexInput1 = Gaffer.IntPlug( defaultValue = 1 )
+		indirectIndexInput2 = Gaffer.IntPlug( defaultValue = 2 )
+
+		indexInput.setInput( indirectIndexInput1 )
+		self.assertTrue( n["out"].source().isSame( input1 ) )
+
+		indexInput.setInput( indirectIndexInput2 )
+		self.assertTrue( n["out"].source().isSame( input2 ) )
+
 	def setUp( self ) :
 
 		GafferTest.TestCase.setUp( self )


### PR DESCRIPTION
This fixes the same issue @davidsminor was tackling in #1526. This approach to fixing it changes the core signalling mechanism for Node::plugInputChangedSignal() to propagate down connections-to-connections so that all downstream plugs are signalled - effectively inputChanged events are now sourceChanged events. This seems pretty reasonable, since we do the same for plugSetSignal, and without there's a blind spot in our signalling mechanism.

Thanks for doing the legwork on this one David, and for the clear description of the problem. I've included your unit test in this PR so we can be sure it fixes the same problem you were looking at.