### PR TITLE
Added extra ray depth and sampling settings to ArnoldOptions node.

### DIFF
--- a/python/GafferArnoldUI/ArnoldOptionsUI.py
+++ b/python/GafferArnoldUI/ArnoldOptionsUI.py
@@ -50,8 +50,21 @@ def __samplingSummary( plug ) :
 		info.append( "Glossy %d" % plug["giGlossySamples"]["value"].getValue() )
 	if plug["giRefractionSamples"]["enabled"].getValue() :
 		info.append( "Refraction %d" % plug["giRefractionSamples"]["value"].getValue() )
-
 	return ", ".join( info )
+
+def __rayDepthSummary( plug ) :
+
+	info = []
+	if plug["giDiffuseDepth"]["enabled"].getValue() :
+		info.append( "Diffuse Depth %d" % plug["giDiffuseDepth"]["value"].getValue() )
+	if plug["giGlossyDepth"]["enabled"].getValue() :
+		info.append( "Glossy Depth %d" % plug["giGlossyDepth"]["value"].getValue() )
+	if plug["giReflectionDepth"]["enabled"].getValue() :
+		info.append( "Reflection Depth %d" % plug["giReflectionDepth"]["value"].getValue() )
+	if plug["giRefractionDepth"]["enabled"].getValue() :
+		info.append( "Refraction Depth %d" % plug["giRefractionDepth"]["value"].getValue() )
+	return ", ".join( info )
+
 
 def __featuresSummary( plug ) :
 
@@ -109,6 +122,7 @@ Gaffer.Metadata.registerNode(
 		"options" : [
 
 			"layout:section:Sampling:summary", __samplingSummary,
+			"layout:section:Ray Depth:summary", __rayDepthSummary,
 			"layout:section:Features:summary", __featuresSummary,
 			"layout:section:Search Paths:summary", __searchPathsSummary,
 			"layout:section:Error Colors:summary", __errorColorsSummary,
@@ -177,6 +191,61 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "Sampling",
 			"label", "Refraction Samples",
+
+		],
+
+		# Ray Depth
+
+		"options.giDiffuseDepth" : [
+
+			"description",
+			"""
+			Controls the number of ray bounces when
+			computing indirect illumination ("bounce light").
+			""",
+
+			"layout:section", "Ray Depth",
+			"label", "Diffuse Depth",
+
+		],
+
+		"options.giGlossyDepth" : [
+
+			"description",
+			"""
+			Controls the number of ray bounces when
+			computing glossy specular reflections.
+			""",
+
+			"layout:section", "Ray Depth",
+			"label", "Glossy Depth",
+
+		],
+
+		"options.giReflectionDepth" : [
+
+			"description",
+			"""
+			Controls the number of ray bounces when
+			computing reflections. 
+			""",
+
+			"layout:section", "Ray Depth",
+			"label", "Reflection Depth",
+
+		],
+
+
+		"options.giRefractionDepth" : [
+
+			"description",
+			"""
+			Controls the number of ray bounces when
+			computing refractions. 
+			""",
+
+			"layout:section", "Ray Depth",
+			"label", "Refraction Depth",
 
 		],
 

--- a/src/GafferArnold/ArnoldOptions.cpp
+++ b/src/GafferArnold/ArnoldOptions.cpp
@@ -52,7 +52,14 @@ ArnoldOptions::ArnoldOptions( const std::string &name )
 	options->addOptionalMember( "ai:AA_samples", new IECore::IntData( 3 ), "aaSamples", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:GI_diffuse_samples", new IECore::IntData( 2 ), "giDiffuseSamples", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:GI_glossy_samples", new IECore::IntData( 2 ), "giGlossySamples", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:GI_reflection_samples", new IECore::IntData( 2 ), "giReflectionSamples", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:GI_refraction_samples", new IECore::IntData( 2 ), "giRefractionSamples", Gaffer::Plug::Default, false );
+
+
+	options->addOptionalMember( "ai:GI_diffuse_depth", new IECore::IntData( 2 ), "giDiffuseDepth", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:GI_glossy_depth", new IECore::IntData( 2 ), "giGlossyDepth", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:GI_reflection_depth", new IECore::IntData( 2 ), "giReflectionDepth", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:GI_refraction_depth", new IECore::IntData( 2 ), "giRefractionDepth", Gaffer::Plug::Default, false );
 
 	// ignore parameters
 

--- a/src/GafferArnold/ArnoldOptions.cpp
+++ b/src/GafferArnold/ArnoldOptions.cpp
@@ -55,6 +55,7 @@ ArnoldOptions::ArnoldOptions( const std::string &name )
 	options->addOptionalMember( "ai:GI_reflection_samples", new IECore::IntData( 2 ), "giReflectionSamples", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:GI_refraction_samples", new IECore::IntData( 2 ), "giRefractionSamples", Gaffer::Plug::Default, false );
 
+	// ray depth parameters
 
 	options->addOptionalMember( "ai:GI_diffuse_depth", new IECore::IntData( 2 ), "giDiffuseDepth", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:GI_glossy_depth", new IECore::IntData( 2 ), "giGlossyDepth", Gaffer::Plug::Default, false );

--- a/src/GafferArnold/ArnoldOptions.cpp
+++ b/src/GafferArnold/ArnoldOptions.cpp
@@ -52,7 +52,6 @@ ArnoldOptions::ArnoldOptions( const std::string &name )
 	options->addOptionalMember( "ai:AA_samples", new IECore::IntData( 3 ), "aaSamples", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:GI_diffuse_samples", new IECore::IntData( 2 ), "giDiffuseSamples", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:GI_glossy_samples", new IECore::IntData( 2 ), "giGlossySamples", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "ai:GI_reflection_samples", new IECore::IntData( 2 ), "giReflectionSamples", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:GI_refraction_samples", new IECore::IntData( 2 ), "giRefractionSamples", Gaffer::Plug::Default, false );
 
 	// ray depth parameters


### PR DESCRIPTION
A number of arnold options were missing from the ArnoldOptions node.
I have tested that these options work with arnold-4.2.11.0.

Perhaps these options should live else where like the StandardOptions node?
Or is there another way to set these options?