### PR TITLE
GafferImage : Fix reference counting.

### DIFF
--- a/src/GafferImage/Premultiply.cpp
+++ b/src/GafferImage/Premultiply.cpp
@@ -118,7 +118,8 @@ void Premultiply::processChannelData( const Gaffer::Context *context, const Imag
 	tmpContext->set( ImagePlug::channelNameContextName, alphaChannel );
 	Context::Scope scopedContext( tmpContext.get() );
 
-	const std::vector<float> &a = inPlug()->channelDataPlug()->getValue()->readable();
+	ConstFloatVectorDataPtr aData = inPlug()->channelDataPlug()->getValue();
+	const std::vector<float> &a = aData->readable();
 	std::vector<float> &out = outData->writable();
 
 	std::vector<float>::const_iterator aIt = a.begin();

--- a/src/GafferImage/Unpremultiply.cpp
+++ b/src/GafferImage/Unpremultiply.cpp
@@ -118,7 +118,8 @@ void Unpremultiply::processChannelData( const Gaffer::Context *context, const Im
 	tmpContext->set( ImagePlug::channelNameContextName, alphaChannel );
 	Context::Scope scopedContext( tmpContext.get() );
 
-	const std::vector<float> &a = inPlug()->channelDataPlug()->getValue()->readable();
+	ConstFloatVectorDataPtr aData = inPlug()->channelDataPlug()->getValue();
+	const std::vector<float> &a = aData->readable();
 	std::vector<float> &out = outData->writable();
 
 	std::vector<float>::const_iterator aIt = a.begin();


### PR DESCRIPTION
When calling `TypedObjectPlug::getValue()`, the caller is responsible for holding the return value with a ConstPtr for as long as the contents are needed. Otherwise the value can die while it is still being accessed. I'd like to consider ways we could check for this sort of gotcha automatically on Travis at some point...