### PR TITLE
Procedurals without bounds

### DIFF
--- a/config/travis/installDependencies.py
+++ b/config/travis/installDependencies.py
@@ -15,7 +15,7 @@ buildDir = "build/gaffer-%d.%d.%d.%d-%s" % ( gafferMilestoneVersion, gafferMajor
 
 # get the prebuilt dependencies package and unpack it into the build directory
 
-downloadURL = "https://github.com/johnhaddon/gafferDependencies/releases/download/0.20.0.0/gafferDependencies-0.20.0.0-linux.tar.gz"
+downloadURL = "https://github.com/johnhaddon/gafferDependencies/releases/download/0.22.0.0/gafferDependencies-0.22.0.0-linux.tar.gz"
 
 sys.stderr.write( "Downloading dependencies \"%s\"" % downloadURL )
 tarFileName, headers = urllib.urlretrieve( downloadURL )

--- a/include/GafferScene/SceneProcedural.h
+++ b/include/GafferScene/SceneProcedural.h
@@ -70,10 +70,13 @@ class SceneProcedural : public IECore::Renderer::Procedural
 		IE_CORE_DECLAREMEMBERPTR( SceneProcedural );
 
 		/// A copy of context is taken.
-		SceneProcedural( ConstScenePlugPtr scenePlug, const Gaffer::Context *context, const ScenePlug::ScenePath &scenePath=ScenePlug::ScenePath() );
+		SceneProcedural( ConstScenePlugPtr scenePlug, const Gaffer::Context *context, const ScenePlug::ScenePath &scenePath=ScenePlug::ScenePath(), bool computeBound = true );
 		virtual ~SceneProcedural();
 
 		virtual IECore::MurmurHash hash() const;
+		/// Returns an accurate computed bound if `computeBound=true`
+		/// was passed to the constructor, otherwise returns
+		/// Procedural::noBound.
 		virtual Imath::Box3f bound() const;
 		virtual void render( IECore::Renderer *renderer ) const;
 
@@ -116,7 +119,7 @@ class SceneProcedural : public IECore::Renderer::Procedural
 	private :
 
 		void updateAttributes();
-		void computeBound();
+		void initBound( bool compute );
 		void motionTimes( unsigned segments, std::set<float> &times ) const;
 
 		// A global counter of all the scene procedurals that are hanging around but haven't been rendered yet, which

--- a/python/GafferArnold/ArnoldRender.py
+++ b/python/GafferArnold/ArnoldRender.py
@@ -101,6 +101,16 @@ class ArnoldRender( GafferScene.ExecutableRender ) :
 		procedural["fileName"].setTypedValue( scriptNode["fileName"].getValue() )
 		procedural["node"].setTypedValue( scenePlug.node().relativeName( scriptNode ) )
 		procedural["frame"].setNumericValue( currentContext.getFrame() )
+		## \todo Determine an appropriate value for the "computeBounds" parameter.
+		# In theory we might see startup time improvements if we turned it off as
+		# we do for 3delight. But on the other hand turning off bounds computation
+		# makes IECoreArnold use load_at_init which by default serialises procedural
+		# expansion (in theory the parallel_node_init option could paralellise that
+		# again). But since Arnold properly expands procedurals only when they are
+		# hit by a ray, perhaps we're actually better off computing accurate bounds
+		# in the hope that not everything will be expanded. The only reason it's a
+		# definite win to turn it off in 3delight is because everything is going to
+		# be expanded anyway.
 
 		contextArgs = IECore.StringVectorData()
 		for entry in [ k for k in currentContext.keys() if k != "frame" and not k.startswith( "ui:" ) ] :
@@ -116,7 +126,7 @@ class ArnoldRender( GafferScene.ExecutableRender ) :
 
 		externalProcedural = IECore.Renderer.ExternalProcedural(
 			"ieProcedural.so",
-			IECore.Box3f( IECore.V3f( -1e30 ), IECore.V3f( 1e30 ) ),
+			IECore.Renderer.Procedural.noBound,
 			{
 				"className" : "gaffer/script",
 				"classVersion" : 1,

--- a/python/GafferScene/ScriptProcedural.py
+++ b/python/GafferScene/ScriptProcedural.py
@@ -72,6 +72,16 @@ class ScriptProcedural( IECore.ParameterisedProcedural ) :
 					defaultValue = 1,
 				),
 
+				IECore.BoolParameter(
+					name = "computeBound",
+					description =
+						"Determines if the procedural will compute an accurate bound "
+						"or just not specify a bound. Not specifying a bound can give "
+						"improved performance in cases where the procedurals will all "
+						"be expanded immediately anyway.",
+					defaultValue = True,
+				),
+
 				IECore.StringVectorParameter(
 					name = "context",
 					description = "Additional context entries to be used during rendering.",
@@ -95,7 +105,7 @@ class ScriptProcedural( IECore.ParameterisedProcedural ) :
 		if plug is  None :
 			return IECore.Box3f()
 
-		sceneProcedural = GafferScene.SceneProcedural( plug, context, "/" )
+		sceneProcedural = GafferScene.SceneProcedural( plug, context, "/", args["computeBound"].value )
 		return sceneProcedural.bound()
 
 	def doRender( self, renderer, args ) :
@@ -106,7 +116,7 @@ class ScriptProcedural( IECore.ParameterisedProcedural ) :
 
 		self.__postExpansionCacheClearConnection = GafferScene.SceneProcedural.allRenderedSignal().connect( Gaffer.WeakMethod( self.__allRendered ) )
 
-		sceneProcedural = GafferScene.SceneProcedural( plug, context, "/" )
+		sceneProcedural = GafferScene.SceneProcedural( plug, context, "/", args["computeBound"].value )
 		renderer.procedural( sceneProcedural )
 
 	def __allRendered( self ):

--- a/python/GafferSceneTest/SceneProceduralTest.py
+++ b/python/GafferSceneTest/SceneProceduralTest.py
@@ -282,5 +282,16 @@ class SceneProceduralTest( unittest.TestCase ) :
 				else :
 					self.assertEqual( bound, IECore.Box3f( sphereBound.min + velocity * frame, sphereBound.max + velocity * frame ) )
 
+	def testComputeBound( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["p"] = GafferScene.Plane()
+
+		proc1 = GafferScene.SceneProcedural( script["p"]["out"], script.context(), "/" )
+		proc2 = GafferScene.SceneProcedural( script["p"]["out"], script.context(), "/", computeBound = False )
+
+		self.assertEqual( proc1.bound(), script["p"]["out"].bound( "/" ) )
+		self.assertEqual( proc2.bound(), IECore.Renderer.Procedural.noBound )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferSceneBindings/SceneProceduralBinding.cpp
+++ b/src/GafferSceneBindings/SceneProceduralBinding.cpp
@@ -60,12 +60,14 @@ void GafferSceneBindings::bindSceneProcedural()
 			init<
 				ConstScenePlugPtr,
 				const Gaffer::Context *,
-				const ScenePlug::ScenePath &
+				const ScenePlug::ScenePath &,
+				bool
 			>(
 				(
 					boost::python::arg( "scenePlug" ),
 					boost::python::arg( "context" ),
-					boost::python::arg( "scenePath" )
+					boost::python::arg( "scenePath" ),
+					boost::python::arg( "computeBound" ) = true
 				)
 			)
 		)


### PR DESCRIPTION
This allows us to omit the calculation of procedural bounds when raytracing with 3delight, where we know that all procedurals will be expanded before the render starts anyway. This gives us a 25% reduction in time to first pixel for a complex benchmark scene.

Requires https://github.com/ImageEngine/cortex/pull/466
