### PR TITLE
Merge : Ensure that input channels are only requested if they exist upstream

### DIFF
--- a/include/GafferImage/ImageAlgo.h
+++ b/include/GafferImage/ImageAlgo.h
@@ -78,6 +78,9 @@ inline std::string baseName( const std::string &channelName );
 /// and "A" respectively. Returns -1 for all other base names.
 inline int colorIndex( const std::string &channelName );
 
+/// Returns true if the specified channel exists in image
+inline bool channelExists( const ImagePlug *image, const std::string &channelName );
+
 enum TileOrder
 {
 	Unordered,

--- a/include/GafferImage/ImageAlgo.inl
+++ b/include/GafferImage/ImageAlgo.inl
@@ -479,6 +479,14 @@ inline int colorIndex( const std::string &channelName )
 	}
 }
 
+inline bool channelExists( const ImagePlug *image, const std::string &channelName )
+{
+	IECore::ConstStringVectorDataPtr channelNamesData = image->channelNamesPlug()->getValue();
+	const std::vector<std::string> &channelNames = channelNamesData->readable();
+
+	return std::find( channelNames.begin(), channelNames.end(), channelName ) != channelNames.end();
+}
+
 template <class ThreadableFunctor>
 void parallelProcessTiles( const ImagePlug *imagePlug, ThreadableFunctor &functor, const Imath::Box2i &window )
 {

--- a/include/GafferImage/Merge.h
+++ b/include/GafferImage/Merge.h
@@ -105,7 +105,7 @@ class Merge : public ImageProcessor
 
 		// Performs the merge operation using the functor 'F'.
 		template<typename F>
-		IECore::ConstFloatVectorDataPtr merge( F f, const Imath::V2i &tileOrigin ) const;
+		IECore::ConstFloatVectorDataPtr merge( F f, const std::string &channelName, const Imath::V2i &tileOrigin ) const;
 
 		static size_t g_firstPlugIndex;
 

--- a/python/GafferImageTest/ImageAlgoTest.py
+++ b/python/GafferImageTest/ImageAlgoTest.py
@@ -93,6 +93,24 @@ class ImageAlgoTest( GafferImageTest.ImageTestCase ) :
 		] :
 			self.assertEqual( GafferImage.colorIndex( channelName ), index )
 
+	def testChannelExists( self ) :
+
+		c = GafferImage.Constant()
+
+		d = GafferImage.DeleteChannels()
+		d["in"].setInput( c["out"] )
+		d["mode"].setValue( GafferImage.DeleteChannels.Mode.Delete )
+		d["channels"].setValue( IECore.StringVectorData( [] ) )
+
+		self.assertTrue( GafferImage.channelExists( d["out"], "R" ) )
+		self.assertTrue( GafferImage.channelExists( d["out"], "G" ) )
+		self.assertTrue( GafferImage.channelExists( d["out"], "B" ) )
+		self.assertTrue( GafferImage.channelExists( d["out"], "A" ) )
+
+		for chan in [ "R", "G", "B", "A" ] :
+			d["channels"].setValue( IECore.StringVectorData( [ chan ] ) )
+			self.assertFalse( GafferImage.channelExists( d["out"], chan ) )
+
 	def testParallelProcessEmptyDataWindow( self ) :
 
 		d = GafferImage.Display()
@@ -101,6 +119,7 @@ class ImageAlgoTest( GafferImageTest.ImageTestCase ) :
 		GafferImageTest.processTiles( d["out"] )
 		d["out"].image()
 		d["out"].imageHash()
+
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageTest/MergeTest.py
+++ b/python/GafferImageTest/MergeTest.py
@@ -389,6 +389,38 @@ class MergeTest( GafferImageTest.ImageTestCase ) :
 		self.assertAlmostEqual( sampler["color"]["b"].getValue(), 0.2 )
 		self.assertAlmostEqual( sampler["color"]["a"].getValue(), 0.2 )
 
+	def testChannelRequest( self ) :
+
+		a = GafferImage.Constant()
+		a["color"].setValue( IECore.Color4f( 0.1, 0.2, 0.3, 0.4 ) )
+
+		ad = GafferImage.DeleteChannels()
+		ad["in"].setInput( a["out"] )
+		ad["mode"].setValue( GafferImage.DeleteChannels.Mode.Delete )
+		ad["channels"].setValue( IECore.StringVectorData( [ "R" ] ) )
+
+		b = GafferImage.Constant()
+		b["color"].setValue( IECore.Color4f( 1.0, 0.3, 0.1, 0.2 ) )
+
+		bd = GafferImage.DeleteChannels()
+		bd["in"].setInput( b["out"] )
+		bd["mode"].setValue( GafferImage.DeleteChannels.Mode.Delete )
+		bd["channels"].setValue( IECore.StringVectorData( [ "G" ] ) )
+
+		merge = GafferImage.Merge()
+		merge["in"][0].setInput( ad["out"] )
+		merge["in"][1].setInput( bd["out"] )
+		merge["operation"].setValue( GafferImage.Merge.Operation.Add )
+
+		sampler = GafferImage.ImageSampler()
+		sampler["image"].setInput( merge["out"] )
+		sampler["pixel"].setValue( IECore.V2f( 10 ) )
+
+		self.assertAlmostEqual( sampler["color"]["r"].getValue(), 0.0 + 1.0 )
+		self.assertAlmostEqual( sampler["color"]["g"].getValue(), 0.2 + 0.0 )
+		self.assertAlmostEqual( sampler["color"]["b"].getValue(), 0.3 + 0.1 )
+		self.assertAlmostEqual( sampler["color"]["a"].getValue(), 0.4 + 0.2 )
+
 	def testDefaultFormat( self ) :
 	
 		a = GafferImage.Constant()

--- a/src/GafferImageBindings/ImageAlgoBinding.cpp
+++ b/src/GafferImageBindings/ImageAlgoBinding.cpp
@@ -48,6 +48,7 @@ void bindImageAlgo()
 	def( "layerName", &GafferImage::layerName );
 	def( "baseName", &GafferImage::baseName );
 	def( "colorIndex", &GafferImage::colorIndex );
+	def( "channelExists", &GafferImage::channelExists );
 
 }
 


### PR DESCRIPTION
This fixes the bug in #1595, which was due to the Merge node requesting channels in upstream branches that didn't exist.