### PR TITLE
Add Format option to Crop node

### DIFF
--- a/include/GafferImage/Crop.h
+++ b/include/GafferImage/Crop.h
@@ -57,9 +57,9 @@ class Crop : public ImageProcessor
 		enum AreaSource
 		{
 			Area = 0,
-			Format = 1,
-			DataWindow = 2,
-			DisplayWindow = 3
+			DataWindow = 1,
+			DisplayWindow = 2,
+			Format = 3
 		};
 
 		Gaffer::IntPlug *areaSourcePlug();

--- a/include/GafferImage/Crop.h
+++ b/include/GafferImage/Crop.h
@@ -43,6 +43,7 @@
 
 namespace GafferImage
 {
+	IE_CORE_FORWARDDECLARE( FormatPlug );
 
 class Crop : public ImageProcessor
 {
@@ -55,9 +56,10 @@ class Crop : public ImageProcessor
 
 		enum AreaSource
 		{
-			Custom = 0,
-			DataWindow = 1,
-			DisplayWindow = 2
+			Area = 0,
+			Format = 1,
+			DataWindow = 2,
+			DisplayWindow = 3
 		};
 
 		Gaffer::IntPlug *areaSourcePlug();
@@ -65,6 +67,12 @@ class Crop : public ImageProcessor
 
 		Gaffer::Box2iPlug *areaPlug();
 		const Gaffer::Box2iPlug *areaPlug() const;
+
+		GafferImage::FormatPlug *formatPlug();
+		const GafferImage::FormatPlug *formatPlug() const;
+
+		Gaffer::BoolPlug *formatCenterPlug();
+		const Gaffer::BoolPlug *formatCenterPlug() const;
 
 		Gaffer::BoolPlug *affectDataWindowPlug();
 		const Gaffer::BoolPlug *affectDataWindowPlug() const;

--- a/python/GafferImageTest/CropTest.py
+++ b/python/GafferImageTest/CropTest.py
@@ -59,6 +59,10 @@ class CropTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( crop["affectDataWindow"].getValue(), True )
 		self.assertEqual( crop["affectDisplayWindow"].getValue(), True )
 
+	def testCompatibility( self ) :
+
+		self.assertEqual( GafferImage.Crop.AreaSource.Custom, GafferImage.Crop.AreaSource.Area )
+
 	def testPassThrough( self ) :
 
 		i = GafferImage.ImageReader()

--- a/python/GafferImageTest/CropTest.py
+++ b/python/GafferImageTest/CropTest.py
@@ -54,7 +54,7 @@ class CropTest( GafferImageTest.ImageTestCase ) :
 
 		crop = GafferImage.Crop()
 
-		self.assertEqual( crop["areaSource"].getValue(), GafferImage.Crop.AreaSource.Custom )
+		self.assertEqual( crop["areaSource"].getValue(), GafferImage.Crop.AreaSource.Area )
 		self.assertTrue( crop["area"].getValue().isEmpty() )
 		self.assertEqual( crop["affectDataWindow"].getValue(), True )
 		self.assertEqual( crop["affectDisplayWindow"].getValue(), True )
@@ -66,7 +66,7 @@ class CropTest( GafferImageTest.ImageTestCase ) :
 
 		crop = GafferImage.Crop()
 		crop["in"].setInput(i["out"])
-		crop["areaSource"].setValue( GafferImage.Crop.AreaSource.Custom )
+		crop["areaSource"].setValue( GafferImage.Crop.AreaSource.Area )
 		crop["area"].setValue( IECore.Box2i( IECore.V2i( 40 ), IECore.V2i( 50 ) ) )
 		crop["affectDataWindow"].setValue( True )
 		crop["affectDisplayWindow"].setValue( True )
@@ -95,6 +95,29 @@ class CropTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( crop.correspondingInput( crop["in"] ), None )
 		self.assertEqual( crop.correspondingInput( crop["enabled"] ), None )
 
+	def testAreaFormat( self ) :
+
+		constant = GafferImage.Constant()
+		constant['format'].setValue( GafferImage.Format( 1024, 576 ) )
+
+		crop1 = GafferImage.Crop()
+		crop1['in'].setInput( constant['out'] )
+		crop1['areaSource'].setValue( GafferImage.Crop.AreaSource.Format )
+		crop1['format'].setValue( GafferImage.Format( 2048, 1152 ) )
+
+		crop2 = GafferImage.Crop()
+		crop2['in'].setInput( constant['out'] )
+		crop2['areaSource'].setValue( GafferImage.Crop.AreaSource.Area )
+		crop2['area'].setValue( IECore.Box2i( IECore.V2i( 0, 0 ), IECore.V2i( 2048, 1152 ) ) )
+
+		self.assertEqual( crop1['out']['dataWindow'].getValue(), crop2['out']['dataWindow'].getValue() )
+
+		crop1['formatCenter'].setValue( True )
+		crop2['area'].setValue( IECore.Box2i( IECore.V2i( -512, -288 ), IECore.V2i( 1536, 864 ) ) )
+		crop2['resetOrigin'].setValue( True )
+
+		self.assertEqual( crop1['out']['dataWindow'].getValue(), crop2['out']['dataWindow'].getValue() )
+
 	def testAffectDataWindow( self ) :
 
 		i = GafferImage.ImageReader()
@@ -102,7 +125,7 @@ class CropTest( GafferImageTest.ImageTestCase ) :
 
 		crop = GafferImage.Crop()
 		crop["in"].setInput(i["out"])
-		crop["areaSource"].setValue( GafferImage.Crop.AreaSource.Custom )
+		crop["areaSource"].setValue( GafferImage.Crop.AreaSource.Area )
 		crop["area"].setValue( IECore.Box2i( IECore.V2i( 40 ), IECore.V2i( 50 ) ) )
 		crop["affectDataWindow"].setValue( True )
 		crop["affectDisplayWindow"].setValue( False )
@@ -117,7 +140,7 @@ class CropTest( GafferImageTest.ImageTestCase ) :
 
 		crop = GafferImage.Crop()
 		crop["in"].setInput(i["out"])
-		crop["areaSource"].setValue( GafferImage.Crop.AreaSource.Custom )
+		crop["areaSource"].setValue( GafferImage.Crop.AreaSource.Area )
 		crop["area"].setValue( IECore.Box2i( IECore.V2i( 40 ), IECore.V2i( 50 ) ) )
 		crop["affectDataWindow"].setValue( False )
 		crop["affectDisplayWindow"].setValue( True )
@@ -138,7 +161,7 @@ class CropTest( GafferImageTest.ImageTestCase ) :
 
 		crop = GafferImage.Crop()
 		crop["in"].setInput(i["out"])
-		crop["areaSource"].setValue( GafferImage.Crop.AreaSource.Custom )
+		crop["areaSource"].setValue( GafferImage.Crop.AreaSource.Area )
 		crop["area"].setValue( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 50 ) ) )
 		crop["affectDataWindow"].setValue( True )
 		crop["affectDisplayWindow"].setValue( False )

