### PR TITLE
Empty data window fixes

### DIFF
--- a/include/GafferImage/Format.inl
+++ b/include/GafferImage/Format.inl
@@ -37,6 +37,8 @@
 #ifndef GAFFERIMAGE_FORMAT_INL
 #define GAFFERIMAGE_FORMAT_INL
 
+#include "GafferImage/ImageAlgo.h"
+
 namespace GafferImage
 {
 
@@ -124,6 +126,11 @@ inline Imath::V2i Format::fromEXRSpace( const Imath::V2i &exrSpace ) const
 
 inline Imath::Box2i Format::fromEXRSpace( const Imath::Box2i &exrSpace ) const
 {
+	if( exrSpace.isEmpty() )
+	{
+		return Imath::Box2i();
+	}
+
 	return Imath::Box2i(
 		Imath::V2i( exrSpace.min.x, fromEXRSpace( exrSpace.max.y ) ),
 		Imath::V2i( exrSpace.max.x + 1, fromEXRSpace( exrSpace.min.y ) + 1 )
@@ -143,6 +150,11 @@ inline Imath::V2i Format::toEXRSpace( const Imath::V2i &internalSpace ) const
 
 inline Imath::Box2i Format::toEXRSpace( const Imath::Box2i &internalSpace ) const
 {
+	if( empty( internalSpace ) )
+	{
+		return Imath::Box2i();
+	}
+
 	return Imath::Box2i(
 		Imath::V2i( internalSpace.min.x, toEXRSpace( internalSpace.max.y - 1 ) ),
 		Imath::V2i( internalSpace.max.x - 1, toEXRSpace( internalSpace.min.y ) )

--- a/include/GafferImage/Sampler.inl
+++ b/include/GafferImage/Sampler.inl
@@ -58,8 +58,12 @@ float Sampler::sample( int x, int y )
 	{
 		return 0.0f;
 	}
-	else if( m_boundingMode == Clamp )
+	else
 	{
+		if( empty( m_dataWindow ) )
+		{
+			return 0.0f;
+		}
 		p = clamp( p, m_dataWindow );
 	}
 

--- a/python/GafferImageTest/FormatTest.py
+++ b/python/GafferImageTest/FormatTest.py
@@ -149,7 +149,10 @@ class FormatTest( GafferImageTest.ImageTestCase ) :
 			b.extendBy( IECore.V2i( int( random.uniform( -500, 500 ) ), int( random.uniform( -500, 500 ) ) ) )
 
 			bDown = f.toEXRSpace( b )
-			self.assertEqual( f.fromEXRSpace( bDown ), b )
+			if not GafferImage.empty( b ) :
+				self.assertEqual( f.fromEXRSpace( bDown ), b )
+			else :
+				self.assertEqual( f.fromEXRSpace( bDown ), IECore.Box2i() )
 
 	def testDisplayWindowCoordinateSystemTransforms( self ) :
 
@@ -208,6 +211,13 @@ class FormatTest( GafferImageTest.ImageTestCase ) :
 
 		f = GafferImage.Format( IECore.Box2i( IECore.V2i( 10 ), IECore.V2i( 20 ) ) )
 		self.assertEqual( str( f ), "(10 10) - (20 20)" )
+
+	def testEmptyBoxCoordinateSystemTransforms( self ) :
+
+		f = GafferImage.Format( 100, 200 )
+		self.assertEqual( f.toEXRSpace( IECore.Box2i() ), IECore.Box2i() )
+		self.assertEqual( f.toEXRSpace( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 0 ) ) ), IECore.Box2i() )
+		self.assertEqual( f.fromEXRSpace( IECore.Box2i() ), IECore.Box2i() )
 
 	def tearDown( self ) :
 

--- a/python/GafferImageTest/ImageTestCase.py
+++ b/python/GafferImageTest/ImageTestCase.py
@@ -101,3 +101,20 @@ class ImageTestCase( GafferTest.TestCase ) :
 
 		if "A" in imageA["channelNames"].getValue() :
 			self.assertLessEqual( stats["max"]["a"].getValue(), maxDifference )
+
+	## Returns an image node with an empty data window. This is useful in
+	# verifying that nodes deal correctly with such inputs.
+	def emptyImage( self ) :
+
+		image = IECore.ImagePrimitive( IECore.Box2i(), IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 100 ) ) )
+		image["R"] = IECore.PrimitiveVariable( IECore.PrimitiveVariable.Interpolation.Varying, IECore.FloatVectorData() )
+		image["G"] = IECore.PrimitiveVariable( IECore.PrimitiveVariable.Interpolation.Varying, IECore.FloatVectorData() )
+		image["B"] = IECore.PrimitiveVariable( IECore.PrimitiveVariable.Interpolation.Varying, IECore.FloatVectorData() )
+		image["A"] = IECore.PrimitiveVariable( IECore.PrimitiveVariable.Interpolation.Varying, IECore.FloatVectorData() )
+
+		result = GafferImage.ObjectToImage()
+		result["object"].setValue( image )
+
+		self.assertEqual( result["out"]["dataWindow"].getValue(), IECore.Box2i() )
+
+		return result

--- a/python/GafferImageTest/ResampleTest.py
+++ b/python/GafferImageTest/ResampleTest.py
@@ -50,7 +50,11 @@ class ResampleTest( GafferImageTest.ImageTestCase ) :
 
 	def testDataWindow( self ) :
 
+		c = GafferImage.Constant()
+		c["color"].setValue( IECore.Color4f( 1 ) )
+
 		r = GafferImage.Resample()
+		r["in"].setInput( c["out"] )
 		r["dataWindow"].setValue(
 			IECore.Box2f(
 				IECore.V2f( 10.5, 11.5 ),

--- a/python/GafferImageTest/ResizeTest.py
+++ b/python/GafferImageTest/ResizeTest.py
@@ -231,5 +231,15 @@ class ResizeTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( r["out"]["format"].getValue(), GafferImage.Format( 100, 100 ) )
 		self.assertEqual( r["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 100 ) ) )
 
+	def testEmptyDataWindow( self ) :
+
+		e = self.emptyImage()
+
+		r = GafferImage.Resize()
+		r["in"].setInput( e["out"] )
+		r["format"].setValue( GafferImage.Format( 2121, 1012 ) )
+
+		self.assertEqual( r["out"]["dataWindow"].getValue(), IECore.Box2i() )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageTest/SamplerTest.py
+++ b/python/GafferImageTest/SamplerTest.py
@@ -195,5 +195,11 @@ class SamplerTest( GafferImageTest.ImageTestCase ) :
 		self.assertNotEqual( sampler2.hash(), sampler3.hash() )
 		self.assertNotEqual( sampler3.hash(), sampler1.hash() )
 
+	def testClampModeWithEmptyDataWindow( self ) :
+
+		empty = self.emptyImage()
+		sampler = GafferImage.Sampler( empty["out"], "R", empty["out"]["format"].getValue().getDisplayWindow(), boundingMode = GafferImage.Sampler.BoundingMode.Clamp )
+		self.assertEqual( sampler.sample( 0, 0 ), 0.0 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferImage/Resample.cpp
+++ b/src/GafferImage/Resample.cpp
@@ -448,6 +448,19 @@ Imath::Box2i Resample::computeDataWindow( const Gaffer::Context *context, const 
 {
 	const Box2i srcDataWindow = inPlug()->dataWindowPlug()->getValue();
 	const Box2f dstDataWindow = dataWindowPlug()->getValue();
+	if( empty( srcDataWindow ) || dstDataWindow.isEmpty() )
+	{
+		// This is a meaningless transformation, so we output an empty data
+		// window. It is perhaps a little odd that you can request a specific
+		// (non-empty) data window via dataWindowPlug(), but then be
+		// overruled by an empty data window from inPlug()->dataWindowPlug().
+		// This is perhaps an indication that the API for Resample is a little
+		// unnatural, and it'd be better to use a scale/translate pair to
+		// define the transformation rather than using a target window. Using
+		// scale/translate would also make concatenation of Resample nodes
+		// more natural, so perhaps we'll need to go that way at some point.
+		return Box2i();
+	}
 
 	Box2f expandedDataWindow = dstDataWindow;
 	if( expandDataWindowPlug()->getValue() )


### PR DESCRIPTION
This fixes a few bugs triggered by empty data windows. We're passing empty data windows more now thanks to the ImageReader missing frame modes, so any such bugs are coming to the surface.