### PR TITLE
Reference : Support metadata edits.

### DIFF
--- a/include/Gaffer/Reference.h
+++ b/include/Gaffer/Reference.h
@@ -60,7 +60,7 @@ class Reference : public SubGraph
 		void load( const std::string &fileName );
 		/// Returns the name of the script currently being referenced.
 		const std::string &fileName() const;
-		
+
 		typedef boost::signal<void ( Reference * )> ReferenceLoadedSignal;
 		/// Emitted when a reference is loaded (or unloaded following an undo).
 		ReferenceLoadedSignal &referenceLoadedSignal();
@@ -69,6 +69,8 @@ class Reference : public SubGraph
 
 		void loadInternal( const std::string &fileName );
 		bool isReferencePlug( const Plug *plug ) const;
+
+		void convertPersistentMetadata( Plug *plug ) const;
 
 		std::string m_fileName;
 		ReferenceLoadedSignal m_referenceLoadedSignal;

--- a/include/Gaffer/Reference.h
+++ b/include/Gaffer/Reference.h
@@ -71,6 +71,7 @@ class Reference : public SubGraph
 		bool isReferencePlug( const Plug *plug ) const;
 
 		void convertPersistentMetadata( Plug *plug ) const;
+		void transferPersistentMetadata( const Plug *srcPlug, Plug *dstPlug ) const;
 
 		std::string m_fileName;
 		ReferenceLoadedSignal m_referenceLoadedSignal;

--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -259,6 +259,10 @@ class ReferenceTest( GafferTest.TestCase ) :
 
 		self.assertEqual( Gaffer.Metadata.plugValue( s2["r"].descendant( p.relativeName( b ) ), "description" ), "ppp" )
 
+		s3 = Gaffer.ScriptNode()
+		s3.execute( s2.serialise() )
+		self.assertEqual( Gaffer.Metadata.plugValue( s3["r"].descendant( p.relativeName( b ) ), "description" ), "ppp" )
+
 	def testMetadataIsntResaved( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -296,6 +296,80 @@ class ReferenceTest( GafferTest.TestCase ) :
 
 		self.assertEqual( Gaffer.Metadata.plugValue( s["r"]["p"], "description" ), "ddd" )
 
+	def testEditPlugMetadata( self ) :
+
+		# Export a box with some metadata
+
+		s = Gaffer.ScriptNode()
+		s["n1"] = GafferTest.AddNode()
+
+		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["n1"] ] ) )
+		p = b.promotePlug( b["n1"]["op1"] )
+		p.setName( "p" )
+
+		Gaffer.Metadata.registerPlugValue( p, "test", "referenced" )
+
+		b.exportForReference( "/tmp/test.grf" )
+
+		# Reference it, and check it loaded.
+
+		s2 = Gaffer.ScriptNode()
+		s2["r"] = Gaffer.Reference()
+		s2["r"].load( "/tmp/test.grf" )
+
+		self.assertEqual( Gaffer.Metadata.plugValue( s2["r"]["p"], "test" ), "referenced" )
+
+		# Edit it, and check it overwrote the original.
+
+		Gaffer.Metadata.registerPlugValue( s2["r"]["p"], "test", "edited" )
+		self.assertEqual( Gaffer.Metadata.plugValue( s2["r"]["p"], "test" ), "edited" )
+
+		# Save and load the script, and check the edit stays in place.
+
+		s3 = Gaffer.ScriptNode()
+		s3.execute( s2.serialise() )
+		self.assertEqual( Gaffer.Metadata.plugValue( s3["r"]["p"], "test" ), "edited" )
+
+		# Reload the reference, and check the edit stays in place.
+
+		s3["r"].load( "/tmp/test.grf" )
+		self.assertEqual( Gaffer.Metadata.plugValue( s3["r"]["p"], "test" ), "edited" )
+
+	def testAddPlugMetadata( self ) :
+
+		# Export a box with no metadata
+
+		s = Gaffer.ScriptNode()
+		s["n1"] = GafferTest.AddNode()
+
+		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["n1"] ] ) )
+		p = b.promotePlug( b["n1"]["op1"] )
+		p.setName( "p" )
+
+		b.exportForReference( "/tmp/test.grf" )
+
+		# Reference it, and check it loaded.
+
+		s2 = Gaffer.ScriptNode()
+		s2["r"] = Gaffer.Reference()
+		s2["r"].load( "/tmp/test.grf" )
+
+		# Add some metadata to the Reference node (not the reference file)
+
+		Gaffer.Metadata.registerPlugValue( s2["r"]["p"], "test", "added" )
+		self.assertEqual( Gaffer.Metadata.plugValue( s2["r"]["p"], "test" ), "added" )
+
+		# Save and load the script, and check the added metadata stays in place.
+
+		s3 = Gaffer.ScriptNode()
+		s3.execute( s2.serialise() )
+		self.assertEqual( Gaffer.Metadata.plugValue( s3["r"]["p"], "test" ), "added" )
+
+		# Reload the reference, and check the edit stays in place.
+
+		s3["r"].load( "/tmp/test.grf" )
+		self.assertEqual( Gaffer.Metadata.plugValue( s3["r"]["p"], "test" ), "added" )
+
 	def testReloadWithUnconnectedPlugs( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/src/GafferBindings/PlugBinding.cpp
+++ b/src/GafferBindings/PlugBinding.cpp
@@ -39,8 +39,6 @@
 
 #include "Gaffer/Plug.h"
 #include "Gaffer/Node.h"
-#include "Gaffer/Reference.h"
-#include "Gaffer/CompoundPlug.h"
 
 #include "GafferBindings/PlugBinding.h"
 #include "GafferBindings/MetadataBinding.h"
@@ -117,22 +115,7 @@ std::string PlugSerialiser::postHierarchy( const Gaffer::GraphComponent *graphCo
 			result += identifier + ".setFlags( Gaffer.Plug.Flags.ReadOnly, True )\n";
 		}
 
-		bool serialiseMetadata = true;
-		const Node *node = plug->node();
-		if( IECore::runTimeCast<const Reference>( node ) )
-		{
-			/// \todo Perhaps we need some sort of plug flag the Reference node can
-			/// set to influence the metadata serialisation, so that the PlugBinding
-			/// doesn't need to know about References at all?
-			if( plug != node->userPlug() && !node->userPlug()->isAncestorOf( plug ) )
-			{
-				serialiseMetadata = false;
-			}
-		}
-		if( serialiseMetadata )
-		{
-			result += metadataSerialisation( plug, identifier );
-		}
+		result += metadataSerialisation( plug, identifier );
 
 		return result;
 	}


### PR DESCRIPTION
Previously we never serialised _any_ metadata from Reference nodes, regardless of whether the metadata originated from within the referenced file or was added/edited after loading. We now support both the addition of new metadata and editing of metadata from the reference.

This implementation uses the persistence flag on each metadata item to track whether it is considered to have come from the referenced file or not. Strictly speaking, this is slightly abusing the semantics of that flag, but this does allow us to support edits with minimal changes, and is similar to the way we treat the Dynamic plug flag already. We still need a full system for tracking reference edits to plug values - when we implement such a thing we should probably track metadata edits with the same mechanism.

Fixes #1536.

@davidsminor, could you take a look and see if this is sufficient for your current purposes? Also, am I right in thinking you have an "import reference" type functionality? If so, could you check that my changes are compatible with that?