--- a/python/GafferImageTest/ImageWriterTest.py
+++ b/python/GafferImageTest/ImageWriterTest.py
@@ -761,7 +761,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		i["format"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 100 ) ), 1 ) )
 
 		c = GafferImage.Crop()
-		c["areaSource"].setValue( GafferImage.Crop.AreaSource.Custom )
+		c["areaSource"].setValue( GafferImage.Crop.AreaSource.Area )
 		c["area"].setValue( IECore.Box2i( IECore.V2i( 40 ), IECore.V2i( 40 ) ) )
 		c["affectDisplayWindow"].setValue( False )
 		c["affectDataWindow"].setValue( True )

--- a/python/GafferImageTest/MergeTest.py
+++ b/python/GafferImageTest/MergeTest.py
@@ -276,7 +276,7 @@ class MergeTest( GafferImageTest.ImageTestCase ) :
 
 		aCrop = GafferImage.Crop()
 		aCrop["in"].setInput( a["out"] )
-		aCrop["areaSource"].setValue( aCrop.AreaSource.Custom )
+		aCrop["areaSource"].setValue( aCrop.AreaSource.Area )
 		aCrop["area"].setValue( IECore.Box2i( IECore.V2i( 50 ), IECore.V2i( 162 ) ) )
 		aCrop["affectDisplayWindow"].setValue( False )
 
