### PR TITLE
TypedObjectPlug.h : Remove unnecessary IECore/Primitive.h include

### DIFF
--- a/include/Gaffer/TypedObjectPlug.h
+++ b/include/Gaffer/TypedObjectPlug.h
@@ -41,7 +41,6 @@
 #include "IECore/Object.h"
 #include "IECore/VectorTypedData.h"
 #include "IECore/ObjectVector.h"
-#include "IECore/Primitive.h"
 #include "IECore/CompoundObject.h"
 
 #include "Gaffer/ValuePlug.h"

--- a/include/GafferScene/BranchCreator.h
+++ b/include/GafferScene/BranchCreator.h
@@ -38,6 +38,8 @@
 #ifndef GAFFERSCENE_BRANCHCREATOR_H
 #define GAFFERSCENE_BRANCHCREATOR_H
 
+#include "IECore/CompoundData.h"
+
 #include "GafferScene/SceneProcessor.h"
 #include "GafferScene/Filter.h"
 

--- a/include/GafferScene/PrimitiveVariableProcessor.h
+++ b/include/GafferScene/PrimitiveVariableProcessor.h
@@ -38,6 +38,8 @@
 #ifndef GAFFERSCENE_PRIMITIVEVARIABLEPROCESSOR_H
 #define GAFFERSCENE_PRIMITIVEVARIABLEPROCESSOR_H
 
+#include "IECore/Primitive.h"
+
 #include "GafferScene/SceneElementProcessor.h"
 
 namespace Gaffer

--- a/include/GafferScene/SceneAlgo.h
+++ b/include/GafferScene/SceneAlgo.h
@@ -47,6 +47,7 @@ namespace IECore
 
 IE_CORE_FORWARDDECLARE( Transform )
 IE_CORE_FORWARDDECLARE( Camera )
+IE_CORE_FORWARDDECLARE( CompoundData )
 
 } // namespace IECore
 

--- a/src/GafferScene/AlembicSource.cpp
+++ b/src/GafferScene/AlembicSource.cpp
@@ -38,6 +38,7 @@
 #include "boost/bind.hpp"
 
 #include "IECore/LRUCache.h"
+#include "IECore/Renderable.h"
 
 #include "Gaffer/Context.h"
 #include "Gaffer/StringPlug.h"

--- a/src/GafferScene/FreezeTransform.cpp
+++ b/src/GafferScene/FreezeTransform.cpp
@@ -57,7 +57,7 @@ FreezeTransform::FreezeTransform( const std::string &name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new M44fPlug( "__transform", Plug::Out ) );
-	
+
 	// pass through the things we don't want to change
 	outPlug()->attributesPlug()->setInput( inPlug()->attributesPlug() );
 	outPlug()->childNamesPlug()->setInput( inPlug()->childNamesPlug() );

--- a/src/GafferScene/FreezeTransform.cpp
+++ b/src/GafferScene/FreezeTransform.cpp
@@ -36,6 +36,7 @@
 
 #include "IECore/TransformOp.h"
 #include "IECore/DespatchTypedData.h"
+#include "IECore/Primitive.h"
 
 #include "Gaffer/Context.h"
 

--- a/src/GafferScene/Group.cpp
+++ b/src/GafferScene/Group.cpp
@@ -41,6 +41,7 @@
 #include "OpenEXR/ImathBoxAlgo.h"
 
 #include "IECore/CompoundObject.h"
+#include "IECore/CompoundData.h"
 
 #include "Gaffer/Context.h"
 #include "Gaffer/StringPlug.h"

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -41,6 +41,7 @@
 #include "boost/lexical_cast.hpp"
 
 #include "IECore/VectorTypedData.h"
+#include "IECore/Primitive.h"
 
 #include "Gaffer/Context.h"
 #include "Gaffer/StringPlug.h"

--- a/src/GafferScene/InteractiveRender.cpp
+++ b/src/GafferScene/InteractiveRender.cpp
@@ -44,6 +44,7 @@
 #include "IECore/EditBlock.h"
 #include "IECore/MessageHandler.h"
 #include "IECore/SceneInterface.h"
+#include "IECore/VisibleRenderable.h"
 
 #include "Gaffer/Context.h"
 #include "Gaffer/ScriptNode.h"

--- a/src/GafferScene/InteractiveRender.cpp
+++ b/src/GafferScene/InteractiveRender.cpp
@@ -95,7 +95,7 @@ class InteractiveRender::SceneGraph
 				delete *it;
 			}
 		}
