### PR TITLE
Node : Fix disconnect-during-unparent bug.

### DIFF
--- a/python/GafferImageTest/ImageStatsTest.py
+++ b/python/GafferImageTest/ImageStatsTest.py
@@ -159,6 +159,15 @@ class ImageStatsTest( GafferImageTest.ImageTestCase ) :
 		self.__assertColour( s["min"].getValue(), IECore.Color4f( 0.25, 0, 0, 0.5 ) )
 		self.__assertColour( s["max"].getValue(), IECore.Color4f( 0.5, 0.5, 0, 0.75 ) )
 
+	def testMin( self ) :
+
+		c = GafferImage.Constant()
+		s = GafferImage.ImageStats()
+		s["in"].setInput( c["out"] )
+		s["regionOfInterest"].setValue( c["out"]["format"].getValue().getDisplayWindow() )
+
+		self.assertEqual( s["max"]["r"].getValue(), 0 )
+
 	def __assertColour( self, colour1, colour2 ) :
 		for i in range( 0, 4 ):
 			self.assertEqual( "%.4f" % colour2[i], "%.4f" % colour1[i] )

--- a/python/GafferImageTest/ImageTestCase.py
+++ b/python/GafferImageTest/ImageTestCase.py
@@ -67,7 +67,7 @@ class ImageTestCase( GafferTest.TestCase ) :
 				tileOrigin.x += GafferImage.ImagePlug.tileSize()
 			tileOrigin.y += GafferImage.ImagePlug.tileSize()
 
-	def assertImagesEqual( self, imageA, imageB, maxDifference = 0, ignoreMetadata = False, ignoreDataWindow = False ) :
+	def assertImagesEqual( self, imageA, imageB, maxDifference = 0.0, ignoreMetadata = False, ignoreDataWindow = False ) :
 
 		self.assertEqual( imageA["format"].getValue(), imageB["format"].getValue() )
 		if not ignoreDataWindow :
@@ -91,14 +91,13 @@ class ImageTestCase( GafferTest.TestCase ) :
 		stats["channels"].setValue( IECore.StringVectorData( [ "R", "G", "B", "A" ] ) )
 
 		if "R" in imageA["channelNames"].getValue() :
-			self.assertLess( stats["max"]["r"].getValue(), maxDifference )
+			self.assertLessEqual( stats["max"]["r"].getValue(), maxDifference )
 
 		if "G" in imageA["channelNames"].getValue() :
-			self.assertLess( stats["max"]["g"].getValue(), maxDifference )
+			self.assertLessEqual( stats["max"]["g"].getValue(), maxDifference )
 
 		if "B" in imageA["channelNames"].getValue() :
-			self.assertLess( stats["max"]["b"].getValue(), maxDifference )
+			self.assertLessEqual( stats["max"]["b"].getValue(), maxDifference )
 
 		if "A" in imageA["channelNames"].getValue() :
-			self.assertLess( stats["max"]["a"].getValue(), maxDifference )
-
+			self.assertLessEqual( stats["max"]["a"].getValue(), maxDifference )

--- a/python/GafferImageTest/ImageTestCase.py
+++ b/python/GafferImageTest/ImageTestCase.py
@@ -42,6 +42,31 @@ import GafferImage
 
 class ImageTestCase( GafferTest.TestCase ) :
 
+	def assertImageHashesEqual( self, imageA, imageB ) :
+
+		self.assertEqual( imageA["format"].hash(), imageB["format"].hash() )
+		self.assertEqual( imageA["dataWindow"].hash(), imageB["dataWindow"].hash() )
+		self.assertEqual( imageA["metadata"].hash(), imageB["metadata"].hash() )
+		self.assertEqual( imageA["channelNames"].hash(), imageB["channelNames"].hash() )
+
+		dataWindow = imageA["dataWindow"].getValue()
+		self.assertEqual( dataWindow, imageB["dataWindow"].getValue() )
+
+		channelNames = imageA["channelNames"].getValue()
+		self.assertEqual( channelNames, imageB["channelNames"].getValue() )
+
+		tileOrigin = GafferImage.ImagePlug.tileOrigin( dataWindow.min )
+		while tileOrigin.y < dataWindow.max.y :
+			tileOrigin.x = GafferImage.ImagePlug.tileOrigin( dataWindow.min ).x
+			while tileOrigin.x < dataWindow.max.x :
+				for channelName in channelNames :
+					self.assertEqual(
+						imageA.channelDataHash( channelName, tileOrigin ),
+						imageB.channelDataHash( channelName, tileOrigin )
+					)
+				tileOrigin.x += GafferImage.ImagePlug.tileSize()
+			tileOrigin.y += GafferImage.ImagePlug.tileSize()
+
 	def assertImagesEqual( self, imageA, imageB, maxDifference = 0, ignoreMetadata = False, ignoreDataWindow = False ) :
 
 		self.assertEqual( imageA["format"].getValue(), imageB["format"].getValue() )

