### PR TITLE
ImageAlgo : Add additional channelExists() overload which takes string vector

### DIFF
--- a/include/GafferImage/ImageAlgo.h
+++ b/include/GafferImage/ImageAlgo.h
@@ -81,6 +81,9 @@ inline int colorIndex( const std::string &channelName );
 /// Returns true if the specified channel exists in image
 inline bool channelExists( const ImagePlug *image, const std::string &channelName );
 
+/// Returns true if the specified channel exists in channelNames
+inline bool channelExists( const std::vector<std::string> &channelNames, const std::string &channelName );
+
 enum TileOrder
 {
 	Unordered,

--- a/include/GafferImage/ImageAlgo.inl
+++ b/include/GafferImage/ImageAlgo.inl
@@ -484,6 +484,11 @@ inline bool channelExists( const ImagePlug *image, const std::string &channelNam
 	IECore::ConstStringVectorDataPtr channelNamesData = image->channelNamesPlug()->getValue();
 	const std::vector<std::string> &channelNames = channelNamesData->readable();
 
+	return channelExists( channelNames, channelName );
+}
+
+inline bool channelExists( const std::vector<std::string> &channelNames, const std::string &channelName )
+{
 	return std::find( channelNames.begin(), channelNames.end(), channelName ) != channelNames.end();
 }
 

--- a/python/GafferImageTest/ImageAlgoTest.py
+++ b/python/GafferImageTest/ImageAlgoTest.py
@@ -111,6 +111,21 @@ class ImageAlgoTest( GafferImageTest.ImageTestCase ) :
 			d["channels"].setValue( IECore.StringVectorData( [ chan ] ) )
 			self.assertFalse( GafferImage.channelExists( d["out"], chan ) )
 
+	def testChannelExistsBindings( self ) :
+		# Test that both forms of binding to channelExists return the same
+		# value
+
+		c = GafferImage.Constant()
+
+		d = GafferImage.DeleteChannels()
+		d["in"].setInput( c["out"] )
+		d["mode"].setValue( GafferImage.DeleteChannels.Mode.Delete )
+		d["channels"].setValue( IECore.StringVectorData( [ "R", "A" ] ) )
+
+		for chan in [ "R", "G", "B", "A" ] :
+			self.assertEqual( GafferImage.channelExists( d["out"], chan ), GafferImage.channelExists( d["out"]["channelNames"].getValue(), chan ) )
+
+
 	def testParallelProcessEmptyDataWindow( self ) :
 
 		d = GafferImage.Display()

--- a/src/GafferImage/Merge.cpp
+++ b/src/GafferImage/Merge.cpp
@@ -199,12 +199,15 @@ void Merge::hashChannelData( const GafferImage::ImagePlug *output, const Gaffer:
 			continue;
 		}
 
-		if( channelExists( it->get(), channelName ) )
+		IECore::ConstStringVectorDataPtr channelNamesData = (*it)->channelNamesPlug()->getValue();
+		const std::vector<std::string> &channelNames = channelNamesData->readable();
+
+		if( channelExists( channelNames, channelName ) )
 		{
 			(*it)->channelDataPlug()->hash( h );
 		}
 
-		if( channelExists( it->get(), "A" ) )
+		if( channelExists( channelNames, "A" ) )
 		{
 			h.append( (*it)->channelDataHash( "A", tileOrigin ) );
 		}
@@ -275,10 +278,13 @@ IECore::ConstFloatVectorDataPtr Merge::merge( F f, const std::string &channelNam
 			continue;
 		}
 
+		IECore::ConstStringVectorDataPtr channelNamesData = (*it)->channelNamesPlug()->getValue();
+		const std::vector<std::string> &channelNames = channelNamesData->readable();
+
 		ConstFloatVectorDataPtr channelData;
 		ConstFloatVectorDataPtr alphaData;
 
-		if( channelExists( it->get(), channelName ) )
+		if( channelExists( channelNames, channelName ) )
 		{
 			channelData = (*it)->channelDataPlug()->getValue();
 		}
@@ -287,7 +293,7 @@ IECore::ConstFloatVectorDataPtr Merge::merge( F f, const std::string &channelNam
 			channelData = ImagePlug::blackTile();
 		}
 
-		if( channelExists( it->get(), "A" ) )
+		if( channelExists( channelNames, "A" ) )
 		{
 			alphaData = (*it)->channelData( "A", tileOrigin );
 		}

--- a/src/GafferImageBindings/ImageAlgoBinding.cpp
+++ b/src/GafferImageBindings/ImageAlgoBinding.cpp
@@ -42,13 +42,47 @@ using namespace boost::python;
 namespace GafferImageBindings
 {
 
+// Register a conversion from StringVectorData.
+/// \todo We could instead do this in the Cortex bindings for all
+/// VectorTypedData types.
+struct StringListFromStringVectorData
+{
+
+	StringListFromStringVectorData()
+	{
+		boost::python::converter::registry::push_back(
+			&convertible,
+			NULL,
+			boost::python::type_id<std::vector<std::string> >()
+		);
+	}
+
+	static void *convertible( PyObject *obj )
+	{
+		extract<IECore::StringVectorData *> dataExtractor( obj );
+		if( dataExtractor.check() )
+		{
+			if( IECore::StringVectorData *data = dataExtractor() )
+			{
+				return &(data->writable());
+			}
+		}
+
+		return NULL;
+	}
+
+};
+
 void bindImageAlgo()
 {
 
 	def( "layerName", &GafferImage::layerName );
 	def( "baseName", &GafferImage::baseName );
 	def( "colorIndex", &GafferImage::colorIndex );
-	def( "channelExists", &GafferImage::channelExists );
+	def( "channelExists", ( bool (*)( const GafferImage::ImagePlug *image, const std::string &channelName ) )&GafferImage::channelExists );
+	def( "channelExists", ( bool (*)( const std::vector<std::string> &channelNames, const std::string &channelName ) )&GafferImage::channelExists );
+
+	StringListFromStringVectorData();
 
 }
 


### PR DESCRIPTION
This PR adds a second channelExists() method to ImageAlgo to allow for a `vector<string>` to be passed straight in, so that if it's called twice in a row, it doesn't have to request channelNamesPlug() to give its value.

There are a couple of issues I had/have with this:

In ImageAlgoBinding, I couldn't figure out how to specify the overloaded method directly there without going through a helper method. I found lots of examples of how to do it with a member method, but not when the method was stand-alone.

I tried something like:

    def( "channelExists", bool ()( const ImagePlug *image, const std::string &channelName ) const )&GafferImage::channelExists );
    def( "channelExists", bool ()( const std::vector<std::string> &channelNames, const std::string &channelName ) const )&GafferImage::channelExists );

