### PR TITLE
ImageView improvements

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -592,7 +592,7 @@ libraries = {
 			"LIBS" : [ "IECoreGL$CORTEX_LIB_SUFFIX", "Gaffer", "GafferImage", "GafferUI", "GLEW$GLEW_LIB_SUFFIX" ],
 		},
 		"pythonEnvAppends" : {
-			"LIBS" : [ "GafferUI", "GafferImageUI" ],
+			"LIBS" : [ "GafferUI", "GafferImage", "GafferImageUI" ],
 		},
 	},
 

--- a/include/GafferImage/ImageAlgo.inl
+++ b/include/GafferImage/ImageAlgo.inl
@@ -499,6 +499,10 @@ void parallelProcessTiles( const ImagePlug *imagePlug, ThreadableFunctor &functo
 	if( empty( processWindow ) )
 	{
 		processWindow = imagePlug->dataWindowPlug()->getValue();
+		if( empty( processWindow ) )
+		{
+			return;
+		}
 	}
 
 	const Imath::V2i tilesOrigin = ImagePlug::tileOrigin( processWindow.min );
@@ -515,6 +519,10 @@ void parallelProcessTiles( const ImagePlug *imagePlug, const std::vector<std::st
 	if( empty( processWindow ) )
 	{
 		processWindow = imagePlug->dataWindowPlug()->getValue();
+		if( empty( processWindow ) )
+		{
+			return;
+		}
 	}
 
 	const Imath::V2i tilesOrigin = ImagePlug::tileOrigin( processWindow.min );
@@ -531,6 +539,10 @@ void parallelGatherTiles( const ImagePlug *imagePlug, TileFunctor &tileFunctor, 
 	if( empty( processWindow ) )
 	{
 		processWindow = imagePlug->dataWindowPlug()->getValue();
+		if( empty( processWindow ) )
+		{
+			return;
+		}
 	}
 
 	const Imath::V2i tilesOrigin = ImagePlug::tileOrigin( processWindow.min );
@@ -557,12 +569,10 @@ void parallelGatherTiles( const ImagePlug *imagePlug, TileFunctor &tileFunctor, 
 template <class TileFunctor, class GatherFunctor>
 void parallelGatherTiles( const ImagePlug *imagePlug, const std::vector<std::string> &channelNames, TileFunctor &tileFunctor, GatherFunctor &gatherFunctor, const Imath::Box2i &window, TileOrder tileOrder )
 {
-
 	Imath::Box2i processWindow = window;
 	if( empty( processWindow ) )
 	{
 		processWindow = imagePlug->dataWindowPlug()->getValue();
-
 		if( empty( processWindow ) )
 		{
 			return;

--- a/include/GafferImageUI/ImageGadget.h
+++ b/include/GafferImageUI/ImageGadget.h
@@ -128,7 +128,10 @@ class ImageGadget : public GafferUI::Gadget
 		// We only pull on the m_image plug lazily when
 		// we need something, and store the result for later
 		// use. These flags and the member variables below
-		// are used to implement this caching.
+		// are used to implement this caching. Note that the
+		// access functions do nothing to handle errors during
+		// computation, so exceptions must be handled by the
+		// caller.
 		enum DirtyFlags
 		{
 			NothingDirty = 0,

--- a/include/GafferImageUI/ImageGadget.h
+++ b/include/GafferImageUI/ImageGadget.h
@@ -1,0 +1,209 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERIMAGEUI_IMAGEGADGET_H
+#define GAFFERIMAGEUI_IMAGEGADGET_H
+
+#include "tbb/concurrent_unordered_map.h"
+
+#include "IECore/MurmurHash.h"
+#include "IECore/VectorTypedData.h"
+
+#include "GafferUI/Gadget.h"
+
+#include "GafferImage/Format.h"
+
+#include "GafferImageUI/TypeIds.h"
+
+namespace IECoreGL
+{
+
+IE_CORE_FORWARDDECLARE( LuminanceTexture )
+
+} // namespace IECoreGL
+
+namespace Gaffer
+{
+
+IE_CORE_FORWARDDECLARE( Plug )
+IE_CORE_FORWARDDECLARE( Context )
+
+} // namespace Gaffer
+
+namespace GafferImage
+{
+
+IE_CORE_FORWARDDECLARE( ImagePlug )
+
+} // namespace GafferImage
+
+namespace GafferImageUI
+{
+
+class ImageGadget : public GafferUI::Gadget
+{
+
+	public :
+
+		ImageGadget();
+		virtual ~ImageGadget();
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImageUI::ImageGadget, ImageGadgetTypeId, Gadget );
+
+		virtual Imath::Box3f bound() const;
+
+		void setImage( GafferImage::ConstImagePlugPtr image );
+		const GafferImage::ImagePlug *getImage() const;
+
+		void setContext( Gaffer::ContextPtr context );
+		Gaffer::Context *getContext();
+		const Gaffer::Context *getContext() const;
+
+		/// Chooses a channel to show in isolation.
+		/// Indices are in the range 0-3 to choose
+		/// which of the RGBA channels is soloed, or
+		/// -1 to show a colour image as usual.
+		void setSoloChannel( int index );
+		int getSoloChannel() const;
+
+	protected :
+
+		virtual void doRender( const GafferUI::Style *style ) const;
+
+	private :
+
+		// Image and context. We must monitor these so
+		// that dirtying of the plug or changes to the context
+		// can be used to trigger a render request.
+
+		void plugDirtied( const Gaffer::Plug *plug );
+		void contextChanged( const IECore::InternedString &name );
+
+		GafferImage::ConstImagePlugPtr m_image;
+		Gaffer::ContextPtr m_context;
+
+		boost::signals::scoped_connection m_plugDirtiedConnection;
+		boost::signals::scoped_connection m_contextChangedConnection;
+
+		// Settings to control how the image is displayed.
+
+		boost::array<IECore::InternedString, 4> m_rgbaChannels;
+		int m_soloChannel;
+
+		// Image access.
+		//
+		// We only pull on the m_image plug lazily when
+		// we need something, and store the result for later
+		// use. These flags and the member variables below
+		// are used to implement this caching.
+		enum DirtyFlags
+		{
+			NothingDirty = 0,
+			FormatDirty = 1,
+			DataWindowDirty = 2,
+			ChannelNamesDirty = 4,
+			TilesDirty = 8,
+			AllDirty = FormatDirty | DataWindowDirty | ChannelNamesDirty | TilesDirty
+		};
+
+		const GafferImage::Format &format() const;
+		const Imath::Box2i &dataWindow() const;
+		const std::vector<std::string> &channelNames() const;
+
+		mutable unsigned m_dirtyFlags;
+		mutable GafferImage::Format m_format;
+		mutable Imath::Box2i m_dataWindow;
+		mutable std::vector<std::string> m_channelNames;
+
+		// Tile storage.
+		//
+		// We store the image to draw as individual textures
+		// representing each channel of each tile. These are
+		// stored in a concurrent_unordered_map so they can
+		// be inserted/updated in parallel in a multithreaded
+		// update step.
+
+		struct TileIndex
+		{
+			TileIndex( const Imath::V2i &tileOrigin, IECore::InternedString channelName )
+				:	tileOrigin( tileOrigin ), channelName( channelName )
+			{
+			}
+
+			bool operator == ( const TileIndex &rhs ) const
+			{
+				return tileOrigin == rhs.tileOrigin && channelName == rhs.channelName;
+			}
+
+			Imath::V2i tileOrigin;
+			IECore::InternedString channelName;
+		};
+
+		struct Tile
+		{
+			IECore::MurmurHash channelDataHash;
+			// Updated in parallel when the hash has changed.
+			IECore::ConstFloatVectorDataPtr channelDataToConvert;
+			// Created from channelDataToConvert in a serial process,
+			// because we can only to OpenGL work on the main thread.
+			IECoreGL::TexturePtr texture;
+		};
+
+		void updateTiles() const;
+		void removeOutOfBoundsTiles() const;
+
+		typedef tbb::concurrent_unordered_map<TileIndex, Tile> Tiles;
+		mutable Tiles m_tiles;
+
+		friend size_t tbb_hasher( const ImageGadget::TileIndex &tileIndex );
+
+		struct TileFunctor;
+
+		// Rendering.
+
+		void renderTiles() const;
+		void renderText( const std::string &text, const Imath::V2f &position, const Imath::V2f &alignment, const GafferUI::Style *style ) const;
+
+};
+
+size_t tbb_hasher( const ImageGadget::TileIndex &tileIndex );
+
+typedef Gaffer::FilteredChildIterator<Gaffer::TypePredicate<ImageGadget> > ImageGadgetIterator;
+typedef Gaffer::FilteredRecursiveChildIterator<Gaffer::TypePredicate<ImageGadget> > RecursiveImageGadgetIterator;
+
+} // namespace GafferImageUI
+
+#endif // GAFFERIMAGEUI_IMAGEGADGET_H

--- a/include/GafferImageUI/ImageView.h
+++ b/include/GafferImageUI/ImageView.h
@@ -120,13 +120,7 @@ class ImageView : public GafferUI::View
 		/// preprocessor is managed by the ImageView base class.
 		void insertConverter( Gaffer::NodePtr converter );
 
-	private:
-
-		GafferImage::ImageStats *imageStatsNode();
-		const GafferImage::ImageStats *imageStatsNode() const;
-
-		GafferImage::ImageSampler *imageSamplerNode();
-		const GafferImage::ImageSampler *imageSamplerNode() const;
+	private :
 
 		GafferImage::Clamp *clampNode();
 		const GafferImage::Clamp *clampNode() const;
@@ -149,12 +143,8 @@ class ImageView : public GafferUI::View
 		ImageGadgetPtr m_imageGadget;
 		bool m_framed;
 
-		int m_channelToView;
-		Imath::V2f m_mousePos;
-		Imath::Color4f m_sampleColor;
-		Imath::Color4f m_minColor;
-		Imath::Color4f m_maxColor;
-		Imath::Color4f m_averageColor;
+		class ColorInspector;
+		boost::shared_ptr<ColorInspector> m_colorInspector;
 
 		typedef std::map<std::string, DisplayTransformCreator> DisplayTransformCreatorMap;
 		static DisplayTransformCreatorMap &displayTransformCreators();

--- a/include/GafferImageUI/ImageView.h
+++ b/include/GafferImageUI/ImageView.h
@@ -67,6 +67,8 @@ IE_CORE_FORWARDDECLARE( ImageSampler )
 namespace GafferImageUI
 {
 
+IE_CORE_FORWARDDECLARE( ImageGadget )
+
 /// \todo Refactor this into smaller components, along the lines of the SceneView class.
 /// Consider redesigning the View/Tool classes so that view functionality can be built up
 /// by adding tools like samplers etc. A good starting point for this refactoring would be
@@ -99,6 +101,8 @@ class ImageView : public GafferUI::View
 		Gaffer::StringPlug *displayTransformPlug();
 		const Gaffer::StringPlug *displayTransformPlug() const;
 
+		virtual void setContext( Gaffer::ContextPtr context );
+
 		typedef boost::function<GafferImage::ImageProcessorPtr ()> DisplayTransformCreator;
 
 		static void registerDisplayTransform( const std::string &name, DisplayTransformCreator creator );
@@ -115,8 +119,6 @@ class ImageView : public GafferUI::View
 		/// \note Subclasses are not allowed to call setPreprocessor() as the
 		/// preprocessor is managed by the ImageView base class.
 		void insertConverter( Gaffer::NodePtr converter );
-
-		virtual void update();
 
 	private:
 
@@ -136,10 +138,16 @@ class ImageView : public GafferUI::View
 		const GafferImage::ImageProcessor *displayTransformNode() const;
 
 		void plugSet( Gaffer::Plug *plug );
+		bool keyPress( const GafferUI::KeyEvent &event );
+		void preRender();
+
 		void insertDisplayTransform();
 
 		typedef std::map<std::string, GafferImage::ImageProcessorPtr> DisplayTransformMap;
 		DisplayTransformMap m_displayTransforms;
+
+		ImageGadgetPtr m_imageGadget;
+		bool m_framed;
 
 		int m_channelToView;
 		Imath::V2f m_mousePos;

--- a/include/GafferImageUI/TypeIds.h
+++ b/include/GafferImageUI/TypeIds.h
@@ -43,6 +43,7 @@ namespace GafferImageUI
 enum TypeId
 {
 	ImageViewTypeId = 110850,
+	ImageGadgetTypeId = 110851,
 
 	LastTypeId = 110899
 };

--- a/include/GafferImageUIBindings/ImageGadgetBinding.h
+++ b/include/GafferImageUIBindings/ImageGadgetBinding.h
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012, John Haddon. All rights reserved.
-//  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,19 +34,14 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
+#ifndef GAFFERIMAGEUIBINDINGS_IMAGEGADGETBINDING_H
+#define GAFFERIMAGEUIBINDINGS_IMAGEGADGETBINDING_H
 
-#include "GafferImageUIBindings/ImageViewBinding.h"
-#include "GafferImageUIBindings/ImageGadgetBinding.h"
-
-using namespace boost::python;
-
-using namespace GafferImageUIBindings;
-
-BOOST_PYTHON_MODULE( _GafferImageUI )
+namespace GafferImageUIBindings
 {
 
-	bindImageView();
-	bindImageGadget();
+void bindImageGadget();
 
-}
+} // namespace GafferImageUIBindings
+
+#endif // GAFFERIMAGEUIBINDINGS_IMAGEGADGETBINDING_H

--- a/python/GafferImageUI/CropUI.py
+++ b/python/GafferImageUI/CropUI.py
@@ -129,7 +129,7 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"layout:activator", "areaSourceIsFormatAndAffectDisplayWindowIsOn",
-			"divider", True
+			"layout:divider", True
 
 		],
 

--- a/python/GafferImageUI/ImageViewToolbar.py
+++ b/python/GafferImageUI/ImageViewToolbar.py
@@ -125,18 +125,27 @@ class _ColorInspectorPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __init__( self, plug, **kw ) :
 
-		self.__row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 )
-		GafferUI.PlugValueWidget.__init__( self, self.__row, plug, **kw )
+		frame = GafferUI.Frame( borderWidth = 4 )
+		frame._qtWidget().setObjectName( "gafferDarker" )
 
-		with self.__row :
+		GafferUI.PlugValueWidget.__init__( self, frame, plug, **kw )
 
-			self.__positionLabel = GafferUI.Label()
-			self.__positionLabel._qtWidget().setFixedWidth( 100 )
-			self.__swatch = GafferUI.ColorSwatch()
-			self.__rgbLabel = GafferUI.Label()
-			self.__rgbLabel._qtWidget().setFixedWidth( 200 )
-			self.__hsvLabel = GafferUI.Label()
-			self.__hsvLabel._qtWidget().setFixedWidth( 150 )
+		with frame :
+
+			with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
+
+				self.__positionLabel = GafferUI.Label()
+				self.__positionLabel._qtWidget().setFixedWidth( 90 )
+
+				self.__swatch = GafferUI.ColorSwatch()
+				self.__swatch._qtWidget().setFixedWidth( 12 )
+				self.__swatch._qtWidget().setFixedHeight( 12 )
+
+				self.__rgbLabel = GafferUI.Label()
+
+				GafferUI.Spacer( IECore.V2i( 20, 10 ), IECore.V2i( 20, 10 ) )
+
+				self.__hsvLabel = GafferUI.Label()
 
 	def _updateFromPlug( self ) :
 
@@ -154,16 +163,16 @@ class _ColorInspectorPlugValueWidget( GafferUI.PlugValueWidget ) :
 		if "A" not in channelNames :
 			color = IECore.Color3f( color[0], color[1], color[2] )
 
-		hsv = color.rgbToHSV()
-
+		self.__positionLabel.setText( "<b>XY : %d %d</b>" % ( pixel.x, pixel.y ) )
 		self.__swatch.setColor( color )
-		self.__positionLabel.setText( "XY : %d, %d" % ( pixel.x, pixel.y ) )
-		self.__hsvLabel.setText( "HSV : %s %s %s" % tuple( GafferUI.NumericWidget.valueToString( x ) for x in ( hsv.r, hsv.g, hsv.b ) ) )
 
 		if isinstance( color, IECore.Color4f ) :
-			self.__rgbLabel.setText( "RGBA : %s %s %s %s" % tuple( GafferUI.NumericWidget.valueToString( x ) for x in ( color.r, color.g, color.b, color.a ) ) )
+			self.__rgbLabel.setText( "<b>RGBA : %.3f %.3f %.3f %.3f</b>" % ( color.r, color.g, color.b, color.a ) )
 		else :
-			self.__rgbLabel.setText( "RGB : %s %s %s" % tuple( GafferUI.NumericWidget.valueToString( x ) for x in ( color.r, color.g, color.b ) ) )
+			self.__rgbLabel.setText( "<b>RGB : %.3f %.3f %.3f</b>" % ( color.r, color.g, color.b ) )
+
+		hsv = color.rgbToHSV()
+		self.__hsvLabel.setText( "<b>HSV : %.3f %.3f %.3f</b>" % ( hsv.r, hsv.g, hsv.b ) )
 
 ##########################################################################
 # Metadata registration.
@@ -172,6 +181,8 @@ class _ColorInspectorPlugValueWidget( GafferUI.PlugValueWidget ) :
 Gaffer.Metadata.registerNode(
 
 	GafferImageUI.ImageView,
+
+	"nodeToolbar:bottom:type", "GafferUI.StandardNodeToolbar.bottom",
 
 	plugs = {
 
@@ -185,7 +196,7 @@ Gaffer.Metadata.registerNode(
 			"plugValueWidget:type", "GafferImageUI.ImageViewToolbar._TogglePlugValueWidget",
 			"togglePlugValueWidget:imagePrefix", "clipping",
 			"togglePlugValueWidget:defaultToggleValue", True,
-			"layout:divider", True,
+			"toolbarLayout:divider", True,
 
 		],
 
@@ -235,8 +246,7 @@ Gaffer.Metadata.registerNode(
 
 			"plugValueWidget:type", "GafferImageUI.ImageViewToolbar._ColorInspectorPlugValueWidget",
 			"label", "",
-			"layout:index", 0,
-			"layout:divider", True,
+			"toolbarLayout:section", "Bottom",
 
 		],
 

--- a/python/GafferImageUI/ImageViewToolbar.py
+++ b/python/GafferImageUI/ImageViewToolbar.py
@@ -185,7 +185,7 @@ Gaffer.Metadata.registerNode(
 			"plugValueWidget:type", "GafferImageUI.ImageViewToolbar._TogglePlugValueWidget",
 			"togglePlugValueWidget:imagePrefix", "clipping",
 			"togglePlugValueWidget:defaultToggleValue", True,
-			"divider", True,
+			"layout:divider", True,
 
 		],
 
@@ -236,7 +236,7 @@ Gaffer.Metadata.registerNode(
 			"plugValueWidget:type", "GafferImageUI.ImageViewToolbar._ColorInspectorPlugValueWidget",
 			"label", "",
 			"layout:index", 0,
-			"divider", True,
+			"layout:divider", True,
 
 		],
 

--- a/python/GafferImageUI/ImageViewToolbar.py
+++ b/python/GafferImageUI/ImageViewToolbar.py
@@ -156,9 +156,13 @@ class _ColorInspectorPlugValueWidget( GafferUI.PlugValueWidget ) :
 		# properly, I think by having some sort of ContextSensitiveWidget
 		# base class which inherits contexts from parents.
 		with view.getContext() :
-			channelNames = view.viewportGadget().getPrimaryChild().getImage()["channelNames"].getValue()
 			pixel = self.getPlug()["pixel"].getValue()
-			color = self.getPlug()["color"].getValue()
+			try :
+				channelNames = view.viewportGadget().getPrimaryChild().getImage()["channelNames"].getValue()
+				color = self.getPlug()["color"].getValue()
+			except :
+				channelNames = view.viewportGadget().getPrimaryChild().getImage()["channelNames"].defaultValue()
+				color = self.getPlug()["color"].defaultValue()
 
 		if "A" not in channelNames :
 			color = IECore.Color3f( color[0], color[1], color[2] )

--- a/python/GafferImageUITest/ImageGadgetTest.py
+++ b/python/GafferImageUITest/ImageGadgetTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,10 +34,49 @@
 #
 ##########################################################################
 
-from FormatPlugValueWidgetTest import FormatPlugValueWidgetTest
-from ImageViewTest import ImageViewTest
-from DocumentationTest import DocumentationTest
-from ImageGadgetTest import ImageGadgetTest
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferUITest
+import GafferImage
+import GafferImageUI
+
+class ImageGadgetTest( GafferUITest.TestCase ) :
+
+	def testBound( self ) :
+
+		g = GafferImageUI.ImageGadget()
+		self.assertEqual( g.bound(), IECore.Box3f() )
+
+		c = GafferImage.Constant()
+		c["format"].setValue( GafferImage.Format( 200, 100 ) )
+
+		g.setImage( c["out"] )
+		self.assertEqual( g.bound(), IECore.Box3f( IECore.V3f( 0 ), IECore.V3f( 200, 100, 0) ) )
+
+		c["format"].setValue( GafferImage.Format( 200, 100, 2 ) )
+		self.assertEqual( g.bound(), IECore.Box3f( IECore.V3f( 0 ), IECore.V3f( 400, 100, 0) ) )
+
+		c2 = GafferImage.Constant()
+		g.setImage( c2["out"] )
+
+		f = GafferImage.FormatPlug.getDefaultFormat( g.getContext() ).getDisplayWindow()
+		self.assertEqual( g.bound(), IECore.Box3f( IECore.V3f( f.min.x, f.min.y, 0 ), IECore.V3f( f.max.x, f.max.y, 0 ) ) )
+
+		GafferImage.FormatPlug.setDefaultFormat( g.getContext(), GafferImage.Format( IECore.Box2i( IECore.V2i( 10, 20 ), IECore.V2i( 30, 40 ) ) ) )
+		self.assertEqual( g.bound(), IECore.Box3f( IECore.V3f( 10, 20, 0 ), IECore.V3f( 30, 40, 0 ) ) )
+
+	def testGetImage( self ) :
+
+		g = GafferImageUI.ImageGadget()
+		self.assertEqual( g.getImage(), None )
+
+		c = GafferImage.Constant()
+		g.setImage( c["out"] )
+		self.assertTrue( g.getImage().isSame( c["out"] ) )
 
 if __name__ == "__main__":
 	unittest.main()
+

--- a/python/GafferOSLUI/OSLShaderUI.py
+++ b/python/GafferOSLUI/OSLShaderUI.py
@@ -122,7 +122,7 @@ Gaffer.Metadata.registerNodeDescription( GafferOSL.OSLShader, __nodeDescription 
 
 Gaffer.Metadata.registerPlugDescription( GafferOSL.OSLShader, "parameters.*", __plugDescription )
 Gaffer.Metadata.registerPlugValue( GafferOSL.OSLShader, "parameters.*", "label", __plugLabel )
-Gaffer.Metadata.registerPlugValue( GafferOSL.OSLShader, "parameters.*", "divider", __plugDivider )
+Gaffer.Metadata.registerPlugValue( GafferOSL.OSLShader, "parameters.*", "layout:divider", __plugDivider )
 Gaffer.Metadata.registerPlugValue( GafferOSL.OSLShader, "parameters.*", "presetNames", __plugPresetNames )
 Gaffer.Metadata.registerPlugValue( GafferOSL.OSLShader, "parameters.*", "presetValues", __plugPresetValues )
 Gaffer.Metadata.registerPlugValue( GafferOSL.OSLShader, "parameters.*", "plugValueWidget:type", __plugWidgetType )

--- a/python/GafferRenderManUI/RenderManShaderUI.py
+++ b/python/GafferRenderManUI/RenderManShaderUI.py
@@ -418,7 +418,7 @@ for nodeType in( GafferRenderMan.RenderManShader, GafferRenderMan.RenderManLight
 	Gaffer.Metadata.registerPlugValue( nodeType, "parameters", "layout:activators", __parameterActivators )
 	Gaffer.Metadata.registerPlugDescription( nodeType, "parameters.*", __plugDescription )
 	Gaffer.Metadata.registerPlugValue( nodeType, "parameters.*", "label", __plugLabel )
-	Gaffer.Metadata.registerPlugValue( nodeType, "parameters.*", "divider", __plugDivider )
+	Gaffer.Metadata.registerPlugValue( nodeType, "parameters.*", "layout:divider", __plugDivider )
 	Gaffer.Metadata.registerPlugValue( nodeType, "parameters.*", "ui:visibleDimensions", __plugVisibleDimensions )
 	Gaffer.Metadata.registerPlugValue( nodeType, "parameters.*", "layout:section", __plugSection )
 	Gaffer.Metadata.registerPlugValue( nodeType, "parameters.*", "layout:activator", __plugActivator )

--- a/python/GafferSceneUI/SceneReaderPathPreview.py
+++ b/python/GafferSceneUI/SceneReaderPathPreview.py
@@ -34,8 +34,6 @@
 #
 ##########################################################################
 
-import fnmatch
-
 import IECore
 
 import Gaffer
@@ -238,30 +236,65 @@ class _Camera( Gaffer.Node ) :
 
 IECore.registerRunTimeTyped( _Camera )
 
-GafferUI.NodeToolbar.registerCreator( _Camera, GafferUI.StandardNodeToolbar )
-GafferUI.PlugValueWidget.registerCreator( _Camera, "in", None )
-GafferUI.PlugValueWidget.registerCreator( _Camera, "out", None )
-GafferUI.PlugValueWidget.registerCreator( _Camera, "user", None )
+Gaffer.Metadata.registerNode(
 
-GafferUI.PlugValueWidget.registerCreator(
 	_Camera,
-	"lookAt",
-	lambda plug : GafferUI.PathPlugValueWidget(
-		plug,
-		path = GafferScene.ScenePath( plug.node()["in"], plug.node().scriptNode().context(), "/" ),
-	),
+
+	"nodeToolbar:top:type", "GafferUI.StandardNodeToolbar.top",
+
+	plugs = {
+
+		"*" : [
+
+			"toolbarLayout:section", "Top",
+
+		],
+
+		"in" : [
+
+			"plugValueWidget:type", "",
+
+		],
+
+		"out" : [
+
+			"plugValueWidget:type", "",
+
+		],
+
+		"user" : [
+
+			"plugValueWidget:type", "",
+
+		],
+
+		"lookAt" : [
+
+			"plugValueWidget:type", "GafferSceneUI.ScenePathPlugValueWidget",
+
+		],
+
+		"depth" : [
+
+			"numericPlugValueWidget:fixedCharacterWidth", 5,
+
+		],
+
+		"angle" : [
+
+			"numericPlugValueWidget:fixedCharacterWidth", 5,
+
+		],
+
+		"elevation" : [
+
+			"numericPlugValueWidget:fixedCharacterWidth", 5,
+
+		],
+
+	}
+
 )
-
-def __fixedWidthNumericPlugValueWidget( plug ) :
-
-	result = GafferUI.NumericPlugValueWidget( plug )
-	result.numericWidget().setFixedCharacterWidth( 5 )
-
-	return result
-
-GafferUI.PlugValueWidget.registerCreator( _Camera, "depth", __fixedWidthNumericPlugValueWidget )
-GafferUI.PlugValueWidget.registerCreator( _Camera, "angle", __fixedWidthNumericPlugValueWidget )
-GafferUI.PlugValueWidget.registerCreator( _Camera, "elevation", __fixedWidthNumericPlugValueWidget )
 
 # Utility node for previewing single objects from a file or
 # sequence (cob, ptc, pdc, etc), as though they were a scene

--- a/python/GafferSceneUI/SceneViewToolbar.py
+++ b/python/GafferSceneUI/SceneViewToolbar.py
@@ -44,8 +44,73 @@ import GafferUI
 import GafferScene
 import GafferSceneUI
 
+Gaffer.Metadata.registerNode(
+
+	GafferSceneUI.SceneView,
+
+	plugs = {
+
+		"shadingMode" : [
+
+			"toolbarLayout:index", 2,
+			"toolbarLayout:divider", True,
+			"plugValueWidget:type", "GafferSceneUI.SceneViewToolbar._ShadingModePlugValueWidget",
+
+		],
+
+		"minimumExpansionDepth" : [
+
+			"plugValueWidget:type", "GafferSceneUI.SceneViewToolbar._ExpansionPlugValueWidget",
+			"toolbarLayout:divider", True,
+
+		],
+
+		"lookThrough" : [
+
+			"plugValueWidget:type", "GafferSceneUI.SceneViewToolbar._LookThroughPlugValueWidget",
+			"toolbarLayout:divider", True,
+			"toolbarLayout:label", "",
+
+		],
+
+		"lookThrough.enabled" : [
+
+			"description",
+			"""
+			When enabled, locks the view to look through a specific camera in the scene.
+			By default, the current render camera is used, but this can be changed using the lookThrough.camera
+			setting.
+			""",
+		],
+
+		"lookThrough.camera" : [
+
+			"description",
+			"""
+			Specifies the camera to look through when lookThrough.enabled is on. The default value
+			means that the current render camera will be used - the paths to other cameras may be specified
+			to choose another camera."
+			""",
+		],
+
+		"grid" : [
+
+			"plugValueWidget:type", "GafferSceneUI.SceneViewToolbar._GridPlugValueWidget",
+
+		],
+
+		"gnomon" : [
+
+			"plugValueWidget:type", "",
+
+		],
+
+	}
+
+)
+
 ##########################################################################
-# Shading Mode
+# _ShadingModePlugValueWidget
 ##########################################################################
 
 class _ShadingModePlugValueWidget( GafferUI.PlugValueWidget ) :
@@ -91,12 +156,8 @@ class _ShadingModePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 			self.getPlug().setValue( value )
 
-Gaffer.Metadata.registerPlugValue( GafferSceneUI.SceneView, "shadingMode", "layout:index", 2 )
-Gaffer.Metadata.registerPlugValue( GafferSceneUI.SceneView, "shadingMode", "divider", True )
-GafferUI.PlugValueWidget.registerCreator( GafferSceneUI.SceneView, "shadingMode", _ShadingModePlugValueWidget )
-
 ##########################################################################
-# Expansion
+# _ExpansionPlugValueWidget
 ##########################################################################
 
 class _ExpansionPlugValueWidget( GafferUI.PlugValueWidget ) :
@@ -133,12 +194,8 @@ class _ExpansionPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		self.getPlug().setValue( 0 if self.getPlug().getValue() else 999 )
 
-GafferUI.PlugValueWidget.registerCreator( GafferSceneUI.SceneView, "minimumExpansionDepth", _ExpansionPlugValueWidget )
-
-Gaffer.Metadata.registerPlugValue( GafferSceneUI.SceneView, "minimumExpansionDepth", "divider", True )
-
 ##########################################################################
-# Lookthrough
+# _LookThroughPlugValueWidget
 ##########################################################################
 
 class _LookThroughPlugValueWidget( GafferUI.PlugValueWidget ) :
@@ -171,28 +228,8 @@ class _LookThroughPlugValueWidget( GafferUI.PlugValueWidget ) :
 		with self.getContext() :
 			self.__cameraWidget.setEnabled( self.getPlug()["enabled"].getValue() )
 
-GafferUI.PlugValueWidget.registerCreator(
-	GafferSceneUI.SceneView,
-	"lookThrough",
-	_LookThroughPlugValueWidget,
-)
-
-Gaffer.Metadata.registerPlugValue( GafferSceneUI.SceneView, "lookThrough", "label", "" )
-
-Gaffer.Metadata.registerPlugDescription( GafferSceneUI.SceneView, "lookThrough.enabled",
-	"When enabled, locks the view to look through a specific camera in the scene. "
-	"By default, the current render camera is used, but this can be changed using the lookThrough.camera "
-	"setting."
-)
-
-Gaffer.Metadata.registerPlugDescription( GafferSceneUI.SceneView, "lookThrough.camera",
-	"Specifies the camera to look through when lookThrough.enabled is on. The default value "
-	"means that the current render camera will be used - the paths to other cameras may be specified "
-	"to choose another camera."
-)
-
 ##########################################################################
-# Grid
+# _GridPlugValueWidget
 ##########################################################################
 
 class _GridPlugValueWidget( GafferUI.PlugValueWidget ) :
@@ -232,6 +269,3 @@ class _GridPlugValueWidget( GafferUI.PlugValueWidget ) :
 		)
 
 		return m
-
-GafferUI.PlugValueWidget.registerCreator( GafferSceneUI.SceneView.staticTypeId(), "grid", _GridPlugValueWidget )
-GafferUI.PlugValueWidget.registerCreator( GafferSceneUI.SceneView.staticTypeId(), "gnomon", None )

--- a/python/GafferUI/Enums.py
+++ b/python/GafferUI/Enums.py
@@ -40,7 +40,7 @@ import GafferUI
 QtCore = GafferUI._qtImport( "QtCore" )
 
 ## \todo Move other enums here - ListContainer.Orientation for instance.
-__all__ = [ "HorizontalAlignment", "VerticalAlignment" ]
+__all__ = [ "HorizontalAlignment", "VerticalAlignment", "Edge" ]
 
 # HorizontalAlignment
 
@@ -109,3 +109,7 @@ def __verticalToQt( a ) :
 
 VerticalAlignment._fromQt = __verticalFromQt
 VerticalAlignment._toQt = __verticalToQt
+
+# Edge
+
+Edge = IECore.Enum.create( "Top", "Bottom", "Left", "Right" )

--- a/python/GafferUI/GLWidget.py
+++ b/python/GafferUI/GLWidget.py
@@ -418,14 +418,7 @@ class _GLGraphicsScene( QtGui.QGraphicsScene ) :
 			widget._qtWidget().layout().setSizeConstraint( QtGui.QLayout.SetNoConstraint )
 
 		self.__overlayProxy = _OverlayProxyWidget()
-
 		self.__overlayProxy.setWidget( self.__overlay._qtWidget() )
-
-		shadow = QtGui.QGraphicsDropShadowEffect( self )
-		shadow.setColor( QtGui.QColor( 0, 0, 0, 70 ) )
-		shadow.setBlurRadius( 6 )
-		shadow.setOffset( 2.0, 2.0 )
-		self.__overlayProxy.setGraphicsEffect( shadow )
 
 		self.addItem( self.__overlayProxy )
 		self.__updateItemGeometry( self.__overlayProxy, self.sceneRect() )

--- a/python/GafferUI/GLWidget.py
+++ b/python/GafferUI/GLWidget.py
@@ -90,18 +90,39 @@ class GLWidget( GafferUI.Widget ) :
 
 		GafferUI.Widget.__init__( self, graphicsView, **kw )
 
-	## Adds a Widget as an overlay.
-	## \todo Support more than one overlay, and provide grid-based
-	# placement options. Perhaps GLWidget should also derive from Container
-	# to support auto-parenting and appropriate removeChild() behaviour.
-	def addOverlay( self, overlay ) :
+		self.__overlay = None
 
-		assert( overlay.parent() is None )
+	## Specifies a widget to be overlaid on top of the GL rendering,
+	# stretched to fill the frame. To add multiple widgets and/or gain
+	# more control over the layout, use a Container as the overlay and
+	# use it to layout multiple child widgets.
+	def setOverlay( self, overlay ) :
+
+		if overlay is self.__overlay :
+			return
+
+		if self.__overlay is not None :
+			self.removeChild( self.__overlay )
+
+		if overlay is not None :
+			oldParent = overlay.parent()
+			if oldParent is not None :
+				oldParent.removeChild( child )
 
 		self.__overlay = overlay
 		self.__overlay._setStyleSheet()
 
-		item = self.__graphicsScene.addOverlay( self.__overlay )
+		self.__graphicsScene.setOverlay( self.__overlay )
+
+	def getOverlay( self ) :
+
+		return self.__overlay
+
+	def removeChild( self, child ) :
+
+		assert( child is self.__overlay )
+		self.__overlay = None
+		self.__graphicsScene.setOverlay( None )
 
 	## Called whenever the widget is resized. May be reimplemented by derived
 	# classes if necessary. The appropriate OpenGL context will already be current
@@ -376,18 +397,30 @@ class _GLGraphicsScene( QtGui.QGraphicsScene ) :
 		self.__backgroundDrawFunction = backgroundDrawFunction
 		self.sceneRectChanged.connect( self.__sceneRectChanged )
 
-	def addOverlay( self, widget ) :
+		self.__overlay = None # Stores the GafferUI.Widget
+		self.__overlayProxy = None # Stores the _OverlayProxyWidget
 
-		self.__widget = widget
+	def setOverlay( self, widget ) :
+
+		if self.__overlay is not None :
+			self.__overlayProxy.setWidget( None )
+			self.removeItem( self.__overlayProxy )
+			self.__overlay = None
+			self.__overlayProxy = None
+
+		if widget is None :
+			return
+
+		self.__overlay = widget
 		if widget._qtWidget().layout() is not None :
 			# removing the size constraint is necessary to keep the widget the
 			# size we tell it to be in __updateItemGeometry.
 			widget._qtWidget().layout().setSizeConstraint( QtGui.QLayout.SetNoConstraint )
 
-		item = QtGui.QGraphicsScene.addWidget( self, widget._qtWidget() )
-		self.__updateItemGeometry( item, self.sceneRect() )
-
-		return item
+		self.__overlayProxy = _OverlayProxyWidget()
+		self.__overlayProxy.setWidget( self.__overlay._qtWidget() )
+		self.addItem( self.__overlayProxy )
+		self.__updateItemGeometry( self.__overlayProxy, self.sceneRect() )
 
 	def drawBackground( self, painter, rect ) :
 
@@ -395,10 +428,26 @@ class _GLGraphicsScene( QtGui.QGraphicsScene ) :
 
 	def __sceneRectChanged( self, sceneRect ) :
 
-		for item in self.items() :
-			self.__updateItemGeometry( item, sceneRect )
+		if self.__overlayProxy is not None :
+			self.__updateItemGeometry( self.__overlayProxy, sceneRect )
 
 	def __updateItemGeometry( self, item, sceneRect ) :
 
 		geometry = item.widget().geometry()
-		item.widget().setGeometry( QtCore.QRect( 0, 0, sceneRect.width(), item.widget().sizeHint().height() ) )
+		item.widget().setGeometry( QtCore.QRect( 0, 0, sceneRect.width(), sceneRect.height() ) )
+
+## A QGraphicsProxyWidget whose shape is composed from the
+# bounds of its child widgets. This allows our overlays to
+# pass through events in the regions where there isn't a
+# child widget.
+class _OverlayProxyWidget( QtGui.QGraphicsProxyWidget ) :
+
+	def __init__( self ) :
+
+		QtGui.QGraphicsProxyWidget.__init__( self )
+
+	def shape( self ) :
+
+		path = QtGui.QPainterPath()
+		path.addRegion( self.widget().childrenRegion() )
+		return path

--- a/python/GafferUI/GLWidget.py
+++ b/python/GafferUI/GLWidget.py
@@ -418,13 +418,26 @@ class _GLGraphicsScene( QtGui.QGraphicsScene ) :
 			widget._qtWidget().layout().setSizeConstraint( QtGui.QLayout.SetNoConstraint )
 
 		self.__overlayProxy = _OverlayProxyWidget()
+
 		self.__overlayProxy.setWidget( self.__overlay._qtWidget() )
+
+		shadow = QtGui.QGraphicsDropShadowEffect( self )
+		shadow.setColor( QtGui.QColor( 0, 0, 0, 70 ) )
+		shadow.setBlurRadius( 6 )
+		shadow.setOffset( 2.0, 2.0 )
+		self.__overlayProxy.setGraphicsEffect( shadow )
+
 		self.addItem( self.__overlayProxy )
 		self.__updateItemGeometry( self.__overlayProxy, self.sceneRect() )
 
 	def drawBackground( self, painter, rect ) :
 
 		self.__backgroundDrawFunction()
+
+		# Reset pixel store setting back to the default. IECoreGL
+		# (and the ImageGadget) meddle with this, and it throws off
+		# the QGraphicsEffects.
+		GL.glPixelStorei( GL.GL_UNPACK_ALIGNMENT, 4 );
 
 	def __sceneRectChanged( self, sceneRect ) :
 

--- a/python/GafferUI/NumericPlugValueWidget.py
+++ b/python/GafferUI/NumericPlugValueWidget.py
@@ -40,9 +40,12 @@ from __future__ import with_statement
 import Gaffer
 import GafferUI
 
+## Supported metadata :
+#
+#  "numericPlugValueWidget:fixedCharacterWidth"
+##
 ## \todo Maths expressions to modify the existing value
 ## \todo Enter names of other plugs to create a connection
-## \todo Color change for connected plugs and output plugs
 ## \todo Reject drag and drop of anything that's not a number
 class NumericPlugValueWidget( GafferUI.PlugValueWidget ) :
 
@@ -179,8 +182,12 @@ class NumericPlugValueWidget( GafferUI.PlugValueWidget ) :
 	def __updateWidth( self ) :
 
 		charWidth = None
-		if isinstance( self.getPlug(), Gaffer.IntPlug ) and self.getPlug().hasMaxValue() :
+		if self.getPlug() is not None :
+			charWidth = Gaffer.Metadata.plugValue( self.getPlug(), "numericPlugValueWidget:fixedCharacterWidth" )
+
+		if charWidth is None and isinstance( self.getPlug(), Gaffer.IntPlug ) and self.getPlug().hasMaxValue() :
 			charWidth = len( str( self.getPlug().maxValue() ) )
+
 		self.__numericWidget.setFixedCharacterWidth( charWidth )
 
 GafferUI.PlugValueWidget.registerType( Gaffer.FloatPlug, NumericPlugValueWidget )

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -51,7 +51,7 @@ QtGui = GafferUI._qtImport( "QtGui" )
 #
 #	- "layout:index" controls ordering of plugs within the layout
 #	- "layout:section" places the plug in a named section of the layout
-#	- "divider" specifies whether or not a plug should be followed by a divider
+#	- "layout:divider" specifies whether or not a plug should be followed by a divider
 #	- "layout:activator" the name of an activator to control editability
 #	- "layout:visibilityActivator" the name of an activator to control visibility
 #
@@ -398,10 +398,11 @@ class PlugLayout( GafferUI.Widget ) :
 	def __staticItemMetadataValue( cls, item, name, parent ) :
 
 		if isinstance( item, Gaffer.Plug ) :
-			##\todo Update "divider" and "label" items to use prefix too
-			if name not in ( "divider", "label" ) :
-				name = "layout:" + name
-			return Gaffer.Metadata.plugValue( item, name )
+			v = Gaffer.Metadata.plugValue( item, "layout:" + name )
+			if v is None and name in ( "divider", "label" ) :
+				# Backwards compatibility with old unprefixed metadata names.
+				v = Gaffer.Metadata.plugValue( item, name )
+			return v
 		else :
 			return cls.__metadataValue( parent, "layout:customWidget:" + item + ":" + name )
 

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -49,21 +49,21 @@ QtGui = GafferUI._qtImport( "QtGui" )
 #
 # Per-plug metadata support :
 #
-#	- "layout:index" controls ordering of plugs within the layout
-#	- "layout:section" places the plug in a named section of the layout
-#	- "layout:divider" specifies whether or not a plug should be followed by a divider
-#	- "layout:activator" the name of an activator to control editability
-#	- "layout:visibilityActivator" the name of an activator to control visibility
+#	- "<layoutName>:index" controls ordering of plugs within the layout
+#	- "<layoutName>:section" places the plug in a named section of the layout
+#	- "<layoutName>:divider" specifies whether or not a plug should be followed by a divider
+#	- "<layoutName>:activator" the name of an activator to control editability
+#	- "<layoutName>:visibilityActivator" the name of an activator to control visibility
 #
 # Per-parent metadata support :
 #
-#   - layout:section:sectionName:summary" dynamic metadata entry returning a
+#   - <layoutName>:section:sectionName:summary" dynamic metadata entry returning a
 #     string to be used as a summary for the section.
-#   - layout:section:sectionName:collapsed" boolean indicating whether or
+#   - <layoutName>:section:sectionName:collapsed" boolean indicating whether or
 #     not a section should be collapsed initially.
-#   - "layout:activator:activatorName" a dynamic boolean metadata entry to control
+#   - "<layoutName>:activator:activatorName" a dynamic boolean metadata entry to control
 #     the activation of plugs within the layout
-#   - "layout:activators" a dynamic metadata entry returning a CompoundData of booleans
+#   - "<layoutName>:activators" a dynamic metadata entry returning a CompoundData of booleans
 #     for several named activators.
 #
 # ## Custom widgets
@@ -73,13 +73,13 @@ QtGui = GafferUI._qtImport( "QtGui" )
 # to display asset management information for each node.
 #
 # A custom widget is specified using parent metadata entries starting with
-# "layout:customWidget:Name:" prefixes, where "Name" is a unique identifier for the
+# "<layoutName>:customWidget:Name:" prefixes, where "Name" is a unique identifier for the
 # custom widget :
 #
-#   - "layout:customWidget:Name:widgetType" specifies a string containing the fully qualified
+#   - "<layoutName>:customWidget:Name:widgetType" specifies a string containing the fully qualified
 #     name of a python callable which will be used to create the widget. This callable will be passed
 #     the same parent GraphComponent (node or plug) that the PlugLayout is being created for.
-#   - "layout:customWidget:Name:*" as for the standard per-plug "layout:*" metadata, so custom
+#   - "<layoutName>:customWidget:Name:*" as for the standard per-plug "<layoutName>:*" metadata, so custom
 #     widgets may be assigned to a section, reordered, given activators etc.
 #
 class PlugLayout( GafferUI.Widget ) :
@@ -87,7 +87,7 @@ class PlugLayout( GafferUI.Widget ) :
 	# We use this when we can't find a ScriptNode to provide the context.
 	__fallbackContext = Gaffer.Context()
 
-	def __init__( self, parent, orientation = GafferUI.ListContainer.Orientation.Vertical, **kw ) :
+	def __init__( self, parent, orientation = GafferUI.ListContainer.Orientation.Vertical, layoutName = "layout", **kw ) :
 
 		assert( isinstance( parent, ( Gaffer.Node, Gaffer.Plug ) ) )
 
@@ -97,6 +97,7 @@ class PlugLayout( GafferUI.Widget ) :
 
 		self.__parent = parent
 		self.__readOnly = False
+		self.__layoutName = layoutName
 
 		# we need to connect to the childAdded/childRemoved signals on
 		# the parent so we can update the ui when plugs are added and removed.
@@ -188,24 +189,24 @@ class PlugLayout( GafferUI.Widget ) :
 	# out the plugs of the specified parent. The sections are returned
 	# in the order in which they will be created.
 	@classmethod
-	def layoutSections( cls, parent, includeCustomWidgets = False ) :
+	def layoutSections( cls, parent, includeCustomWidgets = False, layoutName = "layout" ) :
 
 		d = collections.OrderedDict()
-		for item in cls.layoutOrder( parent, includeCustomWidgets ) :
-			sectionPath = cls.__staticSectionPath(item, parent)
+		for item in cls.layoutOrder( parent, includeCustomWidgets, layoutName = layoutName ) :
+			sectionPath = cls.__staticSectionPath( item, parent, layoutName )
 			sectionName = ".".join( sectionPath )
 			d[sectionName] = 1
 
 		return d.keys()
 
 	## Returns the child plugs of the parent in the order in which they
-	# will be laid out, based on "layout:index" Metadata entries. If
+	# will be laid out, based on "<layoutName>:index" Metadata entries. If
 	# includeCustomWidgets is True, then the positions of custom widgets
 	# are represented by the appearance of the names of the widgets as
 	# strings within the list. If a section name is specified, then the
 	# result will be filtered to include only items in that section.
 	@classmethod
-	def layoutOrder( cls, parent, includeCustomWidgets = False, section = None ) :
+	def layoutOrder( cls, parent, includeCustomWidgets = False, section = None, layoutName = "layout" ) :
 
 		items = parent.children( Gaffer.Plug )
 		items = [ plug for plug in items if not plug.getName().startswith( "__" ) ]
@@ -216,13 +217,13 @@ class PlugLayout( GafferUI.Widget ) :
 			else :
 				metadataNames = Gaffer.Metadata.registeredPlugValues( parent )
 			for name in metadataNames :
-				m = re.match( "layout:customWidget:(.+):widgetType", name )
+				m = re.match( layoutName + ":customWidget:(.+):widgetType", name )
 				if m and cls.__metadataValue( parent, name ) :
 					items.append( m.group( 1 ) )
 
 		itemsAndIndices = [ list( x ) for x in enumerate( items ) ]
 		for itemAndIndex in itemsAndIndices :
-			index = cls.__staticItemMetadataValue( itemAndIndex[1], "index", parent )
+			index = cls.__staticItemMetadataValue( itemAndIndex[1], "index", parent, layoutName )
 			if index is not None :
 				index = index if index >= 0 else sys.maxint + index
 				itemAndIndex[0] = index
@@ -231,7 +232,7 @@ class PlugLayout( GafferUI.Widget ) :
 
 		if section is not None :
 			sectionPath = section.split( "." ) if section else []
-			itemsAndIndices = [ x for x in itemsAndIndices if cls.__staticSectionPath( x[1], parent ) == sectionPath ]
+			itemsAndIndices = [ x for x in itemsAndIndices if cls.__staticSectionPath( x[1], parent, layoutName ) == sectionPath ]
 
 		return [ x[1] for x in itemsAndIndices ]
 
@@ -263,7 +264,7 @@ class PlugLayout( GafferUI.Widget ) :
 
 		# get the items to lay out - these are a combination
 		# of plugs and strings representing custom widgets.
-		items = self.layoutOrder( self.__parent, includeCustomWidgets = True )
+		items = self.layoutOrder( self.__parent, includeCustomWidgets = True, layoutName = self.__layoutName )
 
 		# ditch widgets we don't need any more
 
@@ -308,7 +309,7 @@ class PlugLayout( GafferUI.Widget ) :
 		with self.getContext() :
 			# Must scope the context when getting activators, because they are typically
 			# computed from the plug values, and may therefore trigger a compute.
-			activators = self.__metadataValue( self.__parent, "layout:activators" ) or {}
+			activators = self.__metadataValue( self.__parent, self.__layoutName + ":activators" ) or {}
 
 		activators = { k : v.value for k, v in activators.items() } # convert CompoundData of BoolData to dict of booleans
 
@@ -319,7 +320,7 @@ class PlugLayout( GafferUI.Widget ) :
 				result = activators.get( activatorName )
 				if result is None :
 					with self.getContext() :
-						result = self.__metadataValue( self.__parent, "layout:activator:" + activatorName )
+						result = self.__metadataValue( self.__parent, self.__layoutName + ":activator:" + activatorName )
 					result = result if result is not None else False
 					activators[activatorName] = result
 
@@ -336,7 +337,7 @@ class PlugLayout( GafferUI.Widget ) :
 			# Must scope the context because summaries are typically
 			# generated from plug values, and may therefore trigger
 			# a compute.
-			section.summary = self.__metadataValue( self.__parent, "layout:section:" + section.fullName + ":summary" ) or ""
+			section.summary = self.__metadataValue( self.__parent, self.__layoutName + ":section:" + section.fullName + ":summary" ) or ""
 
 		for subsection in section.subsections.values() :
 			self.__updateSummariesWalk( subsection )
@@ -356,7 +357,7 @@ class PlugLayout( GafferUI.Widget ) :
 		if result is None :
 			return result
 
-		if isinstance( result, GafferUI.PlugValueWidget ) and not result.hasLabel() and Gaffer.Metadata.plugValue( plug, "label" ) != "" :
+		if isinstance( result, GafferUI.PlugValueWidget ) and not result.hasLabel() and self.__itemMetadataValue( plug, "label" ) != "" :
  			result = GafferUI.PlugWidget( result )
 			if self.__layout.orientation() == GafferUI.ListContainer.Orientation.Horizontal :
 				# undo the annoying fixed size the PlugWidget has applied
@@ -395,40 +396,40 @@ class PlugLayout( GafferUI.Widget ) :
 			return Gaffer.Metadata.plugValue( plugOrNode, name )
 
 	@classmethod
-	def __staticItemMetadataValue( cls, item, name, parent ) :
+	def __staticItemMetadataValue( cls, item, name, parent, layoutName ) :
 
 		if isinstance( item, Gaffer.Plug ) :
-			v = Gaffer.Metadata.plugValue( item, "layout:" + name )
+			v = Gaffer.Metadata.plugValue( item, layoutName + ":" + name )
 			if v is None and name in ( "divider", "label" ) :
 				# Backwards compatibility with old unprefixed metadata names.
 				v = Gaffer.Metadata.plugValue( item, name )
 			return v
 		else :
-			return cls.__metadataValue( parent, "layout:customWidget:" + item + ":" + name )
+			return cls.__metadataValue( parent, layoutName + ":customWidget:" + item + ":" + name )
 
 	def __itemMetadataValue( self, item, name ) :
 
-		return self.__staticItemMetadataValue( item, name, parent = self.__parent )
+		return self.__staticItemMetadataValue( item, name, parent = self.__parent, layoutName = self.__layoutName )
 
 	@classmethod
-	def __staticSectionPath( cls, item, parent ) :
+	def __staticSectionPath( cls, item, parent, layoutName ) :
 
 		m = None
 		if isinstance( parent, Gaffer.Node ) :
 			# Backwards compatibility with old metadata entry
 			## \todo Remove
-			m = cls.__staticItemMetadataValue( item, "nodeUI:section", parent )
+			m = cls.__staticItemMetadataValue( item, "nodeUI:section", parent, layoutName )
 			if m == "header" :
 				m = ""
 
 		if m is None :
-			m = cls.__staticItemMetadataValue( item, "section", parent )
+			m = cls.__staticItemMetadataValue( item, "section", parent, layoutName )
 
 		return m.split( "." ) if m else []
 
 	def __sectionPath( self, item ) :
 
-		return self.__staticSectionPath( item, parent = self.__parent )
+		return self.__staticSectionPath( item, parent = self.__parent, layoutName = self.__layoutName )
 
 	def __childAddedOrRemoved( self, *unusedArgs ) :
 
@@ -469,12 +470,18 @@ class PlugLayout( GafferUI.Widget ) :
 		if not self.__node().isInstanceOf( nodeTypeId ) :
 			return
 
-		if key in ( "divider", "layout:index", "layout:section", "plugValueWidget:type" ) :
+		if key in (
+			"divider",
+			self.__layoutName + ":divider",
+			self.__layoutName + ":index",
+			self.__layoutName + ":section",
+			"plugValueWidget:type"
+		) :
 			# we often see sequences of several metadata changes - so
 			# we schedule a lazy update to batch them into one ui update.
 			self.__layoutDirty = True
 			self.__updateLazily()
-		elif re.match( "layout:section:.*:summary", key ) :
+		elif re.match( self.__layoutName + ":section:.*:summary", key ) :
 			self.__summariesDirty = True
 			self.__updateLazily()
 

--- a/python/GafferUI/StandardNodeToolbar.py
+++ b/python/GafferUI/StandardNodeToolbar.py
@@ -41,11 +41,33 @@ import GafferUI
 
 class StandardNodeToolbar( GafferUI.NodeToolbar ) :
 
-	def __init__( self, node, **kw ) :
+	def __init__( self, node, edge = GafferUI.Edge.Top, **kw ) :
 
-		self.__row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 )
+		layout = GafferUI.PlugLayout(
+			node,
+			orientation = GafferUI.ListContainer.Orientation.Horizontal if edge in ( GafferUI.Edge.Top, GafferUI.Edge.Bottom ) else GafferUI.ListContainer.Orientation.Vertical,
+			layoutName = "toolbarLayout",
+			rootSection = str( edge )
+		)
 
-		GafferUI.NodeToolbar.__init__( self, node, self.__row, **kw )
+		GafferUI.NodeToolbar.__init__( self, node, layout, **kw )
 
-		self.__row.append( GafferUI.Spacer( IECore.V2i( 1, 1 ) ), expand = True )
-		self.__row.append( GafferUI.PlugLayout( node, orientation = GafferUI.ListContainer.Orientation.Horizontal ) )
+	@staticmethod
+	def top( node ) :
+
+		return StandardNodeToolbar( node, edge = GafferUI.Edge.Top )
+
+	@staticmethod
+	def bottom( node ) :
+
+		return StandardNodeToolbar( node, edge = GafferUI.Edge.Bottom )
+
+	@staticmethod
+	def left( node ) :
+
+		return StandardNodeToolbar( node, edge = GafferUI.Edge.Left )
+
+	@staticmethod
+	def right( node ) :
+
+		return StandardNodeToolbar( node, edge = GafferUI.Edge.Right )

--- a/python/GafferUI/ViewUI.py
+++ b/python/GafferUI/ViewUI.py
@@ -41,11 +41,13 @@ Gaffer.Metadata.registerNode(
 
 	GafferUI.View,
 
+	"nodeToolbar:top:type", "GafferUI.StandardNodeToolbar.top",
+
 	plugs = {
 
 		"*" : [
 
-			"layout:section", "",
+			"toolbarLayout:section", "Top",
 
 		],
 
@@ -64,5 +66,3 @@ Gaffer.Metadata.registerNode(
 	}
 
 )
-
-GafferUI.NodeToolbar.registerCreator( GafferUI.View, GafferUI.StandardNodeToolbar )

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -964,6 +964,14 @@ _styleSheet = string.Template(
 
 	}
 
+	QFrame#gafferDarker {
+
+		background: solid rgba( 0, 0, 0, 80 );
+		border-radius: 2px;
+		padding: 2px;
+
+	}
+
 	QFrame[gafferHighlighted=\"true\"]#gafferDiffA, QFrame[gafferHighlighted=\"true\"]#gafferDiffB, QFrame[gafferHighlighted=\"true\"]#gafferDiffCommon {
 		background-color: $brightColor;
 	}

--- a/python/GafferUITest/GLWidgetTest.py
+++ b/python/GafferUITest/GLWidgetTest.py
@@ -50,7 +50,7 @@ class GLWidgetTest( GafferUITest.TestCase ) :
 		b = GafferUI.Button()
 
 		w.setChild( g )
-		g.addOverlay( f )
+		g.setOverlay( f )
 		f.setChild( b )
 
 		self.assertTrue( b.parent() is f )
@@ -64,12 +64,12 @@ class GLWidgetTest( GafferUITest.TestCase ) :
 
 		w = GafferUI.Window()
 		g = GafferUI.GLWidget()
-		f = GafferUI.Frame( borderWidth = 0, borderStyle=GafferUI.Frame.BorderStyle.None )
+		c = GafferUI.GridContainer()
 		b = GafferUI.Button()
 
 		w.setChild( g )
-		g.addOverlay( f )
-		f.setChild( b )
+		g.setOverlay( c )
+		c.addChild( b, alignment = ( GafferUI.HorizontalAlignment.None, GafferUI.VerticalAlignment.Top ) )
 
 		w.setVisible( True )
 
@@ -85,7 +85,7 @@ class GLWidgetTest( GafferUITest.TestCase ) :
 		b = GafferUI.Button()
 
 		w.setChild( g )
-		g.addOverlay( f )
+		g.setOverlay( f )
 		f.setChild( b )
 
 		w.setVisible( True )
@@ -109,7 +109,7 @@ class GLWidgetTest( GafferUITest.TestCase ) :
 		b = GafferUI.Button()
 
 		w.setChild( g )
-		g.addOverlay( f )
+		g.setOverlay( f )
 		f.setChild( b )
 
 		w.setVisible( True )
@@ -124,6 +124,24 @@ class GLWidgetTest( GafferUITest.TestCase ) :
 		bP = GafferUI.Widget.mousePosition( relativeTo = b )
 
 		self.assertEqual( bBound.min - wBound.min, wP - bP )
+
+	def testOverlayAccessors( self ) :
+
+		g = GafferUI.GLWidget()
+		self.assertEqual( g.getOverlay(), None )
+
+		b1 = GafferUI.Button()
+		b2 = GafferUI.Button()
+		self.assertEqual( b1.parent(), None )
+		self.assertEqual( b2.parent(), None )
+
+		g.setOverlay( b1 )
+		self.assertEqual( b1.parent(), g )
+		self.assertEqual( b2.parent(), None )
+
+		g.setOverlay( b2 )
+		self.assertEqual( b1.parent(), None )
+		self.assertEqual( b2.parent(), g )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/PlugLayoutTest.py
+++ b/python/GafferUITest/PlugLayoutTest.py
@@ -293,5 +293,18 @@ class PlugLayoutTest( GafferUITest.TestCase ) :
 		self.assertFalse( l2.plugValueWidget( n["p1"], lazy = False ).enabled() )
 		self.assertTrue( l2.plugValueWidget( n["p2"], lazy = False ).enabled() )
 
+	def testRootSection( self ) :
+
+		n = Gaffer.Node()
+		n["p1"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		n["p2"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		Gaffer.Metadata.registerPlugValue( n["p2"], "layout:section", "sectionA" )
+
+		l = GafferUI.PlugLayout( n, rootSection = "sectionA" )
+
+		self.assertTrue( l.plugValueWidget( n["p1"], lazy = False ) is None )
+		self.assertTrue( l.plugValueWidget( n["p2"], lazy = False ) is not None )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/PlugLayoutTest.py
+++ b/python/GafferUITest/PlugLayoutTest.py
@@ -266,5 +266,32 @@ class PlugLayoutTest( GafferUITest.TestCase ) :
 		p["value"].setValue( True )
 		self.assertEqual( l.plugValueWidget( s["n"]["s"], lazy = False ).enabled(), True )
 
+	def testMultipleLayouts( self ) :
+
+		n = Gaffer.Node()
+		n["p1"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		n["p2"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		Gaffer.Metadata.registerNodeValue( n, "layout1:activator:true", True )
+		Gaffer.Metadata.registerNodeValue( n, "layout1:activator:false", False )
+
+		Gaffer.Metadata.registerNodeValue( n, "layout2:activator:true", True )
+		Gaffer.Metadata.registerNodeValue( n, "layout2:activator:false", False )
+
+		Gaffer.Metadata.registerPlugValue( n["p1"], "layout1:activator", "true" )
+		Gaffer.Metadata.registerPlugValue( n["p1"], "layout2:activator", "false" )
+
+		Gaffer.Metadata.registerPlugValue( n["p2"], "layout1:activator", "false" )
+		Gaffer.Metadata.registerPlugValue( n["p2"], "layout2:activator", "true" )
+
+		l1 = GafferUI.PlugLayout( n, layoutName = "layout1" )
+		l2 = GafferUI.PlugLayout( n, layoutName = "layout2" )
+
+		self.assertTrue( l1.plugValueWidget( n["p1"], lazy = False ).enabled() )
+		self.assertFalse( l1.plugValueWidget( n["p2"], lazy = False ).enabled() )
+
+		self.assertFalse( l2.plugValueWidget( n["p1"], lazy = False ).enabled() )
+		self.assertTrue( l2.plugValueWidget( n["p2"], lazy = False ).enabled() )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferImageUI/ImageGadget.cpp
+++ b/src/GafferImageUI/ImageGadget.cpp
@@ -1,0 +1,658 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/bind.hpp"
+#include "boost/algorithm/string/predicate.hpp"
+#include "boost/lexical_cast.hpp"
+
+#include "IECoreGL/Selector.h"
+#include "IECoreGL/LuminanceTexture.h"
+#include "IECoreGL/IECoreGL.h"
+#include "IECoreGL/ShaderLoader.h"
+#include "IECoreGL/Shader.h"
+#include "IECoreGL/GL.h"
+
+#include "Gaffer/Node.h"
+#include "Gaffer/Context.h"
+
+#include "GafferUI/Style.h"
+#include "GafferUI/ViewportGadget.h"
+
+#include "GafferImage/ImagePlug.h"
+#include "GafferImage/ImageAlgo.h"
+
+#include "GafferImageUI/ImageGadget.h"
+
+using namespace std;
+using namespace boost;
+using namespace Imath;
+using namespace IECore;
+using namespace IECoreGL;
+using namespace Gaffer;
+using namespace GafferUI;
+using namespace GafferImage;
+using namespace GafferImageUI;
+
+//////////////////////////////////////////////////////////////////////////
+// ImageGadget implementation
+//////////////////////////////////////////////////////////////////////////
+
+ImageGadget::ImageGadget()
+	:	Gadget( defaultName<ImageGadget>() ),
+		m_image( NULL ),
+		m_soloChannel( -1 ),
+		m_dirtyFlags( AllDirty )
+{
+	/// \todo Expose accessors to allow the user
+	/// to choose which channels are displayed.
+	/// What form should this take though? Should they
+	/// choose a layer name, or should they choose any
+	/// set of 4 channels?
+	m_rgbaChannels[0] = "R";
+	m_rgbaChannels[1] = "G";
+	m_rgbaChannels[2] = "B";
+	m_rgbaChannels[3] = "A";
+
+	setContext( new Context() );
+}
+
+ImageGadget::~ImageGadget()
+{
+}
+
+void ImageGadget::setImage( GafferImage::ConstImagePlugPtr image )
+{
+	if( image == m_image )
+	{
+		return;
+	}
+
+	m_image = image;
+	if( Gaffer::Node *node = const_cast<Gaffer::Node *>( image->node() ) )
+	{
+		m_plugDirtiedConnection = node->plugDirtiedSignal().connect( boost::bind( &ImageGadget::plugDirtied, this, ::_1 ) );
+	}
+	else
+	{
+		m_plugDirtiedConnection.disconnect();
+	}
+
+	m_dirtyFlags = AllDirty;
+	requestRender();
+}
+
+const GafferImage::ImagePlug *ImageGadget::getImage() const
+{
+	return m_image.get();
+}
+
+void ImageGadget::setContext( Gaffer::ContextPtr context )
+{
+	if( context == m_context )
+	{
+		return;
+	}
+
+	m_context = context;
+	m_contextChangedConnection = m_context->changedSignal().connect( boost::bind( &ImageGadget::contextChanged, this, ::_2 ) );
+
+	m_dirtyFlags = AllDirty;
+	requestRender();
+}
+
+Gaffer::Context *ImageGadget::getContext()
+{
+	return m_context.get();
+}
+
+const Gaffer::Context *ImageGadget::getContext() const
+{
+	return m_context.get();
+}
+
+void ImageGadget::setSoloChannel( int index )
+{
+	if( index == m_soloChannel )
+	{
+		return;
+	}
+	if( index < -1 || index > 3 )
+	{
+		throw Exception( "Invalid index" );
+	}
+
+	m_soloChannel = index;
+	requestRender();
+}
+
+int ImageGadget::getSoloChannel() const
+{
+	return m_soloChannel;
+}
+
+Imath::Box3f ImageGadget::bound() const
+{
+	const Format f = format();
+	const Box2i &w = f.getDisplayWindow();
+	if( empty( w ) )
+	{
+		return Box3f();
+	}
+
+	const float a = f.getPixelAspect();
+	return Box3f(
+		V3f( (float)w.min.x * a, (float)w.min.y, 0 ),
+		V3f( (float)w.max.x * a, (float)w.max.y, 0 )
+	);
+}
+
+void ImageGadget::plugDirtied( const Gaffer::Plug *plug )
+{
+	if( plug == m_image->formatPlug() )
+	{
+		m_dirtyFlags |= FormatDirty;
+	}
+	else if( plug == m_image->dataWindowPlug() )
+	{
+		m_dirtyFlags |= DataWindowDirty | TilesDirty;
+	}
+	else if( plug == m_image->channelNamesPlug() )
+	{
+		m_dirtyFlags |= ChannelNamesDirty | TilesDirty;
+	}
+	else if( plug == m_image->channelDataPlug() )
+	{
+		m_dirtyFlags |= TilesDirty;
+	}
+
+	if( m_dirtyFlags )
+	{
+		requestRender();
+	}
+}
+
+void ImageGadget::contextChanged( const IECore::InternedString &name )
+{
+	if( !boost::starts_with( name.string(), "ui:" ) )
+	{
+		m_dirtyFlags = AllDirty;
+		requestRender();
+	}
+}
+
+//////////////////////////////////////////////////////////////////////////
+// Image property access.
+//////////////////////////////////////////////////////////////////////////
+
+const GafferImage::Format &ImageGadget::format() const
+{
+	if( m_dirtyFlags & FormatDirty )
+	{
+		if( !m_image )
+		{
+			m_format = Format();
+		}
+		else
+		{
+			Context::Scope scopedContext( m_context.get() );
+			m_format = m_image->formatPlug()->getValue();
+		}
+		m_dirtyFlags &= ~FormatDirty;
+	}
+
+	return m_format;
+}
+
+const Imath::Box2i &ImageGadget::dataWindow() const
+{
+	if( m_dirtyFlags & DataWindowDirty )
+	{
+		if( !m_image )
+		{
+			m_dataWindow = Box2i();
+		}
+		else
+		{
+			Context::Scope scopedContext( m_context.get() );
+			m_dataWindow = m_image->dataWindowPlug()->getValue();
+		}
+		m_dirtyFlags &= ~DataWindowDirty;
+	}
+
+	return m_dataWindow;
+}
+
+const std::vector<std::string> &ImageGadget::channelNames() const
+{
+	if( m_dirtyFlags & ChannelNamesDirty )
+	{
+		if( !m_image )
+		{
+			m_channelNames.clear();
+		}
+		else
+		{
+			Context::Scope scopedContext( m_context.get() );
+			m_channelNames = m_image->channelNamesPlug()->getValue()->readable();
+		}
+		m_dirtyFlags &= ~ChannelNamesDirty;
+	}
+	return m_channelNames;
+}
+
+//////////////////////////////////////////////////////////////////////////
+// Tile storage
+//////////////////////////////////////////////////////////////////////////
+
+// Needed to allow TileIndex to be used as a key in concurrent_unordered_map.
+inline size_t GafferImageUI::tbb_hasher( const ImageGadget::TileIndex &tileIndex )
+{
+	return
+		tbb::tbb_hasher( tileIndex.tileOrigin.x ) ^
+		tbb::tbb_hasher( tileIndex.tileOrigin.y ) ^
+		tbb::tbb_hasher( tileIndex.channelName.c_str() );
+}
+
+// Tests to see if a tile needs updating, and if it does, computes
+// the channel data to go into it.
+struct ImageGadget::TileFunctor
+{
+
+	TileFunctor( Tiles &tiles )
+		:	m_tiles( tiles )
+	{
+	}
+
+	void operator()( const ImagePlug *image, const string &channelName, const V2i &tileOrigin )
+	{
+		Tile &tile = m_tiles[TileIndex(tileOrigin, channelName)];
+		ConstFloatVectorDataPtr channelData;
+		const IECore::MurmurHash h = image->channelDataPlug()->hash();
+		if( !tile.texture || tile.channelDataHash != h )
+		{
+			tile.channelDataToConvert = image->channelDataPlug()->getValue( &h );
+			tile.channelDataHash = h;
+		}
+	}
+
+	private :
+
+		Tiles &m_tiles;
+
+};
+
+void ImageGadget::updateTiles() const
+{
+	if( !(m_dirtyFlags & TilesDirty) )
+	{
+		return;
+	}
+
+	removeOutOfBoundsTiles();
+
+	// Decide which channels to compute. This is the intersection
+	// of the available channels (channelNames) and the channels
+	// we want to display (m_rgbaChannels).
+	const vector<string> &channelNames = this->channelNames();
+	vector<string> channelsToCompute;
+	for( vector<string>::const_iterator it = channelNames.begin(), eIt = channelNames.end(); it != eIt; ++it )
+	{
+		if( find( m_rgbaChannels.begin(), m_rgbaChannels.end(), *it ) != m_rgbaChannels.end() )
+		{
+			if( m_soloChannel == -1 || m_rgbaChannels[m_soloChannel] == *it )
+			{
+				channelsToCompute.push_back( *it );
+			}
+		}
+	}
+
+	// Use parallelGatherTiles() to do the hard work of launching
+	// threads and iterating over tiles to get any modified channelData.
+	TileFunctor tileFunctor( m_tiles );
+	{
+		Context::Scope scopedContext( m_context.get() );
+		parallelProcessTiles( m_image.get(), channelsToCompute, tileFunctor, dataWindow() );
+	}
+
+	// Now take the new channelData and convert it into textures for display.
+	// We must do this on the main thread because it involves OpenGL.
+	for( Tiles::iterator it = m_tiles.begin(); it != m_tiles.end(); ++it )
+	{
+		if( it->second.channelDataToConvert )
+		{
+			GLuint texture;
+			glGenTextures( 1, &texture );
+			it->second.texture = new Texture( texture );
+			Texture::ScopedBinding binding( *it->second.texture );
+
+			glPixelStorei( GL_UNPACK_ALIGNMENT, 1 );
+			glTexImage2D( GL_TEXTURE_2D, 0, GL_LUMINANCE, ImagePlug::tileSize(), ImagePlug::tileSize(), 0, GL_LUMINANCE,
+				GL_FLOAT, &it->second.channelDataToConvert->readable().front() );
+
+			glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST );
+			glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST );
+			glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE );
+			glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE );
+
+			it->second.channelDataToConvert = NULL;
+		}
+	}
+	m_dirtyFlags &= ~TilesDirty;
+}
+
+void ImageGadget::removeOutOfBoundsTiles() const
+{
+	// In theory, any given tile we hold could turn out to be valid
+	// for some future image we want to display, particularly if the
+	// user is switching back and forth between the same images. But
+	// we don't want to accumulate unbounded numbers of tiles either,
+	// so here we prune out any tiles that we know can't be useful for
+	// the current image, because they either have an invalid channel
+	// name or are outside the data window.
+	const Box2i &dw = dataWindow();
+	const vector<string> &ch = channelNames();
+	for( Tiles::iterator it = m_tiles.begin(); it != m_tiles.end(); )
+	{
+		const Box2i tileBound( it->first.tileOrigin, it->first.tileOrigin + V2i( ImagePlug::tileSize() ) );
+		if( !intersects( dw, tileBound ) || find( ch.begin(), ch.end(), it->first.channelName.string() ) == ch.end() )
+		{
+			it = m_tiles.unsafe_erase( it );
+		}
+		else
+		{
+			++it;
+		}
+	}
+}
+
+//////////////////////////////////////////////////////////////////////////
+// Rendering
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+const char *vertexSource()
+{
+	static const char *g_vertexSource =
+	"void main()"
+	"{"
+	"	gl_Position = gl_ProjectionMatrix * gl_ModelViewMatrix * gl_Vertex;"
+	"	gl_TexCoord[0] = gl_MultiTexCoord0;"
+	"}";
+
+	return g_vertexSource;
+}
+
+const std::string &fragmentSource()
+{
+	static std::string g_fragmentSource;
+	if( g_fragmentSource.empty() )
+	{
+		g_fragmentSource =
+
+		"uniform sampler2D redTexture;\n"
+		"uniform sampler2D greenTexture;\n"
+		"uniform sampler2D blueTexture;\n"
+		"uniform sampler2D alphaTexture;\n"
+
+		"#if __VERSION__ >= 330\n"
+
+		"layout( location=0 ) out vec4 outColor;\n"
+		"#define OUTCOLOR outColor\n"
+
+		"#else\n"
+
+		"#define OUTCOLOR gl_FragColor\n"
+
+		"#endif\n"
+
+		"void main()"
+		"{"
+		"	OUTCOLOR = vec4(\n"
+		"		texture2D( redTexture, gl_TexCoord[0].xy ).r,\n"
+		"		texture2D( greenTexture, gl_TexCoord[0].xy ).r,\n"
+		"		texture2D( blueTexture, gl_TexCoord[0].xy ).r,\n"
+		"		texture2D( alphaTexture, gl_TexCoord[0].xy ).r\n"
+		"	);"
+		"}";
+
+		if( glslVersion() >= 330 )
+		{
+			// the __VERSION__ define is a workaround for the fact that cortex's source preprocessing doesn't
+			// define it correctly in the same way as the OpenGL shader preprocessing would.
+			g_fragmentSource = "#version 330 compatibility\n #define __VERSION__ 330\n\n" + g_fragmentSource;
+		}
+	}
+	return g_fragmentSource;
+}
+
+IECoreGL::Shader *shader()
+{
+	static IECoreGL::ShaderPtr g_shader;
+	if( !g_shader )
+	{
+		g_shader = ShaderLoader::defaultShaderLoader()->create( vertexSource(), "", fragmentSource() );
+	}
+	return g_shader.get();
+}
+
+IECoreGL::Texture *blackTexture()
+{
+	static IECoreGL::TexturePtr g_texture;
+	if( !g_texture )
+	{
+		GLuint texture;
+		glGenTextures( 1, &texture );
+		g_texture = new Texture( texture );
+		Texture::ScopedBinding binding( *g_texture );
+
+		const float black = 0;
+		glPixelStorei( GL_UNPACK_ALIGNMENT, 1 );
+		glTexImage2D( GL_TEXTURE_2D, 0, GL_LUMINANCE, /* width = */ 1, /* height = */ 1, 0, GL_LUMINANCE,
+			GL_FLOAT, &black );
+	}
+	return g_texture.get();
+}
+
+} // namespace
+
+void ImageGadget::renderTiles() const
+{
+	updateTiles();
+
+	GLint previousProgram;
+	glGetIntegerv( GL_CURRENT_PROGRAM, &previousProgram );
+
+	PushAttrib pushAttrib( GL_COLOR_BUFFER_BIT );
+
+	Shader *shader = ::shader();
+	glUseProgram( shader->program() );
+
+	glEnable( GL_TEXTURE_2D );
+
+	glEnable( GL_BLEND );
+	glBlendFunc( GL_ONE, GL_ONE_MINUS_SRC_ALPHA );
+
+	GLuint textureUnits[4];
+	textureUnits[0] = shader->uniformParameter( "redTexture" )->textureUnit;
+	textureUnits[1] = shader->uniformParameter( "greenTexture" )->textureUnit;
+	textureUnits[2] = shader->uniformParameter( "blueTexture" )->textureUnit;
+	textureUnits[3] = shader->uniformParameter( "alphaTexture" )->textureUnit;
+
+	glUniform1i( shader->uniformParameter( "redTexture" )->location, textureUnits[0] );
+	glUniform1i( shader->uniformParameter( "greenTexture" )->location, textureUnits[1] );
+	glUniform1i( shader->uniformParameter( "blueTexture" )->location, textureUnits[2] );
+	glUniform1i( shader->uniformParameter( "alphaTexture" )->location, textureUnits[3] );
+
+	const Box2i dataWindow = this->dataWindow();
+
+	V2i tileOrigin = ImagePlug::tileOrigin( dataWindow.min );
+	for( ; tileOrigin.y < dataWindow.max.y; tileOrigin.y += ImagePlug::tileSize() )
+	{
+		for( tileOrigin.x = ImagePlug::tileOrigin( dataWindow.min ).x; tileOrigin.x < dataWindow.max.x; tileOrigin.x += ImagePlug::tileSize() )
+		{
+			for( int i = 0; i < 4; ++i )
+			{
+				glActiveTexture( GL_TEXTURE0 + textureUnits[i] );
+				const InternedString channelName = m_soloChannel == -1 ? m_rgbaChannels[i] : m_rgbaChannels[m_soloChannel];
+				Tiles::const_iterator it = m_tiles.find( TileIndex( tileOrigin, channelName ) );
+				if( it != m_tiles.end()  && it->second.texture )
+				{
+					it->second.texture->bind();
+				}
+				else
+				{
+					blackTexture()->bind();
+				}
+			}
+
+			const Box2i tileBound( tileOrigin, tileOrigin + V2i( ImagePlug::tileSize() ) );
+			const Box2i validBound = intersection( tileBound, dataWindow );
+			const Box2f uvBound(
+				V2f(
+					lerpfactor<float>( validBound.min.x, tileBound.min.x, tileBound.max.x ),
+					lerpfactor<float>( validBound.min.y, tileBound.min.y, tileBound.max.y )
+				),
+				V2f(
+					lerpfactor<float>( validBound.max.x, tileBound.min.x, tileBound.max.x ),
+					lerpfactor<float>( validBound.max.y, tileBound.min.y, tileBound.max.y )
+				)
+			);
+
+			glBegin( GL_QUADS );
+
+				glTexCoord2f( uvBound.min.x, uvBound.min.y  );
+				glVertex2f( validBound.min.x, validBound.min.y );
+
+				glTexCoord2f( uvBound.min.x, uvBound.max.y  );
+				glVertex2f( validBound.min.x, validBound.max.y );
+
+				glTexCoord2f( uvBound.max.x, uvBound.max.y  );
+				glVertex2f( validBound.max.x, validBound.max.y );
+
+				glTexCoord2f( uvBound.max.x, uvBound.min.y  );
+				glVertex2f( validBound.max.x, validBound.min.y );
+
+			glEnd();
+
+		}
+	}
+
+	glUseProgram( previousProgram );
+}
+
+void ImageGadget::renderText( const std::string &text, const Imath::V2f &position, const Imath::V2f &alignment, const GafferUI::Style *style ) const
+{
+	const float scale = 10.0f;
+	const ViewportGadget *viewport = ancestor<ViewportGadget>();
+	const V2f rasterPosition = viewport->gadgetToRasterSpace( V3f( position.x, position.y, 0.0f ), this );
+	const Box3f bound = style->textBound( Style::LabelText, text );
+
+	ViewportGadget::RasterScope rasterScope( viewport );
+	glTranslate( V2f(
+		rasterPosition.x - scale * lerp( bound.min.x, bound.max.x, alignment.x ),
+		rasterPosition.y + scale * lerp( bound.min.y, bound.max.y, alignment.y )
+	) );
+
+	glScalef( scale, -scale, scale );
+	style->renderText( Style::LabelText, text );
+}
+
+void ImageGadget::doRender( const GafferUI::Style *style ) const
+{
+	if( IECoreGL::Selector::currentSelector() )
+	{
+		return;
+	}
+
+	const Format &format = this->format();
+	const Box2i &displayWindow = format.getDisplayWindow();
+	if( empty( displayWindow ) )
+	{
+		return;
+	}
+
+	// Render a black background the size of the image.
+
+	glColor3f( 0.0f, 0.0f, 0.0f );
+	style->renderSolidRectangle( Box2f( V2f( displayWindow.min ), V2f( displayWindow.max ) ) );
+	const Box2i &dataWindow = this->dataWindow();
+	if( !empty( dataWindow ) )
+	{
+		style->renderSolidRectangle( Box2f( V2f( dataWindow.min ), V2f( dataWindow.max ) ) );
+	}
+
+	// Draw the image tiles over the top.
+
+	renderTiles();
+
+	// And add overlays for the display and data windows.
+
+	glColor3f( 0.1f, 0.1f, 0.1f );
+	style->renderRectangle( Box2f( V2f( displayWindow.min ), V2f( displayWindow.max ) ) );
+
+	string formatText = Format::name( format );
+	const string dimensionsText = lexical_cast<string>( displayWindow.size().x ) + " x " +  lexical_cast<string>( displayWindow.size().y );
+	if( formatText.empty() )
+	{
+		formatText = dimensionsText;
+	}
+	else
+	{
+		formatText += " ( " + dimensionsText + " )";
+	}
+
+	renderText( formatText, V2f( displayWindow.center().x, displayWindow.min.y ), V2f( 0.5, 1.5 ), style );
+
+	if( displayWindow.min != V2i( 0 ) )
+	{
+		renderText( lexical_cast<string>( displayWindow.min ), displayWindow.min, V2f( 1, 1.5 ), style );
+		renderText( lexical_cast<string>( displayWindow.max ), displayWindow.max, V2f( 0, -0.5 ), style );
+	}
+
+	if( !empty( dataWindow ) && dataWindow != displayWindow )
+	{
+		glColor3f( 0.5f, 0.5f, 0.5f );
+		style->renderRectangle( Box2f( V2f( dataWindow.min ), V2f( dataWindow.max ) ) );
+
+		if( dataWindow.min != displayWindow.min )
+		{
+			renderText( lexical_cast<string>( dataWindow.min ), dataWindow.min, V2f( 1, 1.5 ), style );
+			renderText( lexical_cast<string>( dataWindow.max ), dataWindow.max, V2f( 0, -0.5 ), style );
+		}
+	}
+}

--- a/src/GafferImageUI/ImageView.cpp
+++ b/src/GafferImageUI/ImageView.cpp
@@ -147,7 +147,7 @@ class ImageView::ColorInspector : public boost::signals::trackable
 		{
 			if( event.buttons != ButtonEvent::Left || event.modifiers )
 			{
-				return false;
+				return NULL;
 			}
 
 			Pointer::setCurrent( "rgba" );

--- a/src/GafferImageUI/ImageView.cpp
+++ b/src/GafferImageUI/ImageView.cpp
@@ -150,10 +150,22 @@ class ImageView::ColorInspector : public boost::signals::trackable
 				return NULL;
 			}
 
+			Color4f color;
+			try
+			{
+				Context::Scope scopedContext( m_view->getContext() );
+				color = plug()->getChild<Color4fPlug>( "color" )->getValue();
+			}
+			catch( ... )
+			{
+				// If there's an error computing the image, we can't
+				// start a drag.
+				return NULL;
+			}
+
 			Pointer::setCurrent( "rgba" );
 
-			Context::Scope scopedContext( m_view->getContext() );
-			return new Color4fData( plug()->getChild<Color4fPlug>( "color" )->getValue() );
+			return new Color4fData( color );
 		}
 
 		bool dragEnd( const ButtonEvent &event )

--- a/src/GafferImageUI/ImageView.cpp
+++ b/src/GafferImageUI/ImageView.cpp
@@ -82,844 +82,90 @@ using namespace GafferUI;
 using namespace GafferImage;
 using namespace GafferImageUI;
 
-namespace GafferImageUI
-{
+//////////////////////////////////////////////////////////////////////////
+/// Implementation of ImageView::ColorInspector
+//////////////////////////////////////////////////////////////////////////
 
-namespace Detail
-{
-
-/// \todo Refactor all the colour sampling and swatch drawing out of here.
-/// Sampled colours should be available on the ImageView as output plugs,
-/// and a new FooterToolbar type thing in the Viewer should be used for drawing
-/// them using the standard Widget classes. The ImageViewGadget itself should be
-/// responsible only for the setting of the input plugs on the samplers during
-/// mouse move and drag and drop operations. This way the Widgets will give us all
-/// the colour correction (using GafferUI.DisplayTransform), text selection and drag
-/// and drop we could desire for free.
-class ImageViewGadget : public GafferUI::Gadget
+class ImageView::ColorInspector : public boost::signals::trackable
 {
 
 	public :
 
-		ImageViewGadget(
-			IECore::ConstImagePrimitivePtr image,
-			GafferImage::ImageStatsPtr imageStats,
-			GafferImage::ImageSamplerPtr imageSampler,
-			ConstContextPtr context,
-			int &channelToView,
-			Imath::V2f &mousePos,
-			Color4f &sampleColor,
-			Color4f &minColor,
-			Color4f &maxColor,
-			Color4f &averageColor
-		)
-			:	Gadget( defaultName<ImageViewGadget>() ),
-				m_displayBound( image->bound() ),
-				m_displayWindow( image->getDisplayWindow() ),
-				m_dataWindow( image->getDataWindow() ),
-				m_image( image->copy() ),
-				m_texture( 0 ),
-				m_mousePos( mousePos ),
-				m_sampleColor( 0.f ),
-				m_dragSelecting( false ),
-				m_drawSelection( false ),
-				m_channelToView( channelToView ),
-				m_hasAlpha( false ),
-				m_imageStats( imageStats ),
-				m_imageSampler( imageSampler ),
-				m_context( context )
+		ColorInspector( ImageView *view )
+			:	m_view( view ),
+				m_sampler( new ImageSampler )
 		{
-			m_displayWindow.max += Imath::V2i( 1 );
-			m_dataWindow.max += Imath::V2i( 1 );
-
-			V2f displayWindowCenter( ( m_displayWindow.min + m_displayWindow.max ) / Imath::V2f( 2. ) );
-			V2f dataWindowCenter( ( m_dataWindow.min + m_dataWindow.max ) / Imath::V2f( 2. ) );
-			V2f offset( dataWindowCenter.x - displayWindowCenter.x, displayWindowCenter.y - dataWindowCenter.y );
-
-			m_dataBound = Box3f(
-				V3f(
-					offset.x - ( m_dataWindow.size().x ) / 2.,
-					offset.y - ( m_dataWindow.size().y ) / 2.,
-					0.f
-				),
-				V3f(
-					offset.x + ( m_dataWindow.size().x ) / 2.,
-					offset.y + ( m_dataWindow.size().y ) / 2.,
-					0.f
-				)
-			);
-
-			keyPressSignal().connect( boost::bind( &ImageViewGadget::keyPress, this, ::_1,  ::_2 ) );
-			buttonPressSignal().connect( boost::bind( &ImageViewGadget::buttonPress, this, ::_1,  ::_2 ) );
-			buttonReleaseSignal().connect( boost::bind( &ImageViewGadget::buttonRelease, this, ::_1,  ::_2 ) );
-			dragBeginSignal().connect( boost::bind( &ImageViewGadget::dragBegin, this, ::_1, ::_2 ) );
-			dragEnterSignal().connect( boost::bind( &ImageViewGadget::dragEnter, this, ::_1, ::_2 ) );
-			dragMoveSignal().connect( boost::bind( &ImageViewGadget::dragMove, this, ::_1, ::_2 ) );
-			dragEndSignal().connect( boost::bind( &ImageViewGadget::dragEnd, this, ::_1, ::_2 ) );
-			mouseMoveSignal().connect( boost::bind( &ImageViewGadget::mouseMove, this, ::_1, ::_2 ) );
-
-			sampleColor = ImageViewGadget::sampleColor( mousePos );
-
-			// Create some useful structs that we will use to hold information needed
-			// to draw the UI elements that display the color readouts to the screen.
-			m_colorUiElements.reserve(4);
-			m_colorUiElements.push_back( ColorUiElement( sampleColor ) );
-			m_colorUiElements.push_back( ColorUiElement( minColor ) );
-			m_colorUiElements.push_back( ColorUiElement( maxColor ) );
-			m_colorUiElements.push_back( ColorUiElement( averageColor ) );
-			m_colorUiElements[0].name = "RGBA"; // The color under the mouse pointer.
-			m_colorUiElements[0].draw = true;
-			m_colorUiElements[0].position = V2i( 135, 0 );
-			m_colorUiElements[0].hsv = true;
-			m_colorUiElements[1].name = "Min"; // The minimum color within a selection.
-			m_colorUiElements[1].position = V2i( 135, 19 );
-			m_colorUiElements[2].name = "Max"; // The maximum color within a selection.
-			m_colorUiElements[2].position = V2i( 385, 19 );
-			m_colorUiElements[3].name = "Mean"; // The mean color within a selection.
-			m_colorUiElements[3].position = V2i( 635, 19 );
-
-			std::vector< std::string > channelNames;
-			m_image->channelNames( channelNames );
-			m_hasAlpha = std::find( channelNames.begin(), channelNames.end(), "A" ) != channelNames.end();
-		}
-
-		virtual ~ImageViewGadget()
-		{
-		};
-
-		virtual Imath::Box3f bound() const
-		{
-			///\todo: Return an extended bounding box here which includes the infoBox() UI element.
-			/// This allows the image to be framed properly when the "f" button has been pressed to
-			/// focus the viewer on an image.
-			return m_displayBound;
-		}
-
-	protected :
-
-		static const char *vertexSource()
-		{
-			static const char *g_vertexSource =
-			"void main()"
-			"{"
-			"	gl_Position = gl_ProjectionMatrix * gl_ModelViewMatrix * gl_Vertex;"
-			"	gl_FrontColor = gl_Color;"
-			"	gl_BackColor = gl_Color;"
-			"	gl_TexCoord[0] = gl_MultiTexCoord0;"
-			"}";
-
-			return g_vertexSource;
-		}
-
-		static const std::string &fragmentSource()
-		{
-			static std::string g_fragmentSource;
-			if( g_fragmentSource.empty() )
-			{
-				g_fragmentSource =
-
-				"#include \"IECoreGL/FilterAlgo.h\"\n"
-				"#include \"IECoreGL/ColorAlgo.h\"\n"
-
-				"uniform sampler2D texture;"
-				"uniform int channelToView;\n"
-
-				"#if __VERSION__ >= 330\n"
-
-				"uniform uint ieCoreGLNameIn;\n"
-				"layout( location=0 ) out vec4 outColor;\n"
-				"layout( location=1 ) out uint ieCoreGLNameOut;\n"
-				"#define OUTCOLOR outColor\n"
-
-				"#else\n"
-
-				"#define OUTCOLOR gl_FragColor\n"
-
-				"#endif\n"
-
-				"void main()"
-				"{"
-				"	OUTCOLOR = texture2D( texture, gl_TexCoord[0].xy );"
-				"	if( channelToView==1 )"
-				"	{"
-				"		OUTCOLOR = vec4( OUTCOLOR[0], OUTCOLOR[0], OUTCOLOR[0], 1. );"
-				"	}"
-				"	else if( channelToView==2 )"
-				"	{"
-				"		OUTCOLOR = vec4( OUTCOLOR[1], OUTCOLOR[1], OUTCOLOR[1], 1. );"
-				"	}"
-				"	else if( channelToView==3 )"
-				"	{"
-				"		OUTCOLOR = vec4( OUTCOLOR[2], OUTCOLOR[2], OUTCOLOR[2], 1. );"
-				"	}"
-				"	else if( channelToView==4 )"
-				"	{"
-				"		OUTCOLOR = vec4( OUTCOLOR[3], OUTCOLOR[3], OUTCOLOR[3], 1. );"
-				"	}\n"
-
-				"#if __VERSION__ >= 330\n"
-				"	ieCoreGLNameOut = ieCoreGLNameIn;\n"
-				"#endif\n"
-				"}";
-
-				if( glslVersion() >= 330 )
-				{
-					// the __VERSION__ define is a workaround for the fact that cortex's source preprocessing doesn't
-					// define it correctly in the same way as the OpenGL shader preprocessing would.
-					g_fragmentSource = "#version 330 compatibility\n #define __VERSION__ 330\n\n" + g_fragmentSource;
-				}
-			}
-			return g_fragmentSource;
-		}
-
-		static IECoreGL::ShaderPtr shader()
-		{
-			static IECoreGL::ShaderPtr g_shader = 0;
-			if( !g_shader )
-			{
-				g_shader = ShaderLoader::defaultShaderLoader()->create( vertexSource(), "", fragmentSource() );
-			}
-			return g_shader.get();
-		}
-
-		void renderImageWindow( const Imath::Box2f &box, const IECoreGL::Texture *texture, int channelToView ) const
-		{
-			glPushAttrib( GL_COLOR_BUFFER_BIT );
-
-			glEnable( GL_BLEND );
-			glBlendFunc( GL_ONE, GL_ONE_MINUS_SRC_ALPHA );
-
-			glEnable( GL_TEXTURE_2D );
-			glActiveTexture( GL_TEXTURE0 );
-			texture->bind();
-
-			IECoreGL::Shader::SetupPtr setup( new IECoreGL::Shader::Setup( shader() ) );
-			setup->addUniformParameter( "texture", texture );
-
-			const IECore::IntDataPtr channelToViewData( new IECore::IntData( channelToView ) );
-			setup->addUniformParameter( "channelToView", boost::static_pointer_cast<const IECore::Data>( channelToViewData ) );
-			IECoreGL::Shader::Setup::ScopedBinding b( *setup );
-
-			glColor3f( 1.0f, 1.0f, 1.0f );
-
-			glBegin( GL_QUADS );
-
-			glTexCoord2f( 1, 0 );
-			glVertex2f( box.max.x, box.min.y );
-			glTexCoord2f( 1, 1 );
-			glVertex2f( box.max.x, box.max.y );
-			glTexCoord2f( 0, 1 );
-			glVertex2f( box.min.x, box.max.y );
-			glTexCoord2f( 0, 0 );
-			glVertex2f( box.min.x, box.min.y );
-
-			glEnd();
-
-			glPopAttrib();
-		}
-
-		bool keyPress( GadgetPtr gadget, const KeyEvent &event )
-		{
-			int channel = All;
-			if( event.key=="R" )
-			{
-				channel = Red;
-			}
-			else if( event.key=="G" )
-			{
-				channel = Green;
-			}
-			else if( event.key=="B" )
-			{
-				channel = Blue;
-			}
-			else if( event.key=="A" )
-			{
-				channel = Alpha;
-			}
-			else
-			{
-				return false;
-			}
-
-			if( channel == m_channelToView )
-			{
-				m_channelToView = All;
-			}
-			else
-			{
-				m_channelToView = channel;
-			}
-
-			requestRender();
-
-			return true;
-		}
-
-		/// Returns the data window of the image in raster space.
-		inline Box2f dataRasterBox() const
-		{
-			const ViewportGadget *viewportGadget = ancestor<ViewportGadget>();
-			return Box2f(
-					viewportGadget->gadgetToRasterSpace( V3f( m_dataBound.min.x, m_dataBound.min.y, 0.), this ),
-					viewportGadget->gadgetToRasterSpace( V3f( m_dataBound.max.x, m_dataBound.max.y, 0.), this )
-					);
-		}
-
-		/// Returns the display window of the image in raster space.
-		inline Box2f displayRasterBox() const
-		{
-			const ViewportGadget *viewportGadget = ancestor<ViewportGadget>();
-			return Box2f(
-					viewportGadget->gadgetToRasterSpace( V3f( m_displayBound.min.x, m_displayBound.min.y, 0.), this ),
-					viewportGadget->gadgetToRasterSpace( V3f( m_displayBound.max.x, m_displayBound.max.y, 0.), this )
-					);
-		}
-
-		/// Transforms and returns a point from raster space to display space.
-		V2f rasterToDisplaySpace( const V2f &point ) const
-		{
-			Box2f dispRasterBox( displayRasterBox() );
-			V2f wh( ( dispRasterBox.max.x - dispRasterBox.min.x ), ( dispRasterBox.min.y - dispRasterBox.max.y ) );
-			V2f t( ( point[0] - dispRasterBox.min.x ) / wh[0], ( point[1] - dispRasterBox.max.y ) / wh[1] );
-			return V2f(
-				float( m_displayWindow.min.x ) + ( t.x * ( m_displayWindow.size().x ) ),
-				float( m_displayWindow.max.y ) - ( t.y * ( m_displayWindow.size().y ) )
-			);
-		}
-
-		Box2f rasterToDisplaySpace( const Box2f &box ) const
-		{
-			return Box2f( rasterToDisplaySpace( box.min ), rasterToDisplaySpace( box.max ) );
-		}
-
-		/// Transforms and returns a point from raster to display space.
-		V2f gadgetToDisplaySpace( const V3f &point ) const
-		{
-			const ViewportGadget *viewportGadget = ancestor<ViewportGadget>();
-			V2i pointRasterPos( viewportGadget->gadgetToRasterSpace( point, this ) );
-			return rasterToDisplaySpace( V2f( floorf( pointRasterPos.x ), floorf( pointRasterPos.y ) ) );
-		}
-
-		Box2f gadgetToDisplaySpace( const Box3f &box ) const
-		{
-			return Box2f( gadgetToDisplaySpace( box.min ), gadgetToDisplaySpace( box.max ) );
-		}
-
-		/// \todo This is not the final intended use of the ImageSampler -
-		/// we should just be updating the position in it during mouse move,
-		/// and then a Widget overlay should be automatically displaying
-		/// the colorPlug() value (updating automatically when it is notified
-		/// of dirtiness).
-		Color4f sampleColor( const V2f &point ) const
-		{
-			m_imageSampler->pixelPlug()->setValue(
-				// Sample at pixel centers only.
-				V2f(
-					floor( point.x ) + 0.5,
-					floor( point.y ) + 0.5
-				)
-			);
-			Context::Scope context( m_context.get() );
-			return m_imageSampler->colorPlug()->getValue();
-		};
-
-		bool buttonRelease( GadgetPtr gadget, const ButtonEvent &event )
-		{
-			return false;
-		}
-
-		bool buttonPress( GadgetPtr gadget, const ButtonEvent &event )
-		{
-			if( event.buttons != ButtonEvent::Left )
-			{
-				return false;
-			}
-
-			V3f mouseGadgetPos( event.line.p0.x, event.line.p0.y, 0.f );
-			m_mousePos = gadgetToDisplaySpace( mouseGadgetPos );
-
-			/// Check to see if the user is clicking on one of the swatches...
-			if ( ( event.modifiers & ModifiableEvent::Shift ) == false )
-			{
-				const ViewportGadget *viewportGadget = ancestor<ViewportGadget>();
-				V2f mouseRasterPos( viewportGadget->gadgetToRasterSpace( mouseGadgetPos, this ) );
-				for( unsigned int i = 0; i < 4; ++i )
-				{
-					V2f origin( m_colorUiElements[i].position + infoBox().min );
-					Box2f swatchBox( m_colorUiElements[i].swatchBox.min + origin, m_colorUiElements[i].swatchBox.max + origin );
-					if( boxIntersects( swatchBox, mouseRasterPos ) )
-					{
-						m_sampleColor = *m_colorUiElements[i].color;
-						requestRender();
-						return true;
-					}
-				}
-			}
-
-			m_drawSelection = m_colorUiElements[1].draw = m_colorUiElements[2].draw = m_colorUiElements[3].draw = false;
-			*m_colorUiElements[0].color = m_sampleColor = sampleColor( m_mousePos );
-			requestRender();
-
-			return true;
-		}
-
-		bool mouseMove( GadgetPtr gadget, const ButtonEvent &event )
-		{
-			m_mousePos = gadgetToDisplaySpace( V3f( event.line.p0.x, event.line.p0.y, 0 ) );
-			*m_colorUiElements[0].color = sampleColor( m_mousePos );
-			requestRender();
-			return true;
-		}
-
-		bool dragEnter( GadgetPtr gadget, const DragDropEvent &event )
-		{
-			if ( m_dragSelecting )
-			{
-				return true;
-			}
-			return event.sourceGadget == this && event.data == this;
-		}
-
-		bool dragMove( GadgetPtr gadget, const DragDropEvent &event )
-		{
-			m_lastDragPosition = event.line.p1;
-
-			// Update the selection box.
-			if ( m_dragSelecting )
-			{
-				m_drawSelection = m_colorUiElements[1].draw = m_colorUiElements[2].draw = m_colorUiElements[3].draw = true;
-
-				Box3f selectionBox;
-				selectionBox.extendBy( m_dragStartPosition );
-				selectionBox.extendBy( m_lastDragPosition );
-				setSelectionArea( selectionBox );
-
-				/// Set the region of interest on our internal ImageStats node and
-				/// get the min, max and average value of the image.
-				const ViewportGadget *viewportGadget = ancestor<ViewportGadget>();
-				Box2f roif(
-					V2f( viewportGadget->gadgetToRasterSpace( m_sampleWindow.min, this ) ),
-					V2f( viewportGadget->gadgetToRasterSpace( m_sampleWindow.max, this ) )
-				);
-				roif = rasterToDisplaySpace( roif );
-
-				Box2i roi(
-					V2i(
-						fastFloatRound( roif.min.x ),
-						fastFloatRound( roif.min.y )
-					),
-					V2i(
-						fastFloatRound( roif.max.x ),
-						fastFloatRound( roif.max.y )
-					)
-				);
-				m_imageStats->regionOfInterestPlug()->setValue( roi );
-
-				Context::Scope context( m_context.get() );
-				*m_colorUiElements[1].color = m_imageStats->minPlug()->getValue();
-				*m_colorUiElements[2].color = m_imageStats->maxPlug()->getValue();
-				*m_colorUiElements[3].color = m_imageStats->averagePlug()->getValue();
-			}
-
-			m_mousePos = gadgetToDisplaySpace( V3f( event.line.p0.x, event.line.p0.y, 0 ) );
-			*m_colorUiElements[0].color = sampleColor( m_mousePos );
-			requestRender();
-			return true;
-		}
-
-		bool dragEnd( GadgetPtr gadget, const DragDropEvent &event )
-		{
-			Pointer::setCurrent( "" );
-			if( !m_dragSelecting )
-			{
-				return false;
-			}
-			m_dragSelecting = false;
-
-			requestRender();
-			return true;
-		}
-
-		IECore::RunTimeTypedPtr dragBegin( GadgetPtr gadget, const DragDropEvent &event )
-		{
-			if ( event.modifiers & ModifiableEvent::Shift )
-			{
-				m_dragSelecting = true;
-				m_dragStartPosition = m_lastDragPosition = event.line.p0;
-				return this;
-			}
-
-			Pointer::setCurrent( "rgba" );
-			return new Color4fData( m_sampleColor );
-		}
-
-		void setSelectionArea( Box3f selectionBox )
-		{
-			// Get the bounds of the selection.
-			selectionBox = boxIntersection( selectionBox, m_displayBound );
-
-			if ( selectionBox.size().x < 0. )
-			{
-				selectionBox.max.x = selectionBox.min.x;
-			}
-
-			if ( selectionBox.size().y < 0. )
-			{
-				selectionBox.max.y = selectionBox.min.y;
-			}
-
-			selectionBox.min.x = floorf( selectionBox.min.x );
-			selectionBox.min.y = floorf( selectionBox.min.y );
-			selectionBox.max.x = ceilf( selectionBox.max.x );
-			selectionBox.max.y = ceilf( selectionBox.max.y );
-
-			// Save the box in gadget space.
-			m_sampleWindow = selectionBox;
-		}
-
-		void drawWindow( Box2f &rasterWindow,  const Style *style ) const
-		{
-			V2f minPt( rasterToDisplaySpace( rasterWindow.min ) );
-			V2f maxPt( rasterToDisplaySpace( rasterWindow.max ) );
-			drawWindow( rasterWindow, minPt, maxPt, style );
-		}
-
-		void drawWindow( Box2f &rasterWindow, const V2f &bottomLeftPoint, const V2f &topRightPoint, const Style *style ) const
-		{
-			std::string rasterWindowMinStr = std::string( boost::str( boost::format( "(%d, %d)" ) % fastFloatRound( bottomLeftPoint.x ) % fastFloatRound( bottomLeftPoint.y ) ) );
-			std::string rasterWindowMaxStr = std::string( boost::str( boost::format( "(%d, %d)" ) % fastFloatRound( topRightPoint.x ) % fastFloatRound( topRightPoint.y ) ) );
-
-			// Draw the box around the data window.
-			style->renderRectangle( rasterWindow );
-
-			glTranslatef( rasterWindow.max.x+5, rasterWindow.max.y-5, 0.f );
-			glScalef( 10.f, -10.f, 1.f );
-			style->renderText( Style::LabelText, rasterWindowMaxStr );
-
-			glLoadIdentity();
-			glTranslatef( rasterWindow.min.x+5, rasterWindow.min.y+10, 0.f );
-			glScalef( 10.f, -10.f, 1.f );
-
-			style->renderText( Style::LabelText, rasterWindowMinStr );
-			glLoadIdentity();
-		}
-
-		Box2f infoBox() const
-		{
-			const ViewportGadget *viewportGadget = ancestor<ViewportGadget>();
-			V2i viewportWH( viewportGadget->getViewport() );
-			Box2f infoBox(
-					V2f( 0.f, viewportWH.y-20),
-					viewportWH
-				);
-			if ( m_drawSelection )
-			{
-				infoBox.min.y = viewportWH.y-40;
-			}
-			return infoBox;
-		}
-
-		virtual void doRender( const Style *style ) const
-		{
-			if( !m_texture )
-			{
-				// convert image to texture
-				ToGLTextureConverterPtr converter = new ToGLTextureConverter( boost::static_pointer_cast<const ImagePrimitive>( m_image ), true );
-				m_texture = IECore::runTimeCast<IECoreGL::Texture>( converter->convert() );
-				{
-					Texture::ScopedBinding scope( *m_texture );
-					glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR );
-					glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST );
-				}
-			}
-
-			// Transform them to Raster Space
-			///\todo: The RasterScope class transforms Gadgets into a space where coordinate (0, 0) is in the top left corner.
-			/// If we are rasterizing gadgets in 2D then we want (0, 0) to be in the bottom left corner. Perhaps we should write
-			/// a new Scope class to transform to the appropriate 2D space or add a flag to the RasterScope class to flip the Y axis.
-			/// Because of this issue we have to flip the Y axis in a few places such as when we scale the text.
-			const ViewportGadget *viewportGadget = ancestor<ViewportGadget>();
-			Box2f dispRasterBox( displayRasterBox() );
-			Box2f dataRasterBox( ImageViewGadget::dataRasterBox() );
-
-			{
-				ViewportGadget::RasterScope rasterScope( viewportGadget );
-
-				// Draw the display window background.
-				Color4f color( 0.0f, .0f, .0f, 1.f );
-				glColor( color );
-				style->renderSolidRectangle( dispRasterBox );
-			}
-
-			// Draw the image data.
-			{
-				// Get the bounds of the data window in Gadget space.
-				Box2f b( V2f( m_dataBound.min.x, m_dataBound.min.y ), V2f( m_dataBound.max.x, m_dataBound.max.y ) );
-				renderImageWindow( b, (const Texture *)m_texture.get(), m_channelToView );
-			}
-
-			ViewportGadget::RasterScope rasterScope( viewportGadget );
-
-			// Mask the data window where it doesn't overlap the display window.
-			if ( m_dataWindow != m_displayWindow )
-			{
-				const Box2f& c = dispRasterBox;
-				Box2f b = dataRasterBox;
-
-				///\todo We should query the raised color of the current style here and use it but the current design won't allow us. For now it is hard-coded...
-				glColor( Color4f( .29804, .29804, .29804, .90 ) );
-
-				if ( b.min.x <= c.min.x )
-				{
-					Box2f l(b);
-					l.max.x = c.min.x;
-					b.min.x = c.min.x;
-					style->renderSolidRectangle( l );
-				}
-
-				if ( b.max.x >= c.max.x )
-				{
-					Box2f r(b);
-					r.min.x = c.max.x;
-					b.max.x = c.max.x;
-					style->renderSolidRectangle( r );
-				}
-
-				if ( b.max.y <= c.max.y )
-				{
-					Box2f l(b);
-					l.min.y = c.max.y;
-					b.max.y = c.max.y;
-					style->renderSolidRectangle( l );
-				}
-
-				if ( b.min.y >= c.min.y )
-				{
-					Box2f r(b);
-					r.max.y = c.min.y;
-					b.min.y = c.min.y;
-					style->renderSolidRectangle( r );
-				}
-			}
-
-			// Draw the box around the display window.
-			Color4f color( .1f, .1f, .1f, 1.f );
-			glColor( color );
-			style->renderRectangle( dispRasterBox );
-			glLoadIdentity();
-
-			// Draw the display window text.
-			glTranslatef( dispRasterBox.min.x+5, dispRasterBox.min.y+10, 0.f );
-			glScalef( 10.f, -10.f, 1.f );
-
-			///\todo: How do we handle looking up the format here when we have a pixel aspect other than 1?
-			/// Does the IECore::ImagePrimitive have a pixel aspect?
-			const GafferImage::Format f( m_displayWindow.size().x, m_displayWindow.size().y, 1. );
-			std::string formatName = Format::name( f );
-			if( formatName.empty() )
-			{
-				formatName = boost::lexical_cast<std::string>( f );
-			}
-			else
-			{
-				formatName += " ( " + boost::lexical_cast<std::string>( f ) + " )";
-			}
-
-			style->renderText( Style::LabelText, formatName );
-			glLoadIdentity();
-
-			// Draw the data window if it is different to the display window.
-			if ( m_dataWindow != m_displayWindow && m_dataWindow.size() != Imath::V2i( 1 ) )
-			{
-				color = Color4f( .2f, .2f, .2f, 1.f );
-				glColor( color );
-
-				Format format( m_displayWindow );
-				Box2i dataWindow( format.toEXRSpace( m_dataWindow ) );
-				dataWindow.max += Imath::V2i( 1 );
-				drawWindow( dataRasterBox, dataWindow.min, dataWindow.max, style );
-			}
-
-			/// Draw the selection window.
-			if( m_drawSelection )
-			{
-				Box2f rasterBox(
-					V2i( viewportGadget->gadgetToRasterSpace( m_sampleWindow.min, this ) ),
-					V2i( viewportGadget->gadgetToRasterSpace( m_sampleWindow.max, this ) )
-				);
-
-				color = Color4f( 1.f, 0.f, 1.f, 1.f );
-				glColor( color );
-				drawWindow( rasterBox, style );
-			}
-
-			// Draw the color information bar.
-			Imath::Box2f infoBarBox( infoBox() );
-			color = Color4f( 0.f, 0.f, 0.f, 1.f );
-			glColor( color );
-			style->renderSolidRectangle( infoBarBox );
-			glColor( Color4f( .29804, .29804, .29804, .90 ) );
-			style->renderRectangle( infoBarBox );
-
-			// Draw the channel mask icon.
-			Imath::Box2f iconBox( V2f( 10.f, 5.f ) + infoBarBox.min, V2f( 20.f, 15.f ) + infoBarBox.min );
-			if( m_channelToView == All )
-			{
-				float sliceWidth = iconBox.size().x / 3.f;
-				Imath::Box2f iconSlice( iconBox.min, Imath::V2f( sliceWidth + iconBox.min.x, iconBox.max.y ) );
-				glColor( Color4f( 1., 0., 0., 1. ) );
-				style->renderSolidRectangle( iconSlice );
-
-				iconSlice.min.x += sliceWidth;
-				iconSlice.max.x += sliceWidth;
-				glColor( Color4f( 0., 1., 0., 1. ) );
-				style->renderSolidRectangle( iconSlice );
-
-				iconSlice.min.x += sliceWidth;
-				iconSlice.max.x += sliceWidth;
-				glColor( Color4f( 0., 0., 1., 1. ) );
-				style->renderSolidRectangle( iconSlice );
-			}
-			else if( m_channelToView == Red )
-			{
-				glColor( Color4f( 1., 0., 0., 1. ) );
-				style->renderSolidRectangle( iconBox );
-			}
-			else if( m_channelToView == Green )
-			{
-				glColor( Color4f( 0., 1., 0., 1. ) );
-				style->renderSolidRectangle( iconBox );
-			}
-			else if( m_channelToView == Blue )
-			{
-				glColor( Color4f( 0., 0., 1., 1. ) );
-				style->renderSolidRectangle( iconBox );
-			}
-			else if( m_channelToView == Alpha )
-			{
-				glColor( Color4f( 1., 1., 1., 1. ) );
-				style->renderSolidRectangle( iconBox );
-			}
-
-			glColor( Color4f( .29804, .29804, .29804, .90 ) );
-			style->renderRectangle( infoBarBox );
-			glLoadIdentity();
-
-			// Draw the mouse's XY position.
-			glTranslatef( infoBarBox.min.x+30, infoBarBox.min.y+14, 0.f );
-			glScalef( 10.f, -10.f, 1.f );
-			std::string mousePosStr = std::string( boost::str( boost::format( "XY: %d, %d" ) % fastFloatRound( m_mousePos.x - .5 ) % fastFloatRound( m_mousePos.y - .5 ) ) );
-			style->renderText( Style::LabelText, mousePosStr );
-			glLoadIdentity();
-
-			for( unsigned int i = 0; i < m_colorUiElements.size(); ++i )
-			{
-				if( m_colorUiElements[i].draw )
-				{
-					V2f origin( m_colorUiElements[i].position + infoBarBox.min );
-
-					// Render a little swatch of the color.
-					Box2f swatchBox( m_colorUiElements[i].swatchBox );
-					swatchBox.min += origin;
-					swatchBox.max += origin;
-
-					Color4f color( *m_colorUiElements[i].color );
-					if( !m_hasAlpha )
-					{
-						color[3] = 1.;
-					}
-
-					glColor( Color4f( 0.f, 0.f, 0.f, 1.f ) );
-					style->renderSolidRectangle( swatchBox );
-					glColor( Color4f( 1.f ) );
-					style->renderSolidRectangle( Box2f( swatchBox.min, swatchBox.min + ( swatchBox.size() / V2f( 2. ) ) ) );
-					style->renderSolidRectangle( Box2f( swatchBox.min + ( swatchBox.size() / V2f( 2. ) ), swatchBox.max ) );
-					glColor( color );
-					style->renderSolidRectangle( swatchBox );
-					glColor( Color4f( .29804, .29804, .29804, .90 ) );
-					style->renderRectangle( swatchBox );
-
-					// Render the text next to the swatch.
-					V2f textPos( swatchBox.max.x + 5.f, origin.y + 14.f );
-					glTranslatef( textPos.x, textPos.y, 0.f );
-					glScalef( 10.f, -10.f, 1.f );
-					std::string infoStr = std::string(
-							boost::str(
-								boost::format( "%s: %.3f, %.3f, %.3f, %.3f" )
-								% m_colorUiElements[i].name.c_str()
-								% (*m_colorUiElements[i].color)[0]
-								% (*m_colorUiElements[i].color)[1]
-								% (*m_colorUiElements[i].color)[2]
-								% (*m_colorUiElements[i].color)[3]
-								)
-							);
-
-					if( m_colorUiElements[i].hsv )
-					{
-						const Color4f hsv = Imath::rgb2hsv( *m_colorUiElements[i].color );
-						infoStr += boost::str(
-							boost::format( "  HSV: %.3f, %.3f, %.3f" ) % hsv[0] % hsv[1] % hsv[2]
-						);
-					}
-
-					style->renderText( Style::LabelText, infoStr );
-					glLoadIdentity();
-				}
-			}
+			PlugPtr plug = new Plug( "colorInspector" );
+			view->addChild( plug );
+
+			plug->addChild( new V2iPlug( "pixel" ) );
+			plug->addChild( new Color4fPlug( "color" ) );
+
+			// We want to sample the image before the display transforms
+			// are applied. We can't simply get this image from inPlug()
+			// because derived classes may have called insertConverter(),
+			// so we take it from the input to the display transform chain.
+			ImagePlug *image = view->getPreprocessor<Node>()->getChild<Clamp>( "__clamp" )->inPlug();
+			m_sampler->imagePlug()->setInput( image );
+
+			plug->getChild<Color4fPlug>( "color" )->setInput( m_sampler->colorPlug() );
+
+			m_view->viewportGadget()->mouseMoveSignal().connect( boost::bind( &ColorInspector::mouseMove, this, ::_2 ) );
+			m_view->viewportGadget()->getPrimaryChild()->buttonPressSignal().connect( boost::bind( &ColorInspector::buttonPress, this,  ::_2 ) );
+			m_view->viewportGadget()->getPrimaryChild()->dragBeginSignal().connect( boost::bind( &ColorInspector::dragBegin, this, ::_2 ) );
+			m_view->viewportGadget()->getPrimaryChild()->dragEndSignal().connect( boost::bind( &ColorInspector::dragEnd, this, ::_2 ) );
 		}
 
 	private :
 
-		enum ChannelToView
+		Plug *plug()
 		{
-			All = 0,
-			Red = 1,
-			Green = 2,
-			Blue = 3,
-			Alpha = 4
-		};
+			return m_view->getChild<Plug>( "colorInspector" );
+		}
 
-		/// A simple struct that we use to hold the information required to draw a UI element that displays information about a color.
-		struct ColorUiElement
+		bool mouseMove( const ButtonEvent &event )
 		{
-			ColorUiElement( Color4f &swatchColor ): draw( false ), name( "RGBA" ), color( &swatchColor ), position( 0.f ), swatchBox( V2f( 0.f, 5.f ), V2f( 10.f, 15.f ) ), hsv( false ) {}
-			bool draw;
-			std::string name;
-			Color4f *color;
-			Imath::V2f position;
-			Imath::Box2f swatchBox;
-			bool hsv;
-		};
+			ImageGadget *imageGadget = static_cast<ImageGadget *>( m_view->viewportGadget()->getPrimaryChild() );
+			const LineSegment3f l = m_view->viewportGadget()->rasterToGadgetSpace( V2f( event.line.p0.x, event.line.p0.y ), imageGadget );
+			const V2i pixel( floor( l.p0.x ), floor( l.p0.y ) );
+			m_sampler->pixelPlug()->setValue( V2f( pixel ) + V2f( 0.5f ) );
+			plug()->getChild<V2iPlug>( "pixel" )->setValue( pixel );
+			return false;
+		}
 
-		Imath::Box3f m_displayBound;
-		Imath::Box3f m_dataBound;
-		Imath::Box2i m_displayWindow;
-		Imath::Box2i m_dataWindow;
-		ConstImagePrimitivePtr m_image;
-		mutable ConstTexturePtr m_texture;
+		bool buttonPress( const ButtonEvent &event )
+		{
+			if( event.buttons != ButtonEvent::Left || event.modifiers )
+			{
+				return false;
+			}
 
-		Imath::V2f &m_mousePos;
-		Imath::V3f m_dragStartPosition;
-		Imath::V3f m_lastDragPosition;
-		Color4f m_sampleColor;
-		bool m_dragSelecting;
-		bool m_drawSelection;
-		int &m_channelToView;
-		bool m_hasAlpha;
+			return true; // accept press so we get dragBegin()
+		}
 
-		Imath::Box3f m_sampleWindow;
-		GafferImage::ImageStatsPtr m_imageStats;
-		GafferImage::ImageSamplerPtr m_imageSampler;
-		ConstContextPtr m_context;
-		std::vector<ColorUiElement> m_colorUiElements;
+		IECore::DataPtr dragBegin( const ButtonEvent &event )
+		{
+			if( event.buttons != ButtonEvent::Left || event.modifiers )
+			{
+				return false;
+			}
+
+			Pointer::setCurrent( "rgba" );
+
+			Context::Scope scopedContext( m_view->getContext() );
+			return new Color4fData( plug()->getChild<Color4fPlug>( "color" )->getValue() );
+		}
+
+		bool dragEnd( const ButtonEvent &event )
+		{
+			Pointer::setCurrent( "" );
+			return true;
+		}
+
+		ImageView *m_view;
+		ImageSamplerPtr m_sampler;
+
 };
-
-IE_CORE_DECLAREPTR( ImageViewGadget );
-
-}; // namespace Detail
-
-}; // namespace GafferImageUI
 
 //////////////////////////////////////////////////////////////////////////
 /// Implementation of ImageView
@@ -932,13 +178,7 @@ ImageView::ViewDescription<ImageView> ImageView::g_viewDescription( GafferImage:
 ImageView::ImageView( const std::string &name )
 	:	View( name, new GafferImage::ImagePlug() ),
 		m_imageGadget( new ImageGadget() ),
-		m_framed( false ),
-		m_channelToView( 0 ),
-		m_mousePos( Imath::V2f( 0.0f ) ),
-		m_sampleColor( Imath::Color4f( 0.0f ) ),
-		m_minColor( Imath::Color4f( 0.0f ) ),
-		m_maxColor( Imath::Color4f( 0.0f ) ),
-		m_averageColor( Imath::Color4f( 0.0f ) )
+		m_framed( false )
 {
 
 	// build the preprocessor we use for applying colour
@@ -947,15 +187,6 @@ ImageView::ImageView( const std::string &name )
 	NodePtr preprocessor = new Node;
 	ImagePlugPtr preprocessorInput = new ImagePlug( "in" );
 	preprocessor->addChild( preprocessorInput );
-
-	ImageStatsPtr statsNode = new ImageStats( "__imageStats" );
-	preprocessor->addChild( statsNode );
-	statsNode->inPlug()->setInput( preprocessorInput );
-	statsNode->channelsPlug()->setInput( preprocessorInput->channelNamesPlug() );
-
-	ImageSamplerPtr samplerNode = new ImageSampler( "__imageSampler" );
-	preprocessor->addChild( samplerNode );
-	samplerNode->imagePlug()->setInput( preprocessorInput );
 
 	ClampPtr clampNode = new Clamp();
 	preprocessor->setChild(  "__clamp", clampNode );
@@ -1008,6 +239,8 @@ ImageView::ImageView( const std::string &name )
 	m_imageGadget->setImage( preprocessedInPlug<ImagePlug>() );
 	m_imageGadget->setContext( getContext() );
 	viewportGadget()->setPrimaryChild( m_imageGadget );
+
+	m_colorInspector = shared_ptr<ColorInspector>( new ColorInspector( this ) );
 }
 
 void ImageView::insertConverter( Gaffer::NodePtr converter )
@@ -1084,26 +317,6 @@ Gaffer::StringPlug *ImageView::displayTransformPlug()
 const Gaffer::StringPlug *ImageView::displayTransformPlug() const
 {
 	return getChild<StringPlug>( "displayTransform" );
-}
-
-GafferImage::ImageStats *ImageView::imageStatsNode()
-{
-	return getPreprocessor<Node>()->getChild<ImageStats>( "__imageStats" );
-}
-
-const GafferImage::ImageStats *ImageView::imageStatsNode() const
-{
-	return getPreprocessor<Node>()->getChild<ImageStats>( "__imageStats" );
-}
-
-GafferImage::ImageSampler *ImageView::imageSamplerNode()
-{
-	return getPreprocessor<Node>()->getChild<ImageSampler>( "__imageSampler" );
-}
-
-const GafferImage::ImageSampler *ImageView::imageSamplerNode() const
-{
-	return getPreprocessor<Node>()->getChild<ImageSampler>( "__imageSampler" );
 }
 
 GafferImage::Clamp *ImageView::clampNode()

--- a/src/GafferImageUIBindings/ImageGadgetBinding.cpp
+++ b/src/GafferImageUIBindings/ImageGadgetBinding.cpp
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012, John Haddon. All rights reserved.
-//  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -37,17 +36,39 @@
 
 #include "boost/python.hpp"
 
-#include "GafferImageUIBindings/ImageViewBinding.h"
+#include "Gaffer/Context.h"
+
+#include "GafferUIBindings/GadgetBinding.h"
+
+#include "GafferImage/ImagePlug.h"
+
+#include "GafferImageUI/ImageGadget.h"
 #include "GafferImageUIBindings/ImageGadgetBinding.h"
 
 using namespace boost::python;
+using namespace IECorePython;
+using namespace Gaffer;
+using namespace GafferUIBindings;
+using namespace GafferImage;
+using namespace GafferImageUI;
 
-using namespace GafferImageUIBindings;
-
-BOOST_PYTHON_MODULE( _GafferImageUI )
+namespace
 {
 
-	bindImageView();
-	bindImageGadget();
+ImagePlugPtr getImage( const ImageGadget &v )
+{
+	return ImagePlugPtr( const_cast<ImagePlug *>( v.getImage() ) );
+}
 
+} // namespace
+
+void GafferImageUIBindings::bindImageGadget()
+{
+	GadgetClass<ImageGadget>()
+		.def( init<>() )
+		.def( "setImage", &ImageGadget::setImage )
+		.def( "getImage", &getImage )
+		.def( "setContext", &ImageGadget::setContext )
+		.def( "getContext", (Context *(ImageGadget::*)())&ImageGadget::getContext, return_value_policy<CastToIntrusivePtr>() )
+	;
 }


### PR DESCRIPTION
This rewrites most of the ImageView code, improving performance significantly and fixing several important bugs. The redesign follows the pattern established for the SceneView :

- The meat of the drawing is refactored into a reusable ImageGadget class, which manages a cache of texture tiles it uses for rendering.
- The ImageView defers to the ImageGadget to do most of the work.
- Additional features like the colour inspector are implemented as bolt-on classes which add functionality to the view in a non-intrusive manner.

Over time I expect the bolt-on classes may get refactored out into the public API, so that different applications can build viewers with different customisations via config files.

There is some functionality that hasn't made it through the rewrite - the selection of areas for use with an ImageStats node, and the overlay for the colour inspector is now at the top, where there isn't really room for displaying such stats. What I'd like to do is work on the NodeToolbar and PlugLayout classes to add the concept of different toolbars for the top/bottom/left/right of the viewer, and then move the inspector to the lower toolbar. I'm happy to do that next or to defer it till later - mainly I felt that this work was dragging on a bit too long, and I should at least get something visible now.
