### PR TITLE
Update to how Travis reports failing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,20 +31,21 @@ script:
     # Preload libSegFault when running tests, so we get stack
     # traces from any crashes.
     - export LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
-    - ./install/gaffer-*/bin/gaffer test GafferTest
-    - ./install/gaffer-*/bin/gaffer test GafferUITest
-    - ./install/gaffer-*/bin/gaffer test GafferCortexTest
-    - ./install/gaffer-*/bin/gaffer test GafferCortexUITest
-    - ./install/gaffer-*/bin/gaffer test GafferImageTest
-    - ./install/gaffer-*/bin/gaffer test GafferImageUITest
-    - ./install/gaffer-*/bin/gaffer test GafferSceneTest
-    - ./install/gaffer-*/bin/gaffer test GafferSceneUITest
-    - ./install/gaffer-*/bin/gaffer test GafferOSLTest
-    - ./install/gaffer-*/bin/gaffer test GafferOSLUITest
-    - ./install/gaffer-*/bin/gaffer test GafferRenderManTest
-    - ./install/gaffer-*/bin/gaffer test GafferRenderManUITest
-    - ./install/gaffer-*/bin/gaffer test GafferAppleseedTest
-    - ./install/gaffer-*/bin/gaffer test GafferAppleseedUITest
+    - source ./config/travis/runGafferTest GafferTest
+    - source ./config/travis/runGafferTest GafferUITest
+    - source ./config/travis/runGafferTest GafferCortexTest
+    - source ./config/travis/runGafferTest GafferCortexUITest
+    - source ./config/travis/runGafferTest GafferImageTest
+    - source ./config/travis/runGafferTest GafferImageUITest
+    - source ./config/travis/runGafferTest GafferSceneTest
+    - source ./config/travis/runGafferTest GafferSceneUITest
+    - source ./config/travis/runGafferTest GafferOSLTest
+    - source ./config/travis/runGafferTest GafferOSLUITest
+    - source ./config/travis/runGafferTest GafferRenderManTest
+    - source ./config/travis/runGafferTest GafferRenderManUITest
+    - source ./config/travis/runGafferTest GafferAppleseedTest
+    - source ./config/travis/runGafferTest GafferAppleseedUITest
+    - ./config/travis/printTestResults
 
 compiler:
     - gcc

--- a/config/travis/printTestResults
+++ b/config/travis/printTestResults
@@ -1,0 +1,26 @@
+OIFS=$IFS
+IFS=':'
+
+if [ "$GAFFER_TESTS_FAIL" != "" ]; then
+	echo "Gaffer Tests Failed:"
+	failedTests=$GAFFER_TESTS_FAIL
+
+	for t in $failedTests
+	do
+		echo $t
+	done
+fi
+
+echo ""
+
+if [ "$GAFFER_TESTS_PASS" != "" ]; then
+	echo "Gaffer Tests Passed:"
+	passedTests=$GAFFER_TESTS_PASS
+
+	for t in $passedTests
+	do
+		echo $t
+	done
+fi
+
+IFS=$OIFS

--- a/config/travis/runGafferTest
+++ b/config/travis/runGafferTest
@@ -1,0 +1,23 @@
+test_module=$1
+
+./install/gaffer-*/bin/gaffer test $test_module
+
+result=$?
+
+if [ -z "$GAFFER_TESTS_FAIL" ]; then
+	export GAFFER_TESTS_FAIL=""
+fi
+
+if [ -z "$GAFFER_TESTS_PASS" ]; then
+	export GAFFER_TESTS_PASS=""
+fi
+
+if [ $result -eq 0 ]; then
+	export GAFFER_TESTS_PASS=${GAFFER_TESTS_PASS}:${test_module}
+	echo Gaffer Test Passed : ${test_module}
+else
+	export GAFFER_TESTS_FAIL=${GAFFER_TESTS_FAIL}:${test_module}
+	echo Gaffer Test Failed : ${test_module}
+fi
+
+bash -c "exit $result"


### PR DESCRIPTION
This update is especially for @andrewkaufman, who had trouble finding a failed test...

It prints out "Gaffer Test Failed : GafferImageTest" or "Gaffer Test Passed : GafferImageTest" after each batch of tests, enabling easier searching. It also lists at the very bottom which test suites failed and which passed.

Here's a build where every test will pass : https://travis-ci.org/HughMacdonald/gaffer/jobs/88380758
Here's a build where one test will fail : https://travis-ci.org/HughMacdonald/gaffer/jobs/88380822