### PR TITLE
Simplify JH build options.

### DIFF
--- a/config/jh/options
+++ b/config/jh/options
@@ -1,25 +1,25 @@
 ##########################################################################
-#  
-#  Copyright (c) 2011-2012, John Haddon. All rights reserved.
-#  
+#
+#  Copyright (c) 2011-2016, John Haddon. All rights reserved.
+#
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
 #  met:
-#  
+#
 #      * Redistributions of source code must retain the above
 #        copyright notice, this list of conditions and the following
 #        disclaimer.
-#  
+#
 #      * Redistributions in binary form must reproduce the above
 #        copyright notice, this list of conditions and the following
 #        disclaimer in the documentation and/or other materials provided with
 #        the distribution.
-#  
+#
 #      * Neither the name of John Haddon nor the names of
 #        any other contributors to this software may be used to endorse or
 #        promote products derived from this software without specific prior
 #        written permission.
-#  
+#
 #  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 #  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
 #  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
@@ -31,43 +31,16 @@
 #  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 #  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 #  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#  
+#
 ##########################################################################
 
 import os
 
-def getOption( name, default ) :
-
-	import sys
-	result = default
-	for a in sys.argv:
-		if a[:len(name)+1]==name+"=" :	
-			result = a[len(name)+1:]
-
-	return result
-	
 BUILD_DIR = os.path.expanduser( "~/dev/build/gaffer" )
 BUILD_CACHEDIR = os.path.expanduser( "~/dev/buildCache" )
 INSTALL_DIR = os.path.expanduser( "~/dev/install/gaffer-${GAFFER_MAJOR_VERSION}.${GAFFER_MINOR_VERSION}.${GAFFER_PATCH_VERSION}-${PLATFORM}" )
 DEPENDENCIES_SRC_DIR = os.path.expanduser( "~/dev/gafferDependencies" )
-PYTHON_SRC_DIR = "$DEPENDENCIES_SRC_DIR/Python-2.7.2"
-JPEG_SRC_DIR = "$DEPENDENCIES_SRC_DIR/jpeg-8c"
-TIFF_SRC_DIR = "$DEPENDENCIES_SRC_DIR/tiff-3.8.2"
-PNG_SRC_DIR = "$DEPENDENCIES_SRC_DIR/libpng-1.5.4"
-FREETYPE_SRC_DIR = "$DEPENDENCIES_SRC_DIR/freetype-2.3.9"
-PKGCONFIG_SRC_DIR = "$DEPENDENCIES_SRC_DIR/pkg-config-0.23"
-PYOPENGL_SRC_DIR = "$DEPENDENCIES_SRC_DIR/PyOpenGL-3.0.1"
-RMAN_ROOT = "/Applications/3Delight"
-ARNOLD_ROOT = "/Applications/Graphics/Arnold-4.1.0.0-darwin"
-NUKE_ROOT = "/Applications/Nuke6.3v6/Nuke6.3v6.app/Contents/MacOS"
+RMAN_ROOT = os.environ["DELIGHT"]
+ARNOLD_ROOT = os.environ["ARNOLD_ROOT"]
 DOXYGEN = "/usr/local/bin/doxygen"
 PYTHON_LINK_FLAGS = [ "-lpython$PYTHON_VERSION" ]
-
-CORTEX_SRC_DIR = "/Users/john/dev/cortex.git"
-OIIO_SRC_DIR = "/Users/john/dev/oiio.git"
-LLVM_SRC_DIR = "/Users/john/dev/llvm-3.4.2.src"
-OSL_SRC_DIR = "/Users/john/dev/OpenShadingLanguage.git"
-
-SIP_SRC_DIR = "$DEPENDENCIES_SRC_DIR/sip-4.14"
-PYQT_SRC_DIR = "$DEPENDENCIES_SRC_DIR/PyQt-mac-gpl-4.9.5"
-BUILD_DEPENDENCY_PYQT = False


### PR DESCRIPTION
- Remove old arguments pertaining to building dependencies from source.
- Use DELIGHT and ARNOLD_ROOT to find renderers in platform independent way.
- Remove unused getOption() function.