### PR TITLE
Don't reference user plugs

### DIFF
--- a/include/GafferBindings/MetadataBinding.h
+++ b/include/GafferBindings/MetadataBinding.h
@@ -44,6 +44,9 @@ namespace GafferBindings
 
 void bindMetadata();
 
+void metadataModuleDependencies( const Gaffer::Node *node, std::set<std::string> &modules );
+void metadataModuleDependencies( const Gaffer::Plug *plug, std::set<std::string> &modules );
+
 std::string metadataSerialisation( const Gaffer::Node *node, const std::string &identifier );
 std::string metadataSerialisation( const Gaffer::Plug *plug, const std::string &identifier );
 

--- a/python/GafferTest/SerialisationTest.py
+++ b/python/GafferTest/SerialisationTest.py
@@ -143,6 +143,20 @@ class SerialisationTest( GafferTest.TestCase ) :
 		self.assertEqual( Gaffer.Serialisation.modulePath( GafferTest.SphereNode() ), "GafferTest" )
 		self.assertEqual( Gaffer.Serialisation.modulePath( GafferTest.SphereNode ), "GafferTest" )
 
+	def testIncludeParentMetadataWhenExcludingChildren( self ) :
+
+		n1 = Gaffer.Node()
+		Gaffer.Metadata.registerNodeValue( n1, "test", IECore.Color3f( 1, 2, 3 ) )
+
+		with Gaffer.Context() as c :
+			c["serialiser:includeParentMetadata"] = IECore.BoolData( True )
+			s = Gaffer.Serialisation( n1, filter = Gaffer.StandardSet() )
+
+		scope = { "parent" : Gaffer.Node() }
+		exec( s.result(), scope, scope )
+
+		self.assertEqual( Gaffer.Metadata.nodeValue( scope["parent"], "test" ), IECore.Color3f( 1, 2, 3 ) )
+
 if __name__ == "__main__":
 	unittest.main()
 

--- a/src/Gaffer/Box.cpp
+++ b/src/Gaffer/Box.cpp
@@ -365,7 +365,10 @@ void Box::exportForReference( const std::string &fileName ) const
 		}
 		else if( const Plug *plug = IECore::runTimeCast<Plug>( it->get() ) )
 		{
-			if( !boost::regex_match( plug->getName().c_str(), invisiblePlug ) )
+			if(
+				!boost::regex_match( plug->getName().c_str(), invisiblePlug )
+				&& plug != userPlug()
+			)
 			{
 				toExport->add( *it );
 			}

--- a/src/GafferBindings/MetadataBinding.cpp
+++ b/src/GafferBindings/MetadataBinding.cpp
@@ -329,7 +329,7 @@ void bindMetadata()
 				boost::python::arg( "node" ),
 				boost::python::arg( "inherit" ) = true,
 				boost::python::arg( "instanceOnly" ) = false,
-				boost::python::arg( "persistentOnly" ) = false			
+				boost::python::arg( "persistentOnly" ) = false
 			)
 		)
 		.staticmethod( "registeredNodeValues" )
@@ -378,7 +378,7 @@ void bindMetadata()
 				boost::python::arg( "plug" ),
 				boost::python::arg( "inherit" ) = true,
 				boost::python::arg( "instanceOnly" ) = false,
-				boost::python::arg( "persistentOnly" ) = false			
+				boost::python::arg( "persistentOnly" ) = false
 			)
 		)
 		.staticmethod( "registeredPlugValues" )
@@ -414,7 +414,7 @@ void bindMetadata()
 
 		.def( "plugValueChangedSignal", &Metadata::plugValueChangedSignal, return_value_policy<reference_existing_object>() )
 		.staticmethod( "plugValueChangedSignal" )
-		
+
 		.def( "plugsWithMetadata", &plugsWithMetadata,
 			(
 				boost::python::arg( "root" ),
@@ -424,7 +424,7 @@ void bindMetadata()
 			)
 		)
 		.staticmethod( "plugsWithMetadata" )