But it was what went in the brackets after `bool` that I couldn't get. For a member method, it would be `ClassName::*`, but I couldn't figure out what to do here.

The second thing was having it implicitly convert StringVectorData in Python to vector<string> in C++. The code as it currently stands errors on the test, with:

    ArgumentError: Python argument types in
        GafferImage._GafferImage.channelExists(StringVectorData, str)
    did not match C++ signature:
        channelExists(std::vector<std::string, std::allocator<std::string> >, std::string)
        channelExists(GafferImage::ImagePlug const*, std::string)

However, looking at PathMatcherBinding, something very similar is being done and it works.

https://github.com/ImageEngine/gaffer/blob/master/src/GafferSceneBindings/PathMatcherBinding.cpp#L127

    .def( "match", (unsigned (PathMatcher ::*)( const std::vector<IECore::InternedString> & ) const)&PathMatcher::match )

Defines the binding as linking to a method that accepts a vector. However, here:

https://github.com/ImageEngine/gaffer/blob/master/python/GafferSceneTest/PathMatcherTest.py#L547

    self.assertEqual(
        m.match( IECore.InternedStringVectorData( path[1:].split( "/" ) ) ),
        int( result ),
    )

match() is called with an InternedStringVectorData.

The only difference in my case is that I'm using a StringVectorData rather than an InternedStringVectorData, but I would have expected the process to be the same - that the conversion is being done from `[type]VectorData` to `vector<[type]>`


On a side note, I hope it's okay for me to be doing PRs that are "Here's a PR - it's not quite finished, but here are my questions about it"? Nobody's complained (to me, at least), but I'm aware that my PRs tend to end up with a lot more conversation than others...