-		
+
 		void path( ScenePlug::ScenePath &p )
 		{
 			if( !m_parent )
@@ -107,28 +107,28 @@ class InteractiveRender::SceneGraph
 		}
 
 	private :
-		
+
 		friend class SceneGraphBuildTask;
 		friend class ChildNamesUpdateTask;
-		
+
 		friend class SceneGraphIteratorFilter;
 		friend class SceneGraphEvaluatorFilter;
 		friend class SceneGraphOutputFilter;
-		
+
 		// scene structure data:
 		IECore::InternedString m_name;
 		SceneGraph *m_parent;
 		std::vector<InteractiveRender::SceneGraph *> m_children;
-		
+
 		// hashes as of the most recent evaluation:
 		IECore::MurmurHash m_attributesHash;
 		IECore::MurmurHash m_childNamesHash;
-		
+
 		// actual scene data:
 		IECore::ConstCompoundObjectPtr m_attributes;
 		IECore::ConstObjectPtr m_object;
 		Imath::M44f m_transform;
-		
+
 		// flag indicating if this location is currently present - (used
 		// when the child names change)
 		bool m_locationPresent;
@@ -261,22 +261,22 @@ class InteractiveRender::ChildNamesUpdateTask : public tbb::task
 			ContextPtr context = new Context( *m_context, Context::Borrowed );
 			context->set( ScenePlug::scenePathContextName, m_scenePath );
 			Context::Scope scopedContext( context.get() );
-			
+
 			IECore::MurmurHash childNamesHash = m_scene->childNamesPlug()->hash();
-			
+
 			if( childNamesHash != m_sceneGraph->m_childNamesHash )
 			{
 				// child names have changed - we need to update m_locationPresent on the children:
 				m_sceneGraph->m_childNamesHash = childNamesHash;
-				
+
 				// read updated child names:
 				IECore::ConstInternedStringVectorDataPtr childNamesData = m_scene->childNamesPlug()->getValue( &m_sceneGraph->m_childNamesHash );
 				std::vector<IECore::InternedString> childNames = childNamesData->readable();
-				
+
 				// m_sceneGraph->m_children should be sorted by name. Sort this list too so we can
 				// compare the two easily:
 				std::sort( childNames.begin(), childNames.end() );
-				
+
 				std::vector<InternedString>::iterator childNamesBegin = childNames.begin();
 				for( std::vector<SceneGraph *>::const_iterator it = m_sceneGraph->m_children.begin(), eIt = m_sceneGraph->m_children.end(); it != eIt; ++it )
 				{
@@ -286,7 +286,7 @@ class InteractiveRender::ChildNamesUpdateTask : public tbb::task
 					{
 						// ok, it's there - mark this child as still present
 						(*it)->m_locationPresent = true;
-						
+
 						// As both the name lists are sorted, no further child names will be found beyond nameIt
 						// in the list, nor will they be found at nameIt as there shouldn't be any duplicates.
 						// This means we can move the start of the child names list one position past nameIt
@@ -302,14 +302,14 @@ class InteractiveRender::ChildNamesUpdateTask : public tbb::task
 					}
 				}
 			}
-			
+
 			// count children currently present in the scene:
 			size_t numPresentChildren = 0;
 			for( std::vector<SceneGraph *>::const_iterator it = m_sceneGraph->m_children.begin(), eIt = m_sceneGraph->m_children.end(); it != eIt; ++it )
 			{
 				numPresentChildren += (*it)->m_locationPresent;
 			}
-			
+
 			// spawn child tasks:
 			set_ref_count( 1 + numPresentChildren );
 			ScenePlug::ScenePath childPath = m_scenePath;
@@ -471,9 +471,9 @@ class InteractiveRender::SceneGraphBuildTask : public tbb::task
 			// we might as well store them in the scene graph, along with the hash:
 
 			m_sceneGraph->m_attributesHash = m_scene->attributesPlug()->hash();
-			
+
 			// use the precomputed hash in getValue() to save a bit of time:
-			
+
 			m_sceneGraph->m_attributes = m_scene->attributesPlug()->getValue( &m_sceneGraph->m_attributesHash );
 			const BoolData *visibilityData = m_sceneGraph->m_attributes->member<BoolData>( SceneInterface::visibilityName );
 			if( visibilityData && !visibilityData->readable() )
@@ -494,7 +494,7 @@ class InteractiveRender::SceneGraphBuildTask : public tbb::task
 				// nothing more to do
 				return NULL;
 			}
