### PR TITLE
Context processor optimizations

### DIFF
--- a/include/Gaffer/ContextProcessor.h
+++ b/include/Gaffer/ContextProcessor.h
@@ -83,6 +83,8 @@ class ContextProcessor : public BaseType
 
 	private :
 
+		static const ValuePlug *correspondingDescendant( const ValuePlug *plug, const ValuePlug *plugAncestor, const ValuePlug *oppositeAncestor );
+
 		/// Returns the input corresponding to the output and vice versa.
 		const ValuePlug *oppositePlug( const ValuePlug *plug ) const;
 

--- a/include/Gaffer/ContextProcessor.inl
+++ b/include/Gaffer/ContextProcessor.inl
@@ -198,23 +198,34 @@ void ContextProcessor<BaseType>::compute( ValuePlug *output, const Context *cont
 template<typename BaseType>
 const ValuePlug *ContextProcessor<BaseType>::oppositePlug( const ValuePlug *plug ) const
 {
-	std::string path = plug->relativeName( this );
-	std::string oppositePath;
-
-	if( 0 == path.compare( 0, 2, "in" ) )
+	const static IECore::InternedString inName( "in" );
+	const static IECore::InternedString outName( "out" );
+	
+	if( plug->direction() == Plug::Out )
 	{
-		oppositePath = "out" + std::string( path, 2 );
+		const ValuePlug *inPlug = BaseType::template getChild<ValuePlug>( inName );
+		if( plug->getName() == outName )
+		{
+			return inPlug;
+		}
+		if( inPlug )
+		{
+			return inPlug->getChild<ValuePlug>( plug->getName() );
+		}
 	}
-	else if( 0 == path.compare( 0, 3, "out" ) )
+	else
 	{
-		oppositePath = "in" + std::string( path, 3 );
+		const ValuePlug *outPlug = BaseType::template getChild<ValuePlug>( outName );
+		if( plug->getName() == inName )
+		{
+			return outPlug;
+		}
+		if( outPlug )
+		{
+			return outPlug->getChild<ValuePlug>( plug->getName() );
+		}
 	}
-
-	if( oppositePath.size() )
-	{
-		return BaseType::template descendant<ValuePlug>( oppositePath );
-	}
-	return 0;
+	return NULL;
 }
 
 } // namespace Gaffer

--- a/include/Gaffer/ContextProcessor.inl
+++ b/include/Gaffer/ContextProcessor.inl
@@ -157,7 +157,7 @@ void ContextProcessor<BaseType>::hash( const ValuePlug *output, const Context *c
 	{
 		if( enabledPlug()->getValue() )
 		{
-			ContextPtr modifiedContext = new Context( *context );
+			ContextPtr modifiedContext = new Context( *context, Context::Borrowed );
 			processContext( modifiedContext.get() );
 			Context::Scope scopedContext( modifiedContext.get() );
 			h = input->hash();
@@ -180,7 +180,7 @@ void ContextProcessor<BaseType>::compute( ValuePlug *output, const Context *cont
 	{
 		if( enabledPlug()->getValue() )
 		{
-			ContextPtr modifiedContext = new Context( *context );
+			ContextPtr modifiedContext = new Context( *context, Context::Borrowed );
 			processContext( modifiedContext.get() );
 			Context::Scope scopedContext( modifiedContext.get() );
 			output->setFrom( input );


### PR DESCRIPTION
Here are two ContextProcessor optimizations, both of which shaved 10 seconds of a 90 second scene traversal at the start of a render.