### PR TITLE
Scene inspector context fix

### DIFF
--- a/src/GafferImage/ImageReader.cpp
+++ b/src/GafferImage/ImageReader.cpp
@@ -523,7 +523,7 @@ size_t ImageReader::getCacheMemoryLimit()
 {
 	float memoryLimit;
 	imageCache()->getattribute( "max_memory_MB", memoryLimit );
-	return memoryLimit;
+	return (size_t)memoryLimit;
 }
 
 void ImageReader::setCacheMemoryLimit( size_t mb )


### PR DESCRIPTION
SceneInspector.DiffColumn.update() doesn't always get called by SceneInspector.update(), which means it doesn't necessarily get called under SceneInspector.getContext(). I'm fixing this by grabbing the ancestor NodeSetEditor in DiffColumn.update() and using its getContext() if it's available.