-		
+
 		.def( "nodesWithMetadata", &nodesWithMetadata,
 			(
 				boost::python::arg( "root" ),
@@ -439,6 +439,22 @@ void bindMetadata()
 	SignalClass<Metadata::NodeValueChangedSignal, DefaultSignalCaller<Metadata::NodeValueChangedSignal>, ValueChangedSlotCaller>( "NodeValueChangedSignal" );
 	SignalClass<Metadata::PlugValueChangedSignal, DefaultSignalCaller<Metadata::NodeValueChangedSignal>, ValueChangedSlotCaller>( "PlugValueChangedSignal" );
 
+}
+
+void metadataModuleDependencies( const Gaffer::Node *node, std::set<std::string> &modules )
+{
+	/// \todo Derive from the registered values so we can support
+	/// datatypes from other modules.
+	modules.insert( "IECore" );
+	modules.insert( "Gaffer" );
+}
+
+void metadataModuleDependencies( const Gaffer::Plug *plug, std::set<std::string> &modules )
+{
+	/// \todo Derive from the registered values so we can support
+	/// datatypes from other modules.
+	modules.insert( "IECore" );
+	modules.insert( "Gaffer" );
 }
 
 std::string metadataSerialisation( const Gaffer::Node *node, const std::string &identifier )

--- a/src/GafferBindings/NodeBinding.cpp
+++ b/src/GafferBindings/NodeBinding.cpp
@@ -105,7 +105,7 @@ struct ErrorSlotCaller
 void NodeSerialiser::moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules ) const
 {
 	Serialiser::moduleDependencies( graphComponent, modules );
-	modules.insert( "IECore" ); // for the metadata calls
+	metadataModuleDependencies( static_cast<const Gaffer::Node *>( graphComponent ), modules );
 }
 
 std::string NodeSerialiser::postHierarchy( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const

--- a/src/GafferBindings/PlugBinding.cpp
+++ b/src/GafferBindings/PlugBinding.cpp
@@ -93,7 +93,7 @@ static NodePtr node( Plug &p )
 void PlugSerialiser::moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules ) const
 {
 	Serialiser::moduleDependencies( graphComponent, modules );
-	modules.insert( "IECore" ); // for the metadata calls
+	metadataModuleDependencies( static_cast<const Plug *>( graphComponent ), modules );
 }
 
 std::string PlugSerialiser::constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const

--- a/src/GafferBindings/Serialisation.cpp
+++ b/src/GafferBindings/Serialisation.cpp
@@ -71,10 +71,12 @@ Serialisation::Serialisation( const Gaffer::GraphComponent *parent, const std::s
 	{
 		if( const Node *node = runTimeCast<const Node>( parent ) )
 		{
+			metadataModuleDependencies( node, m_modules );
 			m_postScript += metadataSerialisation( node, parentName );
 		}
 		else if( const Plug *plug = runTimeCast<const Plug>( parent ) )
 		{
+			metadataModuleDependencies( plug, m_modules );
 			m_postScript += metadataSerialisation( plug, parentName );
 		}
 	}
@@ -99,7 +101,7 @@ std::string Serialisation::result() const
 	)
 	{
 		boost::format formatter( "Gaffer.Metadata.registerNodeValue( %s, \"%s\", %d, persistent=False )\n" );
-		
+
 		result += "\n";
 		result += boost::str( formatter % m_parentName % "serialiser:milestoneVersion" % GAFFER_MILESTONE_VERSION );
 		result += boost::str( formatter % m_parentName % "serialiser:majorVersion" % GAFFER_MAJOR_VERSION );


### PR DESCRIPTION
This stops the inclusion of user plugs from reference files exported from the Box node (as required in #801), and updates the Reference node to provide backwards compatibility for old references, but otherwise leave the user plug free for the use of the end user.