@@ -318,7 +318,7 @@ class MergeTest( GafferImageTest.ImageTestCase ) :
 
 		bCrop = GafferImage.Crop()
 		bCrop["in"].setInput( b["out"] )
-		bCrop["areaSource"].setValue( bCrop.AreaSource.Custom )
+		bCrop["areaSource"].setValue( bCrop.AreaSource.Area )
 		bCrop["area"].setValue( IECore.Box2i( IECore.V2i( 50 ), IECore.V2i( 162 ) ) )
 		bCrop["affectDisplayWindow"].setValue( False )
 

--- a/python/GafferImageTest/ResizeTest.py
+++ b/python/GafferImageTest/ResizeTest.py
@@ -132,7 +132,7 @@ class ResizeTest( GafferImageTest.ImageTestCase ) :
 
 		crop = GafferImage.Crop()
 		crop["in"].setInput( constant["out"] )
-		crop["areaSource"].setValue( crop.AreaSource.Custom )
+		crop["areaSource"].setValue( crop.AreaSource.Area )
 		crop["area"].setValue( IECore.Box2i( IECore.V2i( 64 ), IECore.V2i( 128 ) ) )
 		crop["affectDisplayWindow"].setValue( False )
 		crop["affectDataWindow"].setValue( True )

--- a/python/GafferImageTest/SamplerTest.py
+++ b/python/GafferImageTest/SamplerTest.py
@@ -160,7 +160,7 @@ class SamplerTest( GafferImageTest.ImageTestCase ) :
 
 		crop = GafferImage.Crop()
 		crop["in"].setInput( constant["out"] )
-		crop["areaSource"].setValue( crop.AreaSource.Custom )
+		crop["areaSource"].setValue( crop.AreaSource.Area )
 		crop["area"].setValue( IECore.Box2i( IECore.V2i( 135 ), IECore.V2i( 214 ) ) )
 		crop["affectDisplayWindow"].setValue( False )
 
@@ -178,7 +178,7 @@ class SamplerTest( GafferImageTest.ImageTestCase ) :
 
 		crop = GafferImage.Crop()
 		crop["in"].setInput( constant["out"] )
-		crop["areaSource"].setValue( crop.AreaSource.Custom )
+		crop["areaSource"].setValue( crop.AreaSource.Area )
 		crop["area"].setValue( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 200 ) ) )
 		crop["affectDisplayWindow"].setValue( False )
 		crop["affectDataWindow"].setValue( False )

