### PR TITLE
GafferDispatch : Rename old requirements child plugs on load.

### DIFF
--- a/python/GafferDispatchTest/ExecutableNodeTest.py
+++ b/python/GafferDispatchTest/ExecutableNodeTest.py
@@ -394,5 +394,18 @@ class ExecutableNodeTest( GafferTest.TestCase ) :
 			self.assertEqual( writer.preTasks( c ), [ GafferDispatch.ExecutableNode.Task( preWriter, c ) ] )
 			self.assertEqual( writer.postTasks( c ), [ GafferDispatch.ExecutableNode.Task( postWriter, c ) ] )
 
+	def testLoadNetworkFromVersion0_19( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( os.path.dirname( __file__ ) + "/scripts/version-0.19.0.0.gfr" )
+		s.load()
+
+		self.assertEqual( len( s["TaskList"]["preTasks"] ), 2 )
+		self.assertEqual( s["TaskList"]["preTasks"][0].getName(), "preTask0" )
+		self.assertEqual( s["TaskList"]["preTasks"][1].getName(), "preTask1" )
+
+		self.assertTrue( s["TaskList"]["preTasks"][0].getInput().isSame( s["SystemCommand"]["task"] ) )
+		self.assertTrue( s["TaskList"]["preTasks"][1].getInput() is None )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferDispatchTest/scripts/version-0.19.0.0.gfr
+++ b/python/GafferDispatchTest/scripts/version-0.19.0.0.gfr
@@ -1,0 +1,15 @@
+import Gaffer
+import IECore
+
+__children = {}
+
+__children["SystemCommand"] = Gaffer.SystemCommand( "SystemCommand" )
+parent.addChild( __children["SystemCommand"] )
+__children["TaskList"] = Gaffer.TaskList( "TaskList" )
+parent.addChild( __children["TaskList"] )
+__children["TaskList"]["requirements"].addChild( Gaffer.ExecutableNode.RequirementPlug( "requirement1", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["TaskList"]["requirements"]["requirement0"].setInput( __children["SystemCommand"]["requirement"] )
+
+
+del __children
+


### PR DESCRIPTION
Although not preventing anything from working, it was distracting to have children of the "preTasks" plug named "requirement1" etc. We now rename such plugs as they are added to the preTasks array plug.