### PR TITLE
Offset : Workaround spurious GCC 4.4.7 compilation error.

### DIFF
--- a/src/GafferImage/Offset.cpp
+++ b/src/GafferImage/Offset.cpp
@@ -58,7 +58,7 @@ size_t bufferIndex( const V2i &p, const Box2i &b )
 {
 	assert( contains( b, p ) );
 	return
-		( p.y - b.min.y ) * b.size().x +
+		( p.y - b.min.y ) * ( b.max.x - b.min.x ) +
 		( p.x - b.min.x );
 }
 


### PR DESCRIPTION
The implementation of Box::size() has a call to isEmpty() in it, and this was for some reason triggering the following GCC error :

> /home/john/dev/build/gaffer/include/OpenEXR/ImathBox.h:539: error: assuming signed overflow does not occur when assuming that (X + c) < X is always false

As a workaround we compute the size directly, assuming that the buffer is non-empty. This is a reasonable assumption, since indexing an empty buffer is going to cause problems of its own.