### PR TITLE
PlugLayout : Stop long summaries expanding widgets below.

### DIFF
--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -663,7 +663,7 @@ class _CollapsibleLayout( _Layout ) :
 				collapsible.setCornerWidget( GafferUI.Label(), True )
 				## \todo This is fighting the default sizing applied in the Label constructor. Really we need a standard
 				# way of controlling size behaviours for all widgets in the public API.
-				collapsible.getCornerWidget()._qtWidget().setSizePolicy( QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Fixed )
+				collapsible.getCornerWidget()._qtWidget().setSizePolicy( QtGui.QSizePolicy.Ignored, QtGui.QSizePolicy.Fixed )
 
 				if subsection.restoreState( "collapsed" ) is False :
 					collapsible.setCollapsed( False )


### PR DESCRIPTION
When the summary was getting too long, it was requesting more space, and expanding the width of the whole column. The plug widgets in the column were then also expanding to take advantage of the apparent extra space. But often the parent SplitContainer would actually be clipping the widened column to make it fit in the layout, so the long summary was actually just pushing the right hand edges of the plug widgets outside of the clipped area, causing a fair amount of user annoyance.

In an ideal world we'd use "..." to indicate that the summary text is being clipped, but this isn't straightforward, so has been omitted here. The underlying QLabel itself has no built-in functionality for elision, because it supports multiline rich text. It is possible to do [manual elision inside a paintEvent()](http://comments.gmane.org/gmane.comp.lib.qt.general/26005) in the case of single line plain text, but we're actually using rich text markup in this case anyway, so the problem appears non-trivial.

One other option would be to use a [fade-out gradient to indicate elision](https://daniel.molkentin.net/2007/03/25/ellipsis-made-easy/), probably based on the actual size not meeting the sizeHint requirements. It seems though that if we were to do this, it would make most sense to do it for the whole column rather than just the label, so we had a prettier visual indication of the plug widgets being clipped too.

So, in short, I wish to punt on the ellipsis for now. Assuming that's acceptable, this addresses IE shotgun ticket 8146.