### PR TITLE
StandardLightVisualiser : Fix environment lights on OS X.

### DIFF
--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -444,7 +444,11 @@ const char *StandardLightVisualiser::faceCameraVertexSource()
 const char *StandardLightVisualiser::environmentLightDrawFragSource()
 {
 	return
-		"#version 150 compatibility\n"
+		"#version 120\n"
+		""
+		"#if __VERSION__ <= 120\n"
+		"#define in varying\n"
+		"#endif\n"
 		""
 		"#include \"IECoreGL/ColorAlgo.h\"\n"
 		""


### PR DESCRIPTION
We'll need to do the same for area lights as well, but since we're not exposing those in the public builds and I haven't got an easy means of testing them, I'm hoping someone else can pick that up - @danieldresser perhaps?

We need to merge this before we can merge #1608.