--- a/python/GafferImageTest/TextTest.py
+++ b/python/GafferImageTest/TextTest.py
@@ -151,5 +151,17 @@ class TextTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( bottomDW.size().y, centerDW.size().y )
 		self.assertEqual( centerDW.size().y, topDW.size().y )	
 
+	def testUnparenting( self ) :
+
+		t1 = GafferImage.Text()
+		t2 = GafferImage.Text()
+
+		s = Gaffer.ScriptNode()
+		s.addChild( t2 )
+		s.removeChild( t2 )
+
+		self.assertImageHashesEqual( t1["out"], t2["out"] )
+		self.assertImagesEqual( t1["out"], t2["out"] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/Node.cpp
+++ b/src/Gaffer/Node.cpp
@@ -39,6 +39,7 @@
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/Metadata.h"
 
+using namespace std;
 using namespace Gaffer;
 
 size_t Node::g_firstPlugIndex;
@@ -134,29 +135,39 @@ bool Node::acceptsInput( const Plug *plug, const Plug *inputPlug ) const
 
 void Node::parentChanging( Gaffer::GraphComponent *newParent )
 {
-	// if we're losing our parent then remove all connections first.
-	// this must be done here rather than from parentChangedSignal()
+	// If we're losing our parent then remove all external connections
+	// first. This must be done here rather than from parentChangedSignal()
 	// because we need a current parent for the operation to be
 	// undoable.
 
 	if( !newParent )
 	{
-		// because the InputGenerator code removes plugs when inputs
-		// are removed, we have to take a copy of the current children
-		// and iterate over that - otherwise our iterators are invalidated
-		// and we get crashes. if we see further problems caused by the
-		// InputGenerator creating plugs whenever it sees fit, we should
-		// consider an API where they are instead asked for explicitly
-		// when needed.
-		ChildContainer frozenChildren = children();
-		for( InputPlugIterator it( frozenChildren ); it!=it.end(); it++ )
+		// Because disconnecting a plug might cause graph changes
+		// via Node::plugInputChangedSignal(), we use a two phase
+		// process to avoid such changes invalidating our
+		// iterators.
+		vector<PlugPtr> toDisconnect;
+		for( RecursivePlugIterator it( this ); it!=it.end(); ++it )
 		{
-			(*it)->setInput( 0 );
+			if( Plug *input = (*it)->getInput<Plug>() )
+			{
+				if( !this->isAncestorOf( input ) )
+				{
+					toDisconnect.push_back( *it );
+				}
+			}
+			for( Plug::OutputContainer::const_iterator oIt = (*it)->outputs().begin(), oeIt = (*it)->outputs().end(); oIt != oeIt; ++oIt )
+			{
+				if( !this->isAncestorOf( *oIt ) )
+				{
+					toDisconnect.push_back( *oIt );
+				}
+			}
 		}
 
-		for( OutputPlugIterator it( frozenChildren ); it!=it.end(); it++ )
+		for( vector<PlugPtr>::const_iterator it = toDisconnect.begin(), eIt = toDisconnect.end(); it != eIt; ++it )
 		{
-			(*it)->removeOutputs();
+			(*it)->setInput( NULL );
 		}
 	}
 }

--- a/src/GafferImage/ImageStats.cpp
+++ b/src/GafferImage/ImageStats.cpp
@@ -36,7 +36,6 @@
 
 #include "Gaffer/TypedPlug.h"
 #include "Gaffer/BoxPlug.h"
-#include "Gaffer/Context.h"
 #include "Gaffer/ScriptNode.h"
 
 #include "GafferImage/ImageStats.h"
@@ -300,11 +299,6 @@ void ImageStats::compute( ValuePlug *output, const Context *context ) const
 	}
 
 	const int channelIndex = colorIndex( channelName );
-
-	// Set up the execution context.
-	ContextPtr tmpContext = new Context( *context, Context::Borrowed );
-	tmpContext->set( ImagePlug::channelNameContextName, channelName );
-	Context::Scope scopedContext( tmpContext.get() );
 
 	// Loop over the ROI and compute the min, max and average channel values and then set our outputs.
 	Sampler s( inPlug(), channelName, regionOfInterest );

--- a/src/GafferImage/ImageStats.cpp
+++ b/src/GafferImage/ImageStats.cpp
@@ -309,8 +309,9 @@ void ImageStats::compute( ValuePlug *output, const Context *context ) const
 	// Loop over the ROI and compute the min, max and average channel values and then set our outputs.
 	Sampler s( inPlug(), channelName, regionOfInterest );
 
-	float min = std::numeric_limits<float>::max();
-	float max = std::numeric_limits<float>::min();
+	float min = Imath::limits<float>::max();
+	float max = Imath::limits<float>::min();
+
 	float average = 0.f;
 
 	double sum = 0.;


### PR DESCRIPTION
We do want to disconnect the node from the external graph, but we must leave all internal connections intact. This has been made more critical by compound nodes like Text, which use internal nodes and connections extensively as part of their implementation.

This also contains several GafferImage fixes needed for proper verification that the Text node is fixed by the main commit.