### PR TITLE
AnimationUI : Fix "Set Key" plug menu item.

### DIFF
--- a/python/GafferUI/AnimationUI.py
+++ b/python/GafferUI/AnimationUI.py
@@ -72,11 +72,14 @@ GafferUI.NodeGadget.registerNodeGadget( Gaffer.Animation, lambda node : None )
 # PlugValueWidget popup menu for setting keys
 ##########################################################################
 
-def __setKey( plug, time, value ) :
+def __setKey( plug, context ) :
+
+	with context :
+		value = plug.getValue()
 
 	with Gaffer.UndoContext( plug.ancestor( Gaffer.ScriptNode ) ) :
 		curve = Gaffer.Animation.acquire( plug )
-		curve.addKey( Gaffer.Animation.Key( time, value ) )
+		curve.addKey( Gaffer.Animation.Key( context.getTime(), value ) )
 
 def __removeKey( plug, time ) :
 
@@ -136,8 +139,7 @@ def __popupMenu( menuDefinition, plugValueWidget ) :
 			"command" : functools.partial(
 				__setKey,
 				plug,
-				context.getTime(),
-				plug.getValue()
+				context
 			),
 			"active" : plugValueWidget._editable( canEditAnimation = True ),
 		}


### PR DESCRIPTION
There were two problems here :

- We weren't using the context to get the current plug value.
- We were getting the plug value during menu definition building and this interacted poorly with the NumericPlugValueWidget as follows :
	- User edits value in NumericPlugValueWidget, but it is not yet committed by NumericPlugValueWidget.__valueChanged
	- User right clicks to get menu
	- Menu is built, and stores the old value from the plug
	- Menu is shown, taking focus from NumericPlugValueWidget
	- Focus loss triggers NumericPlugValueWidget.__valueChanged, and keyframes with the new value
	- User chooses "Set Key" and we overwrite the keyframe with the old stored value

Both these problems are fixed by using the context to compute the plug value just prior to setting the keyframe rather than when the menu builds.