--- a/python/GafferImageUI/CropUI.py
+++ b/python/GafferImageUI/CropUI.py
@@ -64,23 +64,12 @@ Gaffer.Metadata.registerNode(
 	or Display Window.
 	""",
 
-	"layout:activator:areaSourceIsCustom", lambda node : node["areaSource"].getValue() == GafferImage.Crop.AreaSource.Custom,
+	"layout:activator:areaSourceIsArea", lambda node : node["areaSource"].getValue() == GafferImage.Crop.AreaSource.Area,
+	"layout:activator:areaSourceIsFormat", lambda node : node["areaSource"].getValue() == GafferImage.Crop.AreaSource.Format,
 	"layout:activator:affectDisplayWindowIsOn", lambda node : node["affectDisplayWindow"].getValue(),
+	"layout:areaSourceIsFormatAndAffectDisplayWindowIsOn", lambda node : (node['affectDisplayWindow'].getValue() and node["areaSource"].getValue() == GafferImage.Crop.AreaSource.Format),
 
 	plugs = {
-
-		"area" : [
-
-			"description",
-			"""
-			The custom area to set the Data/Display Window to.
-			This plug is only used if 'Area Source' is set to
-			Custom.
-			""",
-
-			"layout:activator", "areaSourceIsCustom",
-
-		],
 
 		"areaSource" : [
 
@@ -93,11 +82,57 @@ Gaffer.Metadata.registerNode(
 			the Area plug.
 			""",
 
+			"preset:Area", GafferImage.Crop.AreaSource.Area,
+			"preset:Format", GafferImage.Crop.AreaSource.Format,
 			"preset:DataWindow", GafferImage.Crop.AreaSource.DataWindow,
 			"preset:DisplayWindow", GafferImage.Crop.AreaSource.DisplayWindow,
-			"preset:Custom", GafferImage.Crop.AreaSource.Custom,
 
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
+		],
+
+		"area" : [
+
+			"description",
+			"""
+			The custom area to set the Data/Display Window to.
+			This plug is only used if 'Area Source' is set to
+			Custom.
+			""",
+
+			"layout:activator", "areaSourceIsArea",
+
+		],
+
+		"format" : [
+
+			"description",
+			"""
+			The Format to use as the area to set the Data/Display
+			Window to. This plug is only used if 'Area Source' is
+			set to Format.
+			""",
+
+			"layout:activator", "areaSourceIsFormat",
+
+		],
+
+		"formatCenter" : [
+
+			"description",
+			"""
+			Whether to center the output image (based on the
+			existing display window) inside the new display
+			window format. This plug is only used if
+			'Area Source' is set to Format, and 'Affect Display
+			Window' it checked.
+			""",
+
+			# "layout:activator", "areaSourceIsFormatAndAffectDisplayWindowIsOn",
+			"layout:activator", "areaSourceIsFormat",
+			"layout:activator", "affectDisplayWindowIsOn",
+
+			"divider", True
 
 		],
 