-			
+
 			// sort the child names so we can compare child name lists easily in ChildNamesUpdateTask:
 			std::sort( childNames.begin(), childNames.end() );
 
@@ -521,12 +521,12 @@ class InteractiveRender::SceneGraphBuildTask : public tbb::task
 					(*it),
 					childPath
 				);
-				
+
 				spawn( *t );
 			}
 
 			wait_for_all();
-			
+
 			// add visible children to m_sceneGraph->m_children:
 			for( std::vector<SceneGraph *>::const_iterator it = children.begin(), eIt = children.end(); it != eIt; ++it )
 			{
@@ -537,7 +537,7 @@ class InteractiveRender::SceneGraphBuildTask : public tbb::task
 				}
 				m_sceneGraph->m_children.push_back( *it );
 			}
-			
+
 			return NULL;
 		}
 
@@ -566,7 +566,7 @@ class InteractiveRender::SceneGraphIteratorFilter : public tbb::filter
 		{
 			m_childIndices.push_back( 0 );
 		}
-		
+
 		virtual void *operator()( void *item )
 		{
 			if( m_childIndices.empty() )
@@ -578,9 +578,9 @@ class InteractiveRender::SceneGraphIteratorFilter : public tbb::filter
 			next();
 			return s;
 		}
-	
+
 	private:
-		
+
 		void next()
 		{
 			// go down one level in the hierarchy if we can:
@@ -594,16 +594,16 @@ class InteractiveRender::SceneGraphIteratorFilter : public tbb::filter
 					return;
 				}
 			}
-			
+
 			while( m_childIndices.size() )
 			{
-				
+
 				// increment child index:
 				++m_childIndices.back();
-				
+
 				// find parent's child count - for the root we define this as 1:
 				size_t parentNumChildren = m_current->m_parent ? m_current->m_parent->m_children.size() : 1;
-				
+
 				if( m_childIndices.back() == parentNumChildren )
 				{
 					// we've got to the end of the child list, jump up one level:
@@ -619,7 +619,7 @@ class InteractiveRender::SceneGraphIteratorFilter : public tbb::filter
 				}
 			}
 		}
-		
+
 		SceneGraph *m_current;
 		std::vector<size_t> m_childIndices;
 };
@@ -654,7 +654,7 @@ class InteractiveRender::SceneGraphEvaluatorFilter : public tbb::filter
 				ContextPtr context = new Context( *m_context, Context::Borrowed );
 				context->set( ScenePlug::scenePathContextName, path );
 				Context::Scope scopedContext( context.get() );
