### PR TITLE
Image viewer fixes

### DIFF
--- a/src/GafferImageUI/ImageGadget.cpp
+++ b/src/GafferImageUI/ImageGadget.cpp
@@ -155,6 +155,14 @@ void ImageGadget::setSoloChannel( int index )
 	}
 
 	m_soloChannel = index;
+	if( m_soloChannel == -1 )
+	{
+		// Last time we called updateTiles(), we
+		// only updated the solo channel, so now
+		// we need to trigger a pass over all the
+		// channels.
+		m_dirtyFlags |= TilesDirty;
+	}
 	requestRender();
 }
 

--- a/src/GafferImageUI/ImageView.cpp
+++ b/src/GafferImageUI/ImageView.cpp
@@ -380,15 +380,18 @@ void ImageView::plugSet( Gaffer::Plug *plug )
 
 bool ImageView::keyPress( const GafferUI::KeyEvent &event )
 {
-	const char *rgba[4] = { "R", "G", "B", "A" };
-	for( int i = 0; i < 4; ++i )
+	if( !event.modifiers )
 	{
-		if( event.key == rgba[i] )
+		const char *rgba[4] = { "R", "G", "B", "A" };
+		for( int i = 0; i < 4; ++i )
 		{
-			m_imageGadget->setSoloChannel(
-				m_imageGadget->getSoloChannel() == i ? -1 : i
-			);
-			return true;
+			if( event.key == rgba[i] )
+			{
+				m_imageGadget->setSoloChannel(
+					m_imageGadget->getSoloChannel() == i ? -1 : i
+				);
+				return true;
+			}
 		}
 	}
 


### PR DESCRIPTION
This fixes a couple of problems with the ImageView. I believe the keypress problem was a result of the recent change to shortcut handling (#1597) rather than the ImageView update (#1592). The update problem was definitely due to the ImageView update though, and I think probably accounts for the glitch @andrewkaufman documented in that PR but was then unable to reproduce.