### PR TITLE
Disabling AnimationUI popup menu for non-ValuePlugs

### DIFF
--- a/python/GafferUI/AnimationUI.py
+++ b/python/GafferUI/AnimationUI.py
@@ -87,7 +87,7 @@ def __removeKey( plug, time ) :
 def __popupMenu( menuDefinition, plugValueWidget ) :
 
 	plug = plugValueWidget.getPlug()
-	if not Gaffer.Animation.canAnimate( plug ) :
+	if not isinstance( plug, Gaffer.ValuePlug ) or not Gaffer.Animation.canAnimate( plug ) :
 		return
 
 	context = plugValueWidget.getContext()


### PR DESCRIPTION
This came up because of Jabuka `InputConnectionPlugs` which get displayed from the Op app. Previously right clicking on those plugs caused the following error. I guess this could also be fixed by adding that `EntityPlug` which derives from `ValuePlug` that @ivanimanishi was discussing, but this change seemed harmless enough to merit the faster fix. Alternatively, there could be an opt-in/opt-out of Animation via app config.

```
Traceback (most recent call last):
  File "/home/andrewk/apps/gaffer/0.21.0.0dev/cent7.x86_64/cortex/9/gaffer/python/GafferUI/Widget.py", line 944, in eventFilter
    return self.__contextMenu( qObject, qEvent )
  File "/home/andrewk/apps/gaffer/0.21.0.0dev/cent7.x86_64/cortex/9/gaffer/python/GafferUI/Widget.py", line 1124, in __contextMenu
    return widget._contextMenuSignal( widget )
RuntimeError: Exception : Traceback (most recent call last):
  File "/home/andrewk/apps/gaffer/0.21.0.0dev/cent7.x86_64/cortex/9/gaffer/python/Gaffer/WeakMethod.py", line 67, in __call__
    return m( *args, **kwArgs )
  File "/home/andrewk/apps/gaffer/0.21.0.0dev/cent7.x86_64/cortex/9/gaffer/python/GafferUI/PlugValueWidget.py", line 513, in __contextMenu
    menuDefinition = self._popupMenuDefinition()
  File "/home/andrewk/apps/gaffer/0.21.0.0dev/cent7.x86_64/cortex/9/gaffer/python/GafferUI/PlugValueWidget.py", line 325, in _popupMenuDefinition
    self.popupMenuSignal()( menuDefinition, self )
RuntimeError: Exception : Traceback (most recent call last):
  File "/home/andrewk/apps/gaffer/0.21.0.0dev/cent7.x86_64/cortex/9/gaffer/python/GafferUI/AnimationUI.py", line 90, in __popupMenu
    if not Gaffer.Animation.canAnimate( plug ) :
ArgumentError: Python argument types in
    Animation.canAnimate(InputConnectionPlug)
did not match C++ signature:
    canAnimate(Gaffer::ValuePlug const*)
```