-			
+
 				if( m_update )
 				{
 					// we're re-traversing this location, so lets only recompute attributes where
@@ -681,7 +681,7 @@ class InteractiveRender::SceneGraphEvaluatorFilter : public tbb::filter
 			{
 				std::string name;
 				ScenePlug::pathToString( path, name );
-			
+
 				IECore::msg( IECore::Msg::Error, "InteractiveRender::update", name + ": " + e.what() );
 			}
 
@@ -708,15 +708,15 @@ class InteractiveRender::SceneGraphEvaluatorFilter : public tbb::filter
 class InteractiveRender::SceneGraphOutputFilter : public tbb::thread_bound_filter
 {
 	public:
-	
+
 		SceneGraphOutputFilter( Renderer *renderer, bool editMode ) :
-			tbb::thread_bound_filter( tbb::filter::serial_in_order ), 
+			tbb::thread_bound_filter( tbb::filter::serial_in_order ),
 			m_renderer( renderer ),
 			m_attrBlockCounter( 0 ),
 			m_editMode( editMode )
 		{
 		}
-		
+
 		virtual ~SceneGraphOutputFilter()
 		{
 			// close pending attribute blocks:
@@ -726,16 +726,16 @@ class InteractiveRender::SceneGraphOutputFilter : public tbb::thread_bound_filte
 				m_renderer->attributeEnd();
 			}
 		}
-		
+
 		virtual void *operator()( void *item )
 		{
 			SceneGraph *s = (SceneGraph*)item;
 			ScenePlug::ScenePath path;
 			s->path( path );
-			
+
 			std::string name;
 			ScenePlug::pathToString( path, name );
-			
+
 			try
 			{
 				if( !m_editMode )
@@ -803,9 +803,9 @@ class InteractiveRender::SceneGraphOutputFilter : public tbb::thread_bound_filte
 
 			return NULL;
 		}
-		
+
 	private:
-		
+
 		Renderer *m_renderer;
 		ScenePlug::ScenePath m_previousPath;
 		int m_attrBlockCounter;
@@ -816,13 +816,13 @@ void InteractiveRender::runPipeline(tbb::pipeline *p)
 {
 	// \todo: tune this number to find a balance between memory and speed once
 	// we have a load of production data:
-	
+
 	p->run( 2 * tbb::task_scheduler_init::default_num_threads() );
 }
 
 void InteractiveRender::outputScene( bool update )
 {
-	
+
 	SceneGraphIteratorFilter iterator( m_sceneGraph.get() );
 
 	SceneGraphEvaluatorFilter evaluator(
@@ -831,7 +831,7 @@ void InteractiveRender::outputScene( bool update )
 		update // only recompute locations whose hashes have changed if true:
 	);
 
-	SceneGraphOutputFilter output( 
+	SceneGraphOutputFilter output(
 		m_renderer.get(),
 		update // edit mode if true
 	);
@@ -850,7 +850,7 @@ void InteractiveRender::outputScene( bool update )
 		continue;
 	}
 	pipelineThread.join();
-	
+
 }
 
 void InteractiveRender::update()
@@ -898,12 +898,12 @@ void InteractiveRender::update()
 			outputGlobalAttributes( globals.get(), m_renderer.get() );
 			outputCoordinateSystems( inPlug(), globals.get(), m_renderer.get() );
 			outputLightsInternal( globals.get(), /* editing = */ false );
-			
+
 			// build the scene graph structure in parallel:
 			m_sceneGraph.reset( new SceneGraph );
 			SceneGraphBuildTask *task = new( tbb::task::allocate_root() ) SceneGraphBuildTask( inPlug(), m_context.get(), m_sceneGraph.get(), ScenePlug::ScenePath() );
 			tbb::task::spawn_root_and_wait( *task );
-			
+
 			// output the scene for the first time:
 			outputScene( false );
 		}
@@ -1022,10 +1022,10 @@ void InteractiveRender::updateAttributes()
 	{
 		return;
 	}
-	
+
 	// output the scene, updating locations whose hashes have changed since last time:
 	outputScene( true );
-	
+
 	m_attributesDirty = false;
 }
 

--- a/src/GafferScene/PrimitiveVariables.cpp
+++ b/src/GafferScene/PrimitiveVariables.cpp
@@ -34,6 +34,8 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
+#include "IECore/Primitive.h"
+
 #include "GafferScene/PrimitiveVariables.h"
 
 using namespace IECore;

--- a/src/GafferScene/PrimitiveVariables.cpp
+++ b/src/GafferScene/PrimitiveVariables.cpp
@@ -51,7 +51,7 @@ PrimitiveVariables::PrimitiveVariables( const std::string &name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new CompoundDataPlug( "primitiveVariables" ) );
-	
+
 	// Fast pass-throughs for things we don't modify
 	outPlug()->attributesPlug()->setInput( inPlug()->attributesPlug() );
 	outPlug()->transformPlug()->setInput( inPlug()->transformPlug() );

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -43,6 +43,7 @@
 #include "IECore/CoordinateSystem.h"
 #include "IECore/ClippingPlane.h"
 #include "IECore/NullObject.h"
+#include "IECore/VisibleRenderable.h"
 
 #include "Gaffer/Context.h"
 

--- a/src/GafferScene/SceneProcedural.cpp
+++ b/src/GafferScene/SceneProcedural.cpp
@@ -67,7 +67,7 @@ using namespace GafferScene;
 // to schedule the work. Generally if left to do this, it schedules it by
 // making as many threads as there are cores, to make best use of the hardware.
 // This is all well and good, until you're running multiple renders side-by-side,
-// telling the renderer to use a limited number of threads so they all play nicely 
+// telling the renderer to use a limited number of threads so they all play nicely
 // together. Let's use the example of a 32 core machine with 4 8-thread 3delight
 // renders running side by side.
 //