--- a/src/GafferImage/Crop.cpp
+++ b/src/GafferImage/Crop.cpp
@@ -357,7 +357,7 @@ void Crop::compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) 
 				if( formatCenterPlug()->getValue() )
 				{
 					const Imath::Box2i displayWindow = inPlug()->formatPlug()->getValue().getDisplayWindow();
-					Imath::V2i centerOffset( ( ( cropWindow.max - displayWindow.max ) + ( cropWindow.min - displayWindow.min ) ) / 2 );
+					Imath::V2i centerOffset( cropWindow.center() - displayWindow.center() );
 
 					cropWindow.min -= centerOffset;
 					cropWindow.max -= centerOffset;

--- a/src/GafferImage/Crop.cpp
+++ b/src/GafferImage/Crop.cpp
@@ -53,7 +53,7 @@ Crop::Crop( const std::string &name )
 	:   ImageProcessor( name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
-	addChild( new IntPlug( "areaSource", Gaffer::Plug::In, Crop::Area, Crop::Area, Crop::DisplayWindow ) );
+	addChild( new IntPlug( "areaSource", Gaffer::Plug::In, Crop::Area, Crop::Area, Crop::Format ) );
 	addChild( new Box2iPlug( "area" ) );
 	addChild( new FormatPlug( "format" ) );
 	addChild( new BoolPlug( "formatCenter" ) );

--- a/src/GafferImage/Crop.cpp
+++ b/src/GafferImage/Crop.cpp
@@ -38,6 +38,7 @@
 #include "GafferImage/Crop.h"
 #include "GafferImage/ImageAlgo.h"
 #include "GafferImage/Offset.h"
+#include "GafferImage/FormatPlug.h"
 
 using namespace Imath;
 using namespace IECore;
@@ -52,8 +53,10 @@ Crop::Crop( const std::string &name )
 	:   ImageProcessor( name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
-	addChild( new IntPlug( "areaSource", Gaffer::Plug::In, Crop::Custom, Crop::Custom, Crop::DisplayWindow ) );
+	addChild( new IntPlug( "areaSource", Gaffer::Plug::In, Crop::Area, Crop::Area, Crop::DisplayWindow ) );
 	addChild( new Box2iPlug( "area" ) );
+	addChild( new FormatPlug( "format" ) );
+	addChild( new BoolPlug( "formatCenter" ) );
 	addChild( new BoolPlug( "affectDataWindow", Gaffer::Plug::In, true ) );
 	addChild( new BoolPlug( "affectDisplayWindow", Gaffer::Plug::In, true ) );
 	addChild( new BoolPlug( "resetOrigin", Gaffer::Plug::In, true ) );
@@ -89,62 +92,82 @@ const Gaffer::IntPlug *Crop::areaSourcePlug() const
 
 Gaffer::Box2iPlug *Crop::areaPlug()
 {
-	return getChild<Box2iPlug>( g_firstPlugIndex+1 );
+	return getChild<Box2iPlug>( g_firstPlugIndex + 1 );
 }
 
 const Gaffer::Box2iPlug *Crop::areaPlug() const
 {
-	return getChild<Box2iPlug>( g_firstPlugIndex+1 );
+	return getChild<Box2iPlug>( g_firstPlugIndex + 1 );
+}
+
+GafferImage::FormatPlug *Crop::formatPlug()
+{
+	return getChild<FormatPlug>( g_firstPlugIndex + 2 );
+}
+
+const GafferImage::FormatPlug *Crop::formatPlug() const
+{
+	return getChild<FormatPlug>( g_firstPlugIndex + 2 );
+}
+
+Gaffer::BoolPlug *Crop::formatCenterPlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 3 );
+}
+
+const Gaffer::BoolPlug *Crop::formatCenterPlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 3 );
 }
 
 Gaffer::BoolPlug *Crop::affectDataWindowPlug()
 {
-	return getChild<BoolPlug>( g_firstPlugIndex+2 );
+	return getChild<BoolPlug>( g_firstPlugIndex + 4 );
 }
 
 const Gaffer::BoolPlug *Crop::affectDataWindowPlug() const
 {
-	return getChild<BoolPlug>( g_firstPlugIndex+2 );
+	return getChild<BoolPlug>( g_firstPlugIndex + 4 );
 }
 
 Gaffer::BoolPlug *Crop::affectDisplayWindowPlug()
 {
-	return getChild<BoolPlug>( g_firstPlugIndex+3 );
+	return getChild<BoolPlug>( g_firstPlugIndex + 5 );
 }
 
 const Gaffer::BoolPlug *Crop::affectDisplayWindowPlug() const
 {
-	return getChild<BoolPlug>( g_firstPlugIndex+3 );
+	return getChild<BoolPlug>( g_firstPlugIndex + 5 );
 }
 
 Gaffer::BoolPlug *Crop::resetOriginPlug()
 {
-	return getChild<BoolPlug>( g_firstPlugIndex + 4 );
+	return getChild<BoolPlug>( g_firstPlugIndex + 6 );
 }
 
 const Gaffer::BoolPlug *Crop::resetOriginPlug() const
 {
-	return getChild<BoolPlug>( g_firstPlugIndex + 4 );
+	return getChild<BoolPlug>( g_firstPlugIndex + 6 );
 }
 
 Gaffer::AtomicBox2iPlug *Crop::cropWindowPlug()
 {
-	return getChild<AtomicBox2iPlug>( g_firstPlugIndex + 5 );
+	return getChild<AtomicBox2iPlug>( g_firstPlugIndex + 7 );
 }
 
 const Gaffer::AtomicBox2iPlug *Crop::cropWindowPlug() const
 {
-	return getChild<AtomicBox2iPlug>( g_firstPlugIndex + 5 );
+	return getChild<AtomicBox2iPlug>( g_firstPlugIndex + 7 );
 }
 
 Gaffer::V2iPlug *Crop::offsetPlug()
 {
-	return getChild<V2iPlug>( g_firstPlugIndex + 6 );
+	return getChild<V2iPlug>( g_firstPlugIndex + 8 );
 }
 
 const Gaffer::V2iPlug *Crop::offsetPlug() const
 {
-	return getChild<V2iPlug>( g_firstPlugIndex + 6 );
+	return getChild<V2iPlug>( g_firstPlugIndex + 8 );
 }
 
 void Crop::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
