### PR TITLE
FilteredSceneProcessor : Remove restrictions on filters.

### DIFF
--- a/include/GafferScene/Isolate.h
+++ b/include/GafferScene/Isolate.h
@@ -69,6 +69,8 @@ class Isolate : public FilteredSceneProcessor
 
 	protected :
 
+		virtual bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const;
+
 		virtual void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
 		virtual void hashChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
 		virtual void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;

--- a/include/GafferScene/Prune.h
+++ b/include/GafferScene/Prune.h
@@ -59,6 +59,8 @@ class Prune : public FilteredSceneProcessor
 
 	protected :
 
+		virtual bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const;
+
 		virtual void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
 		virtual void hashChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
 		virtual void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;

--- a/src/GafferScene/FilteredSceneProcessor.cpp
+++ b/src/GafferScene/FilteredSceneProcessor.cpp
@@ -81,28 +81,6 @@ void FilteredSceneProcessor::affects( const Gaffer::Plug *input, AffectedPlugsCo
 		const Filter *filter = runTimeCast<const Filter>( filterPlug()->source<Plug>()->node() );
 		if( filter && filter->sceneAffectsMatch( scenePlug, static_cast<const ValuePlug *>( input ) ) )
 		{
-			if(
-				input != scenePlug->globalsPlug() &&
-				input != scenePlug->setNamesPlug() &&
-				input != scenePlug->setPlug()
-			)
-			{
-				/// \todo Obviously it would be great to remove this restriction and implement AttributeFilters and
-				/// BoundFilters and suchlike. There are currently two issues :
-				///
-				/// - Implementing DescendantMatch and AncestorMatch would be very expensive for an AttributeFilter,
-				///   and filters currently compute all results at once. At the very least we need a way
-				///   of only computing ExactMatch when that is all that is needed, and only paying the extra
-				///   when descendant and ancestor matches are relevant. If we had a hierarchy hash we might be able
-				///   to do even better.
-				///
-				/// - The Isolate and Prune nodes make a single call to filterHash() in hashSet(), to account for
-				///   the fact that the filter is used in remapping sets. This wouldn't work for filter types which
-				///   actually vary based on data within the scene hierarchy, because then multiple calls would be
-				///   necessary. We could make more calls here, but that would be expensive. In an ideal world we'd
-				///   be able to compute a hash for the filter across a whole hierarchy.
-				throw Exception( "Filters may not currently depend on parts of the scene other than the globals and sets." );
-			}
 			outputs.push_back( filterPlug() );
 		}
 	}

--- a/src/GafferScene/Isolate.cpp
+++ b/src/GafferScene/Isolate.cpp
@@ -110,6 +110,40 @@ void Isolate::affects( const Gaffer::Plug *input, AffectedPlugsContainer &output
 	}
 }
 
+bool Isolate::acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const
+{
+	if( !FilteredSceneProcessor::acceptsInput( plug, inputPlug ) )
+	{
+		return false;
+	}
+
+	if( plug == filterPlug() )
+	{
+		if( const Filter *filter = runTimeCast<const Filter>( inputPlug->source<Plug>()->node() ) )
+		{
+			if(
+				filter->sceneAffectsMatch( inPlug(), inPlug()->boundPlug() ) ||
+				filter->sceneAffectsMatch( inPlug(), inPlug()->transformPlug() ) ||
+				filter->sceneAffectsMatch( inPlug(), inPlug()->attributesPlug() ) ||
+				filter->sceneAffectsMatch( inPlug(), inPlug()->objectPlug() ) ||
+				filter->sceneAffectsMatch( inPlug(), inPlug()->childNamesPlug() )
+			)
+			{
+				// We make a single call to filterHash() in hashSet(), to account for
+				// the fact that the filter is used in remapping sets. This wouldn't
+				// work for filter types which actually vary based on data within the
+				// scene hierarchy, because then multiple calls would be necessary.
+				// We could make more calls here, but that would be expensive.
+				/// \todo In an ideal world we'd be able to compute a hash for the
+				/// filter across a whole hierarchy.
+				return false;
+			}
+		}
+	}
+
+	return true;
+}
+
 void Isolate::hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
 	if( adjustBoundsPlug()->getValue() && mayPruneChildren( path, filterValue( context ) ) )

--- a/src/GafferScene/Prune.cpp
+++ b/src/GafferScene/Prune.cpp
@@ -96,6 +96,40 @@ void Prune::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs 
 	}
 }
 
+bool Prune::acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const
+{
+	if( !FilteredSceneProcessor::acceptsInput( plug, inputPlug ) )
+	{
+		return false;
+	}
+
+	if( plug == filterPlug() )
+	{
+		if( const Filter *filter = runTimeCast<const Filter>( inputPlug->source<Plug>()->node() ) )
+		{
+			if(
+				filter->sceneAffectsMatch( inPlug(), inPlug()->boundPlug() ) ||
+				filter->sceneAffectsMatch( inPlug(), inPlug()->transformPlug() ) ||
+				filter->sceneAffectsMatch( inPlug(), inPlug()->attributesPlug() ) ||
+				filter->sceneAffectsMatch( inPlug(), inPlug()->objectPlug() ) ||
+				filter->sceneAffectsMatch( inPlug(), inPlug()->childNamesPlug() )
+			)
+			{
+				// We make a single call to filterHash() in hashSet(), to account for
+				// the fact that the filter is used in remapping sets. This wouldn't
+				// work for filter types which actually vary based on data within the
+				// scene hierarchy, because then multiple calls would be necessary.
+				// We could make more calls here, but that would be expensive.
+				/// \todo In an ideal world we'd be able to compute a hash for the
+				/// filter across a whole hierarchy.
+				return false;
+			}
+		}
+	}
+
+	return true;
+}
+
 void Prune::hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
 	if( adjustBoundsPlug()->getValue() )


### PR DESCRIPTION
This is to allow @davidsminor to do some investigations into more advanced filters internally at Image Engine. David, I haven't added tests for the new Prune/Isolate behaviour because there's no suitable filter in GafferScene. Could you verify that they're rejecting filters appropriately at your end before merging?