### PR TITLE
Build improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
     - if [ -n "$COMPILER_VERSION" ]; then export CXX="${CXX}-${COMPILER_VERSION}"; fi
 
 script:
-    - scons -j 2 install CXX=$CXX ENV_VARS_TO_IMPORT=PATH RMAN_ROOT=$DELIGHT
+    - scons -j 2 install CXX=$CXX CXXSTD=$CXXSTD ENV_VARS_TO_IMPORT=PATH RMAN_ROOT=$DELIGHT
     # Preload libSegFault when running tests, so we get stack
     # traces from any crashes.
     - export LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
@@ -57,10 +57,13 @@ compiler:
     - clang
 
 env:
-    - COMPILER_VERSION=
-    - COMPILER_VERSION=4.8
+    - COMPILER_VERSION= CXXSTD=c++98
+    - COMPILER_VERSION=4.8 CXXSTD=c++98
+    - COMPILER_VERSION=4.8 CXXSTD=c++11
 
 matrix:
     exclude:
         - compiler: clang
-          env: COMPILER_VERSION=4.8
+          env: COMPILER_VERSION=4.8 CXXSTD=c++98
+        - compiler: clang
+          env: COMPILER_VERSION=4.8 CXXSTD=c++11

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,13 @@ os:
 
 addons:
   apt:
+    sources:
+        - ubuntu-toolchain-r-test
     packages:
         - inkscape
         - doxygen
+        - gcc-4.8
+        - g++-4.8
 
 before_install:
     - export DISPLAY=:99.0
@@ -25,6 +29,7 @@ install:
     - export DL_SHADERS_PATH=$DELIGHT/shaders
     - export DL_DISPLAYS_PATH=$DELIGHT/displays
     - export PATH=$DELIGHT/bin:$PATH
+    - if [ -n "$COMPILER_VERSION" ]; then export CXX="${CXX}-${COMPILER_VERSION}"; fi
 
 script:
     - scons -j 2 install CXX=$CXX ENV_VARS_TO_IMPORT=PATH RMAN_ROOT=$DELIGHT
@@ -50,3 +55,12 @@ script:
 compiler:
     - gcc
     - clang
+
+env:
+    - COMPILER_VERSION=
+    - COMPILER_VERSION=4.8
+
+matrix:
+    exclude:
+        - compiler: clang
+          env: COMPILER_VERSION=4.8

--- a/SConstruct
+++ b/SConstruct
@@ -273,13 +273,22 @@ if env["PLATFORM"] == "darwin" :
 
 elif env["PLATFORM"] == "posix" :
 
-	# gcc 4.1.2 in conjunction with boost::flat_map produces crashes when
-	# using the -fstrict-aliasing optimisation (which defaults to on with -O2),
-	# so we turn the optimisation off here, only for that specific gcc version.
 	if "g++" in os.path.basename( env["CXX"] ) :
+
 		gccVersion = subprocess.Popen( [ env["CXX"], "-dumpversion" ], env=env["ENV"], stdout=subprocess.PIPE ).stdout.read().strip()
-		if gccVersion == "4.1.2" :
+		gccVersion = [ int( v ) for v in gccVersion.split( "." ) ]
+
+		# GCC 4.1.2 in conjunction with boost::flat_map produces crashes when
+		# using the -fstrict-aliasing optimisation (which defaults to on with -O2),
+		# so we turn the optimisation off here, only for that specific GCC version.
+		if gccVersion == [ 4, 1, 2 ] :
 			env.Append( CXXFLAGS = [ "-fno-strict-aliasing" ] )
+
+		# GCC prior to 4.8 emits spurious "assuming signed overflow does not occur"
+		# warnings, typically triggered by the comparisons in Box3f::isEmpty().
+		# Downgrade these back to warning status.
+		if gccVersion[0] == 4 and gccVersion[1] < 8 :
+			env.Append( CXXFLAGS = [ "-Wno-error=strict-overflow" ] )
 
 	env["GAFFER_PLATFORM"] = "linux"
 

--- a/SConstruct
+++ b/SConstruct
@@ -88,6 +88,12 @@ options.Add(
 )
 
 options.Add(
+	"CXXSTD",
+	"The C++ standard to build against.",
+	"c++98",
+)
+
+options.Add(
 	"LINKFLAGS",
 	"The extra flags to pass to the C++ linker during compilation.",
 	"",
@@ -291,6 +297,8 @@ elif env["PLATFORM"] == "posix" :
 			env.Append( CXXFLAGS = [ "-Wno-error=strict-overflow" ] )
 
 	env["GAFFER_PLATFORM"] = "linux"
+
+env.Append( CXXFLAGS = [ "-std=$CXXSTD" ] )
 
 if env["BUILD_CACHEDIR"] != "" :
 	CacheDir( env["BUILD_CACHEDIR"] )

--- a/src/GafferImage/Offset.cpp
+++ b/src/GafferImage/Offset.cpp
@@ -58,7 +58,7 @@ size_t bufferIndex( const V2i &p, const Box2i &b )
 {
 	assert( contains( b, p ) );
 	return
-		( p.y - b.min.y ) * ( b.max.x - b.min.x ) +
+		( p.y - b.min.y ) * b.size().x +
 		( p.x - b.min.x );
 }
 

--- a/src/GafferRenderMan/RenderManShader.cpp
+++ b/src/GafferRenderMan/RenderManShader.cpp
@@ -133,7 +133,7 @@ void RenderManShader::loadShader( const std::string &shaderName, bool keepExisti
 
 	// A metadata option to override the shader type.
 	// This can be useful to work around some 3delight issues.
-	// For example, if you want to call illuminance() in a coshader, you need to add a 
+	// For example, if you want to call illuminance() in a coshader, you need to add a
 	// dummy surface() method, but you still want the type to be "ri:shader".
 	ConstCompoundDataPtr annotations = shader->blindData()->member<CompoundData>( "ri:annotations" );
 	if( annotations )
@@ -417,6 +417,9 @@ static void loadCoshaderArrayParameter( Gaffer::Plug *parametersPlug, const std:
 
 	if( existingPlug )
 	{
+		// Must take a copy as the contents of `existingPlug->children()` is
+		// modified each time we transfer a child over with plug->addChild() below.
+		GraphComponent::ChildContainer existingChildren = existingPlug->children();
 		for( size_t i = 0, e = std::min( existingPlug->children().size(), maxSize ); i < e; ++i )
 		{
 			if( i < plug->children().size() )
@@ -425,7 +428,7 @@ static void loadCoshaderArrayParameter( Gaffer::Plug *parametersPlug, const std:
 			}
 			else
 			{
-				plug->addChild( existingPlug->getChild<Plug>( i ) );
+				plug->addChild( existingChildren[i] );
 			}
 		}
 	}


### PR DESCRIPTION
I wasn't happy with the contortions @HughMacdonald was having to go through to avoid GCC's spurious `"error: assuming signed overflow does not occur"` problem in #1517. In this PR I've taken an alternative approach, downgrading that particular warning back to normal warning status (after it was promoted to error status by `-Werror`). I'm convinced that the code triggering the warnings is perfectly reasonable, and I've also verified that the warnings are not issued in GCC 4.8 anyway. I've also added GCC 4.8 to the Travis test setup for good measure, so we now also test with the correct compiler version for VFXPlatform 2016.