@@ -152,8 +175,10 @@ void Crop::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs )
 	ImageProcessor::affects( input, outputs );
 
 	if(
-		areaPlug()->isAncestorOf( input ) ||
 		input == areaSourcePlug() ||
+		areaPlug()->isAncestorOf( input ) ||
+		input == formatPlug() ||
+		input == formatCenterPlug() ||
 		input == inPlug()->dataWindowPlug() ||
 		input == inPlug()->formatPlug()
 	)
@@ -164,7 +189,7 @@ void Crop::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs )
 	if(
 		input == cropWindowPlug() ||
 		input == affectDisplayWindowPlug() ||
-		input == resetOriginPlug() ||
+		offsetPlug()->isAncestorOf( input ) ||
 		input == inPlug()->formatPlug()
 	)
 	{
@@ -175,7 +200,7 @@ void Crop::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs )
 		input == cropWindowPlug() ||
 		input == affectDisplayWindowPlug() ||
 		input == affectDataWindowPlug() ||
-		input == resetOriginPlug() ||
+		offsetPlug()->isAncestorOf( input ) ||
 		input == inPlug()->dataWindowPlug()
 	)
 	{
@@ -184,6 +209,8 @@ void Crop::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs )
 
 	if(
 		input == affectDisplayWindowPlug() ||
+		input == areaSourcePlug() ||
+		input == formatCenterPlug() ||
 		input == resetOriginPlug() ||
 		input == cropWindowPlug()
 	)
@@ -208,7 +235,7 @@ void Crop::hashFormat( const GafferImage::ImagePlug *parent, const Gaffer::Conte
 
 	inPlug()->formatPlug()->hash( h );
 	cropWindowPlug()->hash( h );
-	resetOriginPlug()->hash( h );
+	offsetPlug()->hash( h );
 }
 
 GafferImage::Format Crop::computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const
@@ -221,13 +248,12 @@ GafferImage::Format Crop::computeFormat( const Gaffer::Context *context, const I
 	}
 
 	Imath::Box2i displayWindow = cropWindowPlug()->getValue();
-	if( resetOriginPlug()->getValue() )
-	{
-		displayWindow.max -= displayWindow.min;
-		displayWindow.min = V2i( 0 );
-	}
+	const Imath::V2i offset = offsetPlug()->getValue();
 
-	return Format( displayWindow, inPlug()->formatPlug()->getValue().getPixelAspect() );
+	displayWindow.max += offset;
+	displayWindow.min += offset;
+
+	return GafferImage::Format( displayWindow, inPlug()->formatPlug()->getValue().getPixelAspect() );
 }
 
 
@@ -239,23 +265,21 @@ void Crop::hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer::C
 	cropWindowPlug()->hash( h );
 	affectDataWindowPlug()->hash( h );
 	affectDisplayWindowPlug()->hash( h );
-	resetOriginPlug()->hash( h );
+	offsetPlug()->hash( h );
 }
 
 Imath::Box2i Crop::computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const
 {
 	Box2i result = inPlug()->dataWindowPlug()->getValue();
 	const Box2i cropWindow = cropWindowPlug()->getValue();
+	const V2i offset = offsetPlug()->getValue();
 	if( affectDataWindowPlug()->getValue() )
 	{
 		result = intersection( result, cropWindow );
 	}
 
-	if( affectDisplayWindowPlug()->getValue() && resetOriginPlug()->getValue() )
-	{
-		result.min -= cropWindow.min;
-		result.max -= cropWindow.min;
-	}
+	result.min += offset;
+	result.max += offset;
 
 	return result;
 }
@@ -270,14 +294,23 @@ void Crop::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context
 
 		switch ( areaSource )
 		{
-			case DataWindow:
+			case Crop::DataWindow:
 			{
 				inPlug()->dataWindowPlug()->hash( h );
 				break;
 			}
-			case DisplayWindow:
+			case Crop::DisplayWindow:
 			{
 				inPlug()->formatPlug()->hash( h );
+				break;
+			}
+			case Crop::Format:
+			{
+				formatPlug()->hash( h );
+				if( formatCenterPlug()->getValue() )
+				{
+					inPlug()->formatPlug()->hash( h );
+				}
 				break;
 			}
 			default:
@@ -292,6 +325,10 @@ void Crop::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context
 		affectDisplayWindowPlug()->hash( h );
 		resetOriginPlug()->hash( h );
 		cropWindowPlug()->hash( h );
+		if( areaSourcePlug()->getValue() == Crop::Format && formatCenterPlug()->getValue() )
+		{
+			inPlug()->formatPlug()->hash( h );
+		}
 	}
 }
 