@@ -166,13 +166,13 @@ SceneProcedural::SceneProcedural( ConstScenePlugPtr scenePlug, const Gaffer::Con
 
 	transformBlurData = globals->member<BoolData>( "attribute:gaffer:transformBlur" );
 	m_attributes.transformBlur = transformBlurData ? transformBlurData->readable() : true;
-	
+
 	const IntData *transformBlurSegmentsData = globals->member<IntData>( "attribute:gaffer:transformBlurSegments" );
 	m_attributes.transformBlurSegments = transformBlurSegmentsData ? transformBlurSegmentsData->readable() : 1;
-	
+
 	deformationBlurData = globals->member<BoolData>( "attribute:gaffer:deformationBlur" );
 	m_attributes.deformationBlur = deformationBlurData ? deformationBlurData->readable() : true;
-	
+
 	const IntData *deformationBlurSegmentsData = globals->member<IntData>( "attribute:gaffer:deformationBlurSegments" );
 	m_attributes.deformationBlurSegments = deformationBlurSegmentsData ? deformationBlurSegmentsData->readable() : 1;
 
@@ -260,7 +260,7 @@ void SceneProcedural::computeBound()
 	}
 	catch( const std::exception &e )
 	{
-		m_bound = Imath::Box3f();	
+		m_bound = Imath::Box3f();
 		std::string name;
 		ScenePlug::pathToString( m_scenePath, name );
 		IECore::msg( IECore::Msg::Error, "SceneProcedural::bound() " + name, e.what() );
@@ -291,7 +291,7 @@ class SceneProcedural::SceneProceduralCreate
 			SceneProceduralContainer &childProcedurals,
 			const SceneProcedural &parent,
 			const vector<InternedString> &childNames
-			
+
 		) :
 			m_childProcedurals( childProcedurals ),
 			m_parent( parent ),
@@ -309,13 +309,13 @@ class SceneProcedural::SceneProceduralCreate
 				m_childProcedurals[ i ] = sceneProcedural;
 			}
 		}
-	
+
 	private:
-	
+
 		SceneProceduralContainer &m_childProcedurals;
 		const SceneProcedural &m_parent;
 		const vector<InternedString> &m_childNames;
-		
+
 };
 
 
@@ -328,7 +328,7 @@ void SceneProcedural::render( Renderer *renderer ) const
 
 	std::string name;
 	ScenePlug::pathToString( m_scenePath, name );
-	
+
 	/// \todo See above.
 	try
 	{
@@ -339,7 +339,7 @@ void SceneProcedural::render( Renderer *renderer ) const
 		const BoolData *visibilityData = attributes->member<BoolData>( "scene:visible" );
 		if( visibilityData && !visibilityData->readable() )
 		{
-		
+
 			if( !m_rendered )
 			{
 				decrementPendingProcedurals();
@@ -476,9 +476,9 @@ IECore::MurmurHash SceneProcedural::hash() const
 void SceneProcedural::updateAttributes( bool full )
 {
 	Context::Scope scopedContext( m_context.get() );
-	
+
 	// \todo: Investigate if it's worth keeping these around and reusing them in SceneProcedural::render().
-	
+
 	ConstCompoundObjectPtr attributes;
 	if( full )
 	{

--- a/src/GafferScene/SceneProcedural.cpp
+++ b/src/GafferScene/SceneProcedural.cpp
@@ -47,6 +47,7 @@
 #include "IECore/StateRenderable.h"
 #include "IECore/AngleConversion.h"
 #include "IECore/MotionBlock.h"
+#include "IECore/Primitive.h"
 
 #include "Gaffer/Context.h"
 #include "Gaffer/ScriptNode.h"


### PR DESCRIPTION
Prompted by this here query, which got me thinking about how much/little of Cortex Gaffer actually needs :

https://groups.google.com/forum/#!topic/gaffer-dev/OvURWRVP8co

This leaves us with the following dependencies on Cortex in libGaffer :

 - IECore/AngleConversion.h
 - IECore/BoxTraits.h
 - IECore/CompoundData.h
 - IECore/CompoundObject.h
 - IECore/Data.h
 - IECore/DateTimeData.h
 - IECore/Exception.h
 - IECore/FileSequenceFunctions.h
 - IECore/FileSequence.h
 - IECore/InternedString.h
 - IECore/LRUCache.h
 - IECore/MessageHandler.h
 - IECore/MurmurHash.h
 - IECore/Object.h
 - IECore/ObjectVector.h
 - IECore/RefCounted.h
 - IECore/RunTimeTyped.h
 - IECore/SimpleTypedData.h
 - IECore/SplineData.h
 - IECore/Spline.h
 - IECore/VectorTypedData.h

With the possible exception of Spline, these seem pretty reasonable, and give a decent hint as to what a leaner Cortex base library might look like.

Also fixed up some whitespace issues.

I suggest we don't merge this until we've released 0.20.0.0, in case any of our internal tools will need some include tweaking to take into account the fix.