### PR TITLE
Light Visualisers:  Fixed Y-up convention for UVs on area lights

### DIFF
--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -522,7 +522,7 @@ const char *StandardLightVisualiser::areaLightDrawFragSource()
 		""
 		"void main()"
 		"{"
-			"vec2 texCoords = fragmentst;"
+			"vec2 texCoords = vec2( fragmentst.x, 1 - fragmentst.y );"
 			"if( sphericalProjection )"
 			"{"
 			"	const float toUnit = 0.5 / 3.1415926535897932384626433832795;"


### PR DESCRIPTION
This is a rather embarrassing one to have missed:  the area light visualiser from my last big pull request doesn't account for our convention for UVs vs OpenGL textures, and the images were upside down.  Sorry I didn't catch it earlier.