@@ -304,14 +341,27 @@ void Crop::compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) 
 
 		switch ( areaSource )
 		{
-			case DataWindow:
+			case Crop::DataWindow:
 			{
 				cropWindow = inPlug()->dataWindowPlug()->getValue();
 				break;
 			}
-			case DisplayWindow:
+			case Crop::DisplayWindow:
 			{
 				cropWindow = inPlug()->formatPlug()->getValue().getDisplayWindow();
+				break;
+			}
+			case Crop::Format:
+			{
+				cropWindow = formatPlug()->getValue().getDisplayWindow();
+				if( formatCenterPlug()->getValue() )
+				{
+					const Imath::Box2i displayWindow = inPlug()->formatPlug()->getValue().getDisplayWindow();
+					Imath::V2i centerOffset( ( ( cropWindow.max - displayWindow.max ) + ( cropWindow.min - displayWindow.min ) ) / 2 );
+
+					cropWindow.min -= centerOffset;
+					cropWindow.max -= centerOffset;
+				}
 				break;
 			}
 			default:
@@ -326,9 +376,16 @@ void Crop::compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) 
 	else if( output->parent<Plug>() == offsetPlug() )
 	{
 		V2i offset( 0 );
-		if( affectDisplayWindowPlug()->getValue() && resetOriginPlug()->getValue() )
+		if( affectDisplayWindowPlug()->getValue() )
 		{
-			offset -= cropWindowPlug()->getValue().min;
+			if( resetOriginPlug()->getValue() )
+			{
+				offset -= cropWindowPlug()->getValue().min;
+			}
+			else if( areaSourcePlug()->getValue() == Crop::Format && formatCenterPlug()->getValue() )
+			{
+				offset -= cropWindowPlug()->getValue().min - formatPlug()->getValue().getDisplayWindow().min;
+			}
 		}
 		static_cast<IntPlug *>( output )->setValue(
 			output == offsetPlug()->getChild( 0 ) ? offset[0] : offset[1]

--- a/src/GafferImageBindings/CropBinding.cpp
+++ b/src/GafferImageBindings/CropBinding.cpp
@@ -53,7 +53,8 @@ void bindCrop()
 	scope s = GafferBindings::DependencyNodeClass<Crop>();
 
 	enum_<Crop::AreaSource>( "AreaSource" )
-		.value( "Custom", Crop::Custom )
+		.value( "Area", Crop::Area )
+		.value( "Format", Crop::Format )
 		.value( "DataWindow", Crop::DataWindow )
 		.value( "DisplayWindow", Crop::DisplayWindow )
 	;

--- a/startup/GafferImage/cropCompatibility.py
+++ b/startup/GafferImage/cropCompatibility.py
@@ -1,0 +1,42 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import GafferImage
+
+# Backwards compatibility for Crop.AreaSource.Custom being renamed
+# to Crop.AreaSource.Area
+
+GafferImage.Crop.AreaSource.Custom = GafferImage.Crop.AreaSource.Area


### PR DESCRIPTION
This PR adds an extra option to the Crop node to specify a Format to crop to.
It also adds a checkbox that allows the previous DisplayWindow to be centered in the new Format.

I have a couple of questions on this:

* I have renamed the enum in C++ to add Area to the end of each name, as just Format was clashing. I haven't added this to the Python bindings, as the Python enum values are referenced using GafferImage.Crop.AreaSource.Format, while the C++ enum values are referenced directly.
* There is an option for a user to select Format and then select Custom from the Format menu. Can I suggest a UI option to control whether Custom is available in the Format drop-down list.

Other than that, all feedback welcome.