### PR TITLE
Fixed a bug in plugs/nodesWithMetadata

### DIFF
--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -864,6 +864,7 @@ class MetadataTest( GafferTest.TestCase ) :
 		Gaffer.Metadata.registerNodeValue( s["n"], "nodeData1", "something" )
 		Gaffer.Metadata.registerNodeValue( s["n2"], "nodeData2", "something" )
 		Gaffer.Metadata.registerNodeValue( s["m"], "nodeData3", "something" )
+		Gaffer.Metadata.registerNodeValue( s["n"], "nodeData3", "something" )
 
 		# register class value on GafferTest.AddNode:
 		Gaffer.Metadata.registerNodeValue( GafferTest.AddNode, "nodeData3", "something" )
@@ -872,6 +873,7 @@ class MetadataTest( GafferTest.TestCase ) :
 		Gaffer.Metadata.registerPlugValue( s["n"]["op1"], "plugData1", "something" )
 		Gaffer.Metadata.registerPlugValue( s["n2"]["op2"], "plugData2", "something" )
 		Gaffer.Metadata.registerPlugValue( s["m"]["op2"], "plugData3", "something" )
+		Gaffer.Metadata.registerPlugValue( s["m"]["op1"], "plugData3", "something" )
 
 		# register class value on GafferTest.AddNode:
 		Gaffer.Metadata.registerPlugValue( GafferTest.AddNode, "op1", "plugData3", "somethingElse" )
@@ -880,7 +882,7 @@ class MetadataTest( GafferTest.TestCase ) :
 		self.assertEqual( Gaffer.Metadata.nodesWithMetadata( s, "nodeData1" ), [ s["n"] ] )
 		self.assertEqual( Gaffer.Metadata.nodesWithMetadata( s, "nodeData2" ), [ s["n2"] ] )
 		self.assertEqual( Gaffer.Metadata.nodesWithMetadata( s, "nodeData3" ), [ s["n"], s["n2"], s["n3"], s["m"] ] )
-		self.assertEqual( Gaffer.Metadata.nodesWithMetadata( s, "nodeData3", instanceOnly=True ), [ s["m"] ] )
+		self.assertEqual( set(Gaffer.Metadata.nodesWithMetadata( s, "nodeData3", instanceOnly=True )), set([ s["n"], s["m"] ]) )
 
 		# telling it to list plugs should make it return an empty list:
 		self.assertEqual( Gaffer.Metadata.plugsWithMetadata( s, "nodeData1" ), [] )
@@ -889,8 +891,8 @@ class MetadataTest( GafferTest.TestCase ) :
 		# test it lists plugs with matching data:
 		self.assertEqual( Gaffer.Metadata.plugsWithMetadata( s, "plugData1" ), [ s["n"]["op1"] ] )
 		self.assertEqual( Gaffer.Metadata.plugsWithMetadata( s, "plugData2" ), [ s["n2"]["op2"] ] )
-		self.assertEqual( Gaffer.Metadata.plugsWithMetadata( s, "plugData3" ), [ s["n"]["op1"], s["n2"]["op1"], s["n3"]["op1"], s["m"]["op2"] ] )
-		self.assertEqual( Gaffer.Metadata.plugsWithMetadata( s, "plugData3", instanceOnly=True ), [ s["m"]["op2"] ] )
+		self.assertEqual( Gaffer.Metadata.plugsWithMetadata( s, "plugData3" ), [ s["n"]["op1"], s["n2"]["op1"], s["n3"]["op1"], s["m"]["op1"], s["m"]["op2"] ] )
+		self.assertEqual( set( Gaffer.Metadata.plugsWithMetadata( s, "plugData3", instanceOnly=True ) ), set( [ s["m"]["op1"], s["m"]["op2"] ] ) )
 
 		# telling it to list nodes should make it return an empty list:
 		self.assertEqual( Gaffer.Metadata.nodesWithMetadata( s, "plugData1" ), [] )
@@ -900,7 +902,7 @@ class MetadataTest( GafferTest.TestCase ) :
 		m = s["m"]
 		s.removeChild( m )
 		self.assertEqual( Gaffer.Metadata.plugsWithMetadata( s, "plugData3", instanceOnly=True ), [] )
-		self.assertEqual( Gaffer.Metadata.nodesWithMetadata( s, "nodeData3", instanceOnly=True ), [] )
+		self.assertEqual( Gaffer.Metadata.nodesWithMetadata( s, "nodeData3", instanceOnly=True ), [ s["n"] ] )
 
 
 if __name__ == "__main__":

--- a/src/Gaffer/Metadata.cpp
+++ b/src/Gaffer/Metadata.cpp
@@ -412,7 +412,6 @@ std::vector<Node*> Metadata::nodesWithMetadata( GraphComponent *root, IECore::In
 			if( it->second->find( key ) != it->second->end() )
 			{
 				nodes.push_back( const_cast<Node*>( node ) );
-				break;
 			}
 		}
 	}
@@ -613,7 +612,6 @@ std::vector<Plug*> Metadata::plugsWithMetadata( GraphComponent *root, IECore::In
 			if( it->second->find( key ) != it->second->end() )
 			{
 				plugs.push_back( const_cast<Plug*>( plug ) );
-				break;
 			}
 		}
 	}


### PR DESCRIPTION
Looks like I had a couple of stray break statements in Metadata.cpp, so I've just removed them