### PR TITLE
Add support for lldb on OSX for debugging

### DIFF
--- a/bin/gaffer
+++ b/bin/gaffer
@@ -155,7 +155,11 @@ fi
 ##########################################################################
 
 if [[ -n $GAFFER_DEBUG ]] ; then 
-	exec gdb --args $GAFFER_ROOT/bin/python $GAFFER_ROOT/bin/gaffer.py "$@"
+	if [[ -z $GAFFER_DEBUGGER ]] ; then
+		export GAFFER_DEBUGGER="gdb --args"
+	fi
+
+	exec $GAFFER_DEBUGGER $GAFFER_ROOT/bin/python $GAFFER_ROOT/bin/gaffer.py "$@"
 else
 	exec $GAFFER_ROOT/bin/python $GAFFER_ROOT/bin/gaffer.py "$@"
 fi


### PR DESCRIPTION
This adds support for `lldb` as the debugger on OSX.

I wasn't sure if some people (@johnhaddon?) use gdb on OSX, in which case I would suggest instead that we could only use `lldb` if `$GAFFER_DEBUG = "lldb"`, otherwise use gdb.