### PR TITLE
Cyclic dependency fixes

### DIFF
--- a/include/Gaffer/DownstreamIterator.h
+++ b/include/Gaffer/DownstreamIterator.h
@@ -1,0 +1,312 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFER_DOWNSTREAMITERATOR_H
+#define GAFFER_DOWNSTREAMITERATOR_H
+
+#include "boost/iterator/iterator_facade.hpp"
+
+#include "IECore/MessageHandler.h"
+
+#include "Gaffer/DependencyNode.h"
+
+namespace Gaffer
+{
+
+/// Performs a depth-first iteration of a plug's outputs and affected plugs.
+class DownstreamIterator : public boost::iterator_facade<DownstreamIterator, const Plug, boost::forward_traversal_tag>
+{
+
+	public :
+
+		DownstreamIterator( const Plug *plug )
+			:	m_root( plug ), m_pruned( false )
+		{
+			m_stack.push_back(
+				Level(
+					plug
+				)
+			);
+		}
+
+		size_t depth() const
+		{
+			return m_stack.size() - 1;
+		}
+
+		const Plug *upstream() const
+		{
+			if( m_stack.size() > 1 )
+			{
+				return *(m_stack[m_stack.size()-2].it);
+			}
+			return m_root;
+		}
+
+		/// Calling prune() causes the next increment to skip any recursion
+		/// that it would normally perform.
+		void prune()
+		{
+			m_pruned = true;
+		}
+
+		bool operator==( const DependencyNode::AffectedPlugsContainer::const_iterator &rhs ) const
+		{
+			return stackTop().it == rhs ;
+		}
+
+		bool operator!=( const DependencyNode::AffectedPlugsContainer::const_iterator &rhs ) const
+		{
+			return stackTop().it != rhs;
+		}
+
+		const DependencyNode::AffectedPlugsContainer::const_iterator &end() const
+		{
+			return m_stack[0].end;
+		}
+
+	private :
+
+		friend class boost::iterator_core_access;
+
+		class Level
+		{
+
+			public :
+
+				Level( const Plug *plug )
+					:	plugs( plug->outputs().begin(), plug->outputs().end() )
+				{
+					addDependentPlugs( plug );
+					addAncestorOutputs( plug );
+					it = plugs.begin();
+					end = plugs.end();
+				}
+
+				Level( const Level &other )
+					:	plugs( other.plugs ), it( plugs.begin() + (other.it - other.plugs.begin()) ), end( plugs.end() )
+				{
+				}
+
+				bool operator == ( const Level &other ) const
+				{
+					return plugs == other.plugs && ( it - plugs.begin() == other.it - other.plugs.begin() );
+				}
+
+				DependencyNode::AffectedPlugsContainer plugs;
+				DependencyNode::AffectedPlugsContainer::const_iterator it;
+				DependencyNode::AffectedPlugsContainer::const_iterator end;
+
+			private :
+
+				void addDependentPlugs( const Plug *plug )
+				{
+					if( !plug->children().empty() )
+					{
+						// We only call affects() for leaf level plugs. This
+						// is because ComputeNode hash/compute also only occurs
+						// for leaf plugs, and it would be too big a burden on
+						// node implementers to implement affects() to reflect
+						// child behaviour in parents.
+						return;
+					}
+
+					const DependencyNode *node = IECore::runTimeCast<const DependencyNode>( plug->node() );
+					if( !node )
+					{
+						return;
+					}
+
+					const size_t firstDependentIndex = plugs.size();
+
+					// We don't want client code iterating the graph to
+					// be responsible for dealing with buggy Node::affects()
+					// implementations, so we catch and report any exceptions
+					// which occur.
+					try
+					{
+						node->affects( plug, plugs );
+					}
+					catch( const std::exception &e )
+					{
+						IECore::msg(
+							IECore::Msg::Error,
+							node->fullName() + "::affects()",
+							e.what()
+						);
+					}
+					catch( ... )
+					{
+						IECore::msg(
+							IECore::Msg::Error,
+							node->fullName() + "::affects()",
+							"Unknown exception"
+						);
+					}
+
+					// Likewise we don't want client code to be exposed to
+					// dependencies which are disallowed.
+					plugs.erase(
+						std::remove_if(
+							plugs.begin() + firstDependentIndex,
+							plugs.end(),
+							isNonLeaf
+						),
+						plugs.end()
+					);
+				}
+
+				static bool isNonLeaf( const Plug *plug )
+				{
+					if( plug->children().empty() )
+					{
+						return false;
+					}
+					const Node *node = plug->node();
+					IECore::msg(
+						IECore::Msg::Error,
+						node->fullName() + "::affects()",
+						"Non-leaf plug " + plug->relativeName( node ) + " returned by affects()"
+					);
+					return true;
+				}
+
+				void addAncestorOutputs( const Plug *plug )
+				{
+					// It is valid to connect a compound plug into
+					// a non-compound Plug, but when this is done, the
+					// "leaf level" where the plugs have no children
+					// is deeper on the source side than it is on the
+					// destination side. Since we only propagate dependencies
+					// along the leaf levels, we must account for the
+					// mismatch by finding ancestors which output to leaf
+					// level plugs, and including those destination
+					// plugs in our traversal.
+					plug = plug->parent<Plug>();
+					while( plug )
+					{
+						for( Plug::OutputContainer::const_iterator it = plug->outputs().begin(), eIt = plug->outputs().end(); it!=eIt; ++it )
+						{
+							if( (*it)->children().empty() )
+							{
+								plugs.push_back( *it );
+							}
+						}
+						plug = plug->parent<Plug>();
+					}
+				}
+
+		};
+
+		typedef std::vector<Level> Levels;
+		Levels m_stack;
+		const Plug *m_root;
+		bool m_pruned;
+
+		void increment()
+		{
+			const Plug *currentPlug = *(stackTop().it);
+			if( !m_pruned && !cyclic() )
+			{
+				// go downstream if we can
+				Level level( currentPlug );
+				if( !level.plugs.empty() )
+				{
+					m_stack.push_back( level );
+					return;
+				}
+				// otherwise fall through
+			}
+
+			++(stackTop().it);
+			while( m_stack.size() > 1 && stackTop().it == stackTop().end )
+			{
+				m_stack.pop_back();
+				++(stackTop().it);
+			}
+			m_pruned = false;
+		}
+
+		bool equal( const DownstreamIterator &other ) const
+		{
+			return m_stack == other.m_stack;
+		}
+
+		const Plug &dereference() const
+		{
+			return **(stackTop().it);
+		}
+
+		Level &stackTop()
+		{
+			return *(m_stack.rbegin());
+		}
+
+		const Level &stackTop() const
+		{
+			return *(m_stack.rbegin());
+		}
+
+		bool cyclic() const
+		{
+			const Plug *currentPlug = *(stackTop().it);
+			if( !currentPlug->getFlags( Plug::AcceptsDependencyCycles ) )
+			{
+				// We don't want to iterate our stack looking for cycles
+				// on every increment - that would be slow. Instead we only
+				// check for a cycle when we visit the rare plugs which
+				// declare that they expect to take part in a cycle.
+				return false;
+			}
+			if( currentPlug == m_root )
+			{
+				return true;
+			}
+			for( int i = 0, e = m_stack.size() - 1; i < e; ++i )
+			{
+				if( *(m_stack[i].it) == currentPlug )
+				{
+					return true;
+				}
+			}
+			return false;
+		}
+
+};
+
+} // namespace Gaffer
+
+#endif // GAFFER_DOWNSTREAMITERATOR_H

--- a/include/Gaffer/Plug.h
+++ b/include/Gaffer/Plug.h
@@ -229,6 +229,7 @@ class Plug : public GraphComponent
 
 		void setFlagsInternal( unsigned flags );
 
+		bool acceptsInputInternal( const Plug *input, bool detectDependencyCycles ) const;
 		void setInput( PlugPtr input, bool setChildInputs, bool updateParentInput );
 		void setInputInternal( PlugPtr input, bool emit );
 		void emitInputChanged();

--- a/include/Gaffer/Switch.inl
+++ b/include/Gaffer/Switch.inl
@@ -135,20 +135,22 @@ void Switch<BaseType>::affects( const Plug *input, DependencyNode::AffectedPlugs
 		input == indexPlug()
 	)
 	{
-		const Plug *out = BaseType::template getChild<Plug>( "out" );
-		if( out->children().size() )
+		if( const Plug *out = BaseType::template getChild<Plug>( "out" ) )
 		{
-			for( RecursiveOutputPlugIterator it( out ); it != it.end(); ++it )
+			if( out->children().size() )
 			{
-				if( !(*it)->children().size() )
+				for( RecursiveOutputPlugIterator it( out ); it != it.end(); ++it )
 				{
-					outputs.push_back( it->get() );
+					if( !(*it)->children().size() )
+					{
+						outputs.push_back( it->get() );
+					}
 				}
 			}
-		}
-		else
-		{
-			outputs.push_back( out );
+			else
+			{
+				outputs.push_back( out );
+			}
 		}
 	}
 	else if( input->direction() == Plug::In )

--- a/include/GafferBindings/DependencyNodeBinding.h
+++ b/include/GafferBindings/DependencyNodeBinding.h
@@ -90,9 +90,9 @@ class DependencyNodeWrapper : public NodeWrapper<WrappedType>
 		{
 			if( this->isSubclassed() )
 			{
+				IECorePython::ScopedGILLock gilLock;
 				try
 				{
-					IECorePython::ScopedGILLock gilLock;
 					boost::python::object f = this->methodOverride( "affects" );
 					if( f )
 					{
@@ -114,9 +114,9 @@ class DependencyNodeWrapper : public NodeWrapper<WrappedType>
 		{
 			if( this->isSubclassed() )
 			{
+				IECorePython::ScopedGILLock gilLock;
 				try
 				{
-					IECorePython::ScopedGILLock gilLock;
 					boost::python::object f = this->methodOverride( "enabledPlug" );
 					if( f )
 					{
@@ -141,9 +141,9 @@ class DependencyNodeWrapper : public NodeWrapper<WrappedType>
 		{
 			if( this->isSubclassed() )
 			{
+				IECorePython::ScopedGILLock gilLock;
 				try
 				{
-					IECorePython::ScopedGILLock gilLock;
 					boost::python::object f = this->methodOverride( "correspondingInput" );
 					if( f )
 					{

--- a/include/GafferTest/DownstreamIteratorTest.h
+++ b/include/GafferTest/DownstreamIteratorTest.h
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012, John Haddon. All rights reserved.
-//  Copyright (c) 2013-2015, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,40 +34,14 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "IECorePython/ScopedGILRelease.h"
+#ifndef GAFFERTEST_DOWNSTREAMITERATORTEST_H
+#define GAFFERTEST_DOWNSTREAMITERATORTEST_H
 
-#include "GafferBindings/DependencyNodeBinding.h"
-
-#include "GafferTest/MultiplyNode.h"
-#include "GafferTest/RecursiveChildIteratorTest.h"
-#include "GafferTest/FilteredRecursiveChildIteratorTest.h"
-#include "GafferTest/MetadataTest.h"
-#include "GafferTest/ContextTest.h"
-#include "GafferTest/ComputeNodeTest.h"
-#include "GafferTest/DownstreamIteratorTest.h"
-
-using namespace boost::python;
-using namespace GafferTest;
-
-static void testMetadataThreadingWrapper()
-{
-	IECorePython::ScopedGILRelease gilRelease;
-	testMetadataThreading();
-}
-
-BOOST_PYTHON_MODULE( _GafferTest )
+namespace GafferTest
 {
 
-	GafferBindings::DependencyNodeClass<MultiplyNode>();
+void testDownstreamIterator();
 
-	def( "testRecursiveChildIterator", &testRecursiveChildIterator );
-	def( "testFilteredRecursiveChildIterator", &testFilteredRecursiveChildIterator );
-	def( "testMetadataThreading", &testMetadataThreadingWrapper );
-	def( "testManyContexts", &testManyContexts );
-	def( "testManySubstitutions", &testManySubstitutions );
-	def( "testManyEnvironmentSubstitutions", &testManyEnvironmentSubstitutions );
-	def( "testScopingNullContext", &testScopingNullContext );
-	def( "testComputeNodeThreading", &testComputeNodeThreading );
-	def( "testDownstreamIterator", &testDownstreamIterator );
+} // namespace GafferTest
 
-}
+#endif // GAFFERTEST_DOWNSTREAMITERATORTEST_H

--- a/python/GafferArnoldTest/ArnoldShaderTest.py
+++ b/python/GafferArnoldTest/ArnoldShaderTest.py
@@ -343,5 +343,28 @@ class ArnoldShaderTest( unittest.TestCase ) :
 
 		self.assertEqual( a["out"].attributes( "/plane" ).keys(), [ "ai:surface"] )
 
+	def testDirtyPropagationThroughShaderAssignment( self ) :
+
+		n = GafferArnold.ArnoldShader()
+		n.loadShader( "flat" )
+
+		p = GafferScene.Plane()
+		a = GafferScene.ShaderAssignment()
+		a["in"].setInput( p["out"] )
+		a["shader"].setInput( n["out"] )
+
+		cs = GafferTest.CapturingSlot( a.plugDirtiedSignal() )
+
+		n["parameters"]["color"]["r"].setValue( 0.25 )
+
+		self.assertEqual(
+			[ c[0] for c in cs ],
+			[
+				a["shader"],
+				a["out"]["attributes"],
+				a["out"],
+			],
+		)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/SceneProceduralTest.py
+++ b/python/GafferSceneTest/SceneProceduralTest.py
@@ -47,7 +47,7 @@ import GafferTest
 import GafferScene
 import GafferSceneTest
 
-class SceneProceduralTest( unittest.TestCase ) :
+class SceneProceduralTest( GafferSceneTest.SceneTestCase ) :
 
 	class __WrappingProcedural( IECore.ParameterisedProcedural ) :
 
@@ -76,10 +76,15 @@ class SceneProceduralTest( unittest.TestCase ) :
 		renderer = IECoreGL.Renderer()
 		renderer.setOption( "gl:mode", IECore.StringData( "deferred" ) )
 
-		with IECore.WorldBlock( renderer ) :
+		with IECore.CapturingMessageHandler() as mh :
 
-			procedural = GafferScene.SceneProcedural( badNode["out"], Gaffer.Context(), "/" )
-			self.__WrappingProcedural( procedural ).render( renderer )
+			with IECore.WorldBlock( renderer ) :
+
+				procedural = GafferScene.SceneProcedural( badNode["out"], Gaffer.Context(), "/" )
+				self.__WrappingProcedural( procedural ).render( renderer )
+
+		self.assertTrue( len( mh.messages ) )
+		self.assertTrue( "Unable to find font" in mh.messages[0].message )
 
 	def testPythonComputationErrors( self ) :
 
@@ -95,10 +100,15 @@ class SceneProceduralTest( unittest.TestCase ) :
 		renderer = IECoreGL.Renderer()
 		renderer.setOption( "gl:mode", IECore.StringData( "deferred" ) )
 
-		with IECore.WorldBlock( renderer ) :
+		with IECore.CapturingMessageHandler() as mh :
 
-			procedural = GafferScene.SceneProcedural( script["plane"]["out"], Gaffer.Context(), "/" )
-			self.__WrappingProcedural( procedural ).render( renderer )
+			with IECore.WorldBlock( renderer ) :
+
+				procedural = GafferScene.SceneProcedural( script["plane"]["out"], Gaffer.Context(), "/" )
+				self.__WrappingProcedural( procedural ).render( renderer )
+
+		self.assertTrue( len( mh.messages ) )
+		self.assertTrue( "iDontExist" in mh.messages[0].message )
 
 	def testMotionBlurredBounds( self ) :
 

--- a/python/GafferSceneTest/ShaderTest.py
+++ b/python/GafferSceneTest/ShaderTest.py
@@ -156,5 +156,17 @@ class ShaderTest( unittest.TestCase ) :
 			],
 		)
 
+	def testDisallowCyclicConnections( self ) :
+
+		n1 = GafferSceneTest.TestShader()
+		n2 = GafferSceneTest.TestShader()
+		n3 = GafferSceneTest.TestShader()
+
+		n2["parameters"]["i"].setInput( n1["out"]["r"] )
+		n3["parameters"]["i"].setInput( n2["out"]["g"] )
+
+		self.assertFalse( n1["parameters"]["i"].acceptsInput( n3["out"]["b"] ) )
+		self.assertRaisesRegexp( RuntimeError, "rejects input", n1["parameters"]["i"].setInput, n3["out"]["b"] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/ShaderTest.py
+++ b/python/GafferSceneTest/ShaderTest.py
@@ -134,5 +134,27 @@ class ShaderTest( unittest.TestCase ) :
 		self.assertEqual( state[0].type, "test:shader" )
 		self.assertEqual( state[1].type, "test:surface" )
 
+	def testDirtyPropagationThroughShaderAssignment( self ) :
+
+		n = GafferSceneTest.TestShader()
+
+		p = GafferScene.Plane()
+		a = GafferScene.ShaderAssignment()
+		a["in"].setInput( p["out"] )
+		a["shader"].setInput( n["out"] )
+
+		cs = GafferTest.CapturingSlot( a.plugDirtiedSignal() )
+
+		n["parameters"]["i"].setValue( 1 )
+
+		self.assertEqual(
+			[ c[0] for c in cs ],
+			[
+				a["shader"],
+				a["out"]["attributes"],
+				a["out"],
+			],
+		)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/DependencyNodeTest.py
+++ b/python/GafferTest/DependencyNodeTest.py
@@ -576,5 +576,17 @@ class DependencyNodeTest( GafferTest.TestCase ) :
 
 		s["n2"]["op1"].setInput( s["n1"]["product"] )
 
+	def testDisallowCyclicConnections( self ) :
+
+		a1 = GafferTest.AddNode()
+		a2 = GafferTest.AddNode()
+		a3 = GafferTest.AddNode()
+
+		a2["op1"].setInput( a1["sum"] )
+		a3["op1"].setInput( a2["sum"] )
+
+		self.assertFalse( a1["op1"].acceptsInput( a3["sum"] ) )
+		self.assertRaisesRegexp( RuntimeError, "rejects input", a1["op1"].setInput, a3["sum"] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/DownstreamIteratorTest.py
+++ b/python/GafferTest/DownstreamIteratorTest.py
@@ -1,0 +1,49 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import GafferTest
+
+class DownstreamIteratorTest( GafferTest.TestCase ) :
+
+	def test( self ) :
+
+		# call through to c++ test.
+		GafferTest.testDownstreamIterator()
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferTest/ExpressionTest.py
+++ b/python/GafferTest/ExpressionTest.py
@@ -339,7 +339,12 @@ class ExpressionTest( GafferTest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 		s["fileName"].setValue( os.path.dirname( __file__ ) + "/scripts/legacyExpression.gfr" )
-		s.load( continueOnError = True )
+
+		with IECore.CapturingMessageHandler() as mh :
+			s.load( continueOnError = True )
+
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertTrue( "rejects input " in mh.messages[0].message )
 
 		s.context().setFrame( 3 )
 		with s.context() :
@@ -816,7 +821,12 @@ class ExpressionTest( GafferTest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 		s["fileName"].setValue( os.path.dirname( __file__ ) + "/scripts/expressionVersion-0.15.0.0.gfr" )
-		s.load( continueOnError = True )
+
+		with IECore.CapturingMessageHandler() as mh :
+			s.load( continueOnError = True )
+
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertTrue( "rejects input " in mh.messages[0].message )
 
 		self.assertEqual( s["n"]["user"]["b"].getValue(), 2 )
 		self.assertTrue( s["n"]["user"]["b"].getInput().node().isSame( s["e"] ) )

--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -456,7 +456,12 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s2 = Gaffer.ScriptNode()
 		s2["r"] = Gaffer.Reference()
 
-		self.assertRaises( Exception, s2["r"].load, "/tmp/test.grf" )
+		with IECore.CapturingMessageHandler() as mh :
+			self.assertRaises( Exception, s2["r"].load, "/tmp/test.grf" )
+
+		self.assertEqual( len( mh.messages ), 2 )
+		self.assertTrue( "has no attribute 'SphereNode'" in mh.messages[0].message )
+		self.assertTrue( "KeyError: 'n'" in mh.messages[1].message )
 
 	def testErrorTolerantLoading( self ) :
 

--- a/python/GafferTest/TestCase.py
+++ b/python/GafferTest/TestCase.py
@@ -110,7 +110,7 @@ class TestCase( unittest.TestCase ) :
 		inputPlugs = []
 		def __walkInputs( parent ) :
 			for child in parent.children() :
-				if isinstance( child, Gaffer.CompoundPlug ) :
+				if len( child ) :
 					__walkInputs( child )
 				elif isinstance( child, Gaffer.ValuePlug ) :
 					if child not in inputsToIgnore :

--- a/python/GafferTest/__init__.py
+++ b/python/GafferTest/__init__.py
@@ -127,6 +127,7 @@ from SubGraphTest import SubGraphTest
 from FileSequencePathFilterTest import FileSequencePathFilterTest
 from AnimationTest import AnimationTest
 from StatsApplicationTest import StatsApplicationTest
+from DownstreamIteratorTest import DownstreamIteratorTest
 
 if __name__ == "__main__":
 	import unittest

--- a/src/Gaffer/DependencyNode.cpp
+++ b/src/Gaffer/DependencyNode.cpp
@@ -36,7 +36,6 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "Gaffer/DependencyNode.h"
-#include "Gaffer/CompoundPlug.h"
 
 using namespace Gaffer;
 
@@ -53,7 +52,7 @@ DependencyNode::~DependencyNode()
 
 void DependencyNode::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
 {
-	if( input->isInstanceOf( CompoundPlug::staticTypeId() ) )
+	if( !input->children().empty() )
 	{
 		throw IECore::Exception( "DependencyNode::affects() called with non-leaf plug " + input->fullName() );
 	}

--- a/src/Gaffer/Plug.cpp
+++ b/src/Gaffer/Plug.cpp
@@ -49,6 +49,7 @@
 #include "Gaffer/Action.h"
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/Metadata.h"
+#include "Gaffer/DownstreamIterator.h"
 
 using namespace boost;
 using namespace Gaffer;
@@ -623,9 +624,36 @@ class Plug::DirtyPlugs
 
 		void insert( Plug *plugToDirty )
 		{
-			if( !m_emitting ) // see comment in emit()
+			if( m_emitting ) // see comment in emit()
 			{
-				insertInternal( plugToDirty );
+				return;
+			}
+
+			if( !insertVertex( plugToDirty ).second )
+			{
+				// Previously inserted, so we'll already
+				// have visited the dependents.
+				return;
+			}
+
+			for( DownstreamIterator it( plugToDirty ); it != it.end(); ++it )
+			{
+				InsertedVertex v = insertVertex( &*it );
+				if( !it->getFlags( Plug::AcceptsDependencyCycles ) )
+				{
+					add_edge(
+						v.first,
+						insertVertex( it.upstream() ).first,
+						m_graph
+					);
+				}
+
+				if( !v.second )
+				{
+					// Already visited this plug by another path,
+					// so we can prune the iteration.
+					it.prune();
+				}
 			}
 		}
 
@@ -666,9 +694,13 @@ class Plug::DirtyPlugs
 
 		typedef std::map<const Plug *, VertexDescriptor> PlugMap;
 
-		// Inserts a vertex representing plugToDirty into the graph, and
-		// then inserts all affected plugs.
-		VertexDescriptor insertInternal( Plug *plugToDirty )
+		// Equivalent to the return type for map::insert - the first
+		// field is the vertex descriptor, and the second field is
+		// false if the vertex was already there, true if it was
+		// inserted.
+		typedef std::pair<VertexDescriptor, bool> InsertedVertex;
+
+		InsertedVertex insertVertex( const Plug *plug )
 		{
 			// We need to hold a reference to the plug, because otherwise
 			// it might be deleted between now and emit(). But if there is
@@ -676,28 +708,27 @@ class Plug::DirtyPlugs
 			// we'd end up deleting it in emit() since we'd have sole
 			// ownership. Nobody wants that. If we had weak pointers, this
 			// would make for an ideal use.
-			assert( plugToDirty->refCount() );
+			assert( plug->refCount() );
 
-			// If we've inserted this one before, then early out. There's
-			// no point repeating the propagation all over again, and our
-			// Graph isn't designed to have duplicate edges anyway.
-			PlugMap::const_iterator it = m_plugs.find( plugToDirty );
+			PlugMap::const_iterator it = m_plugs.find( plug );
 			if( it != m_plugs.end() )
 			{
-				return it->second;
+				return InsertedVertex( it->second, false );
 			}
 
-			// Insert a vertex for this plug.
 			VertexDescriptor result = add_vertex( m_graph );
-			m_graph[result] = plugToDirty;
-			m_plugs[plugToDirty] = result;
+			m_graph[result] = const_cast<Plug *>( plug );
+			m_plugs[plug] = result;
 
-			// Insert all ancestor plugs.
-			Plug *child = plugToDirty;
-			VertexDescriptor childVertex = result;
-			while( Plug *parent = child->parent<Plug>() )
+			// Insert parent plug.
+			if( const Plug *parent = plug->parent<Plug>() )
 			{
-				if( !parent->refCount() )
+				if( parent->refCount() )
+				{
+					VertexDescriptor parentVertex = insertVertex( parent ).first;
+					add_edge( parentVertex, result, m_graph );
+				}
+				else
 				{
 					// We can end up here when constructing a SplinePlug,
 					// because it calls setValue() in its constructor.
@@ -706,91 +737,10 @@ class Plug::DirtyPlugs
 					// it in emit(). And there's no point signalling dirtiness
 					// because the plug has no parent and therefore can have
 					// no observers.
-					break;
-				}
-
-				VertexDescriptor parentVertex = insertInternal( parent );
-				add_edge( parentVertex, childVertex, m_graph );
-
-				child = parent;
-				childVertex = parentVertex;
-			}
-
-			// Propagate dirtiness to output plugs and affected plugs.
-			// We only propagate dirtiness along leaf level plugs, because
-			// they are the only plugs which can be the target of the affects(),
-			// and compute() methods. We must handle any exceptions thrown by
-			// DependencyNode::affects() so that we don't leave the graph in
-			// an unexpected state - propagateDirtiness() is called in the middle
-			// of addChild(), setInput() and setValue() methods, and we want those
-			// to succeed at all costs.
-			if( !plugToDirty->isInstanceOf( (IECore::TypeId)CompoundPlugTypeId ) )
-			{
-				for( Plug::OutputContainer::const_iterator it=plugToDirty->outputs().begin(), eIt=plugToDirty->outputs().end(); it!=eIt; ++it )
-				{
-					VertexDescriptor outputVertex = insertInternal( const_cast<Plug *>( *it ) );
-					add_edge( outputVertex, result, m_graph );
-				}
-
-				const DependencyNode *dependencyNode = plugToDirty->ancestor<DependencyNode>();
-				if( dependencyNode )
-				{
-					DependencyNode::AffectedPlugsContainer affected;
-					try
-					{
-						dependencyNode->affects( plugToDirty, affected );
-					}
-					catch( const std::exception &e )
-					{
-						IECore::msg(
-							IECore::Msg::Error,
-							dependencyNode->relativeName( dependencyNode->scriptNode() ) + "::affects()",
-							e.what()
-						);
-					}
-					catch( ... )
-					{
-						IECore::msg(
-							IECore::Msg::Error,
-							dependencyNode->relativeName( dependencyNode->scriptNode() ) + "::affects()",
-							"Unknown exception"
-						);
-					}
-
-					for( DependencyNode::AffectedPlugsContainer::const_iterator it=affected.begin(); it!=affected.end(); it++ )
-					{
-						if( ( *it )->isInstanceOf( (IECore::TypeId)Gaffer::CompoundPlugTypeId ) )
-						{
-							// DependencyNode::affects() implementations are only allowed to place leaf plugs in the outputs,
-							// so we helpfully report any mistakes.
-							IECore::msg(
-								IECore::Msg::Error,
-								dependencyNode->relativeName( dependencyNode->scriptNode() ) + "::affects()",
-								"Non-leaf plug " + (*it)->relativeName( dependencyNode ) + " returned by affects()"
-							);
-							continue;
-						}
-						// cast is ok - AffectedPlugsContainer only holds const pointers so that
-						// affects() can be const to discourage implementations from having side effects.
-						VertexDescriptor affectedVertex = insertInternal( const_cast<Plug *>( *it ) );
-
-						if( (*it)->getFlags( Plug::AcceptsDependencyCycles ) )
-						{
-							// Skip making an edge to avoid a cycle in emit() - we still propagated
-							// dirtiness onwards with the call to insertInternal() above though, so the
-							// only thing lost is a guarantee of emission ordering. It might be more
-							// accurate to make the edge and then wait until emit() to see if a cycle
-							// has actually been created in practice, and then remove it. But this is
-							// simpler, and it seems reasonable to assume that the existence of the
-							// flag indicates a definite intention to create a cycle.
-							continue;
-						}
-						add_edge( affectedVertex, result, m_graph );
-					}
 				}
 			}
 
-			return result;
+			return InsertedVertex( result, true );
 		}
 
 		void emit()

--- a/src/Gaffer/Plug.cpp
+++ b/src/Gaffer/Plug.cpp
@@ -818,7 +818,15 @@ class Plug::DirtyPlugs
 			ScopedAssignment<bool> scopedAssignment( m_emitting, true );
 
 			std::vector<VertexDescriptor> sorted;
-			topological_sort( m_graph, std::back_inserter( sorted ) );
+			try
+			{
+				topological_sort( m_graph, std::back_inserter( sorted ) );
+			}
+			catch( const std::exception &e )
+			{
+				IECore::msg( IECore::Msg::Error, "Plug dirty propagation", e.what() );
+			}
+
 			for( std::vector<VertexDescriptor>::const_iterator it = sorted.begin(), eIt = sorted.end(); it != eIt; ++it )
 			{
 				Plug *plug = m_graph[*it].get();

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -185,11 +185,11 @@ void Shader::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs
 		const Plug *out = outPlug();
 		if( out )
 		{
-			if( out->children().size() )
+			if( !out->children().empty() )
 			{
 				for( RecursivePlugIterator it( out ); it != it.end(); it++ )
 				{
-					if( !(*it)->isInstanceOf( CompoundPlug::staticTypeId() ) )
+					if( (*it)->children().empty() )
 					{
 						outputs.push_back( it->get() );
 					}

--- a/src/GafferTest/DownstreamIteratorTest.cpp
+++ b/src/GafferTest/DownstreamIteratorTest.cpp
@@ -1,0 +1,135 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Gaffer/DownstreamIterator.h"
+#include "Gaffer/Random.h"
+
+#include "GafferTest/Assert.h"
+#include "GafferTest/DownstreamIteratorTest.h"
+
+using namespace Gaffer;
+
+void GafferTest::testDownstreamIterator()
+{
+
+	//   a
+	//   |
+	//   b
+	//  / \.
+	// c   d
+	//      \.
+	//		 e
+
+	Random::Ptr a = new Random( "a" );
+	Random::Ptr b = new Random( "b" );
+	Random::Ptr c = new Random( "c" );
+	Random::Ptr d = new Random( "d" );
+	Random::Ptr e = new Random( "e" );
+
+	b->floatRangePlug()->getChild( 0 )->setInput( a->outFloatPlug() );
+	c->floatRangePlug()->getChild( 0 )->setInput( b->outFloatPlug() );
+	d->floatRangePlug()->getChild( 0 )->setInput( b->outFloatPlug() );
+	e->floatRangePlug()->getChild( 0 )->setInput( d->outFloatPlug() );
+
+	DownstreamIterator it1( a->floatRangePlug()->getChild( 0 ) );
+	DownstreamIterator it2( a->floatRangePlug()->getChild( 0 ) );
+
+	GAFFERTEST_ASSERT( &*it1 == a->outFloatPlug() );
+	GAFFERTEST_ASSERT( &*it2 == a->outFloatPlug() );
+	GAFFERTEST_ASSERT( it1.upstream() == a->floatRangePlug()->getChild( 0 ) );
+	GAFFERTEST_ASSERT( it2.upstream() == a->floatRangePlug()->getChild( 0 ) );
+	GAFFERTEST_ASSERT( it1 == it2 );
+	GAFFERTEST_ASSERT( it1 != it1.end() );
+	GAFFERTEST_ASSERT( it2 != it2.end() );
+
+	it1++;
+
+	GAFFERTEST_ASSERT( &*it1 == b->floatRangePlug()->getChild( 0 ) );
+	GAFFERTEST_ASSERT( &*it2 == a->outFloatPlug() );
+	GAFFERTEST_ASSERT( it1.upstream() == a->outFloatPlug() );
+	GAFFERTEST_ASSERT( it2.upstream() == a->floatRangePlug()->getChild( 0 ) );
+	GAFFERTEST_ASSERT( it1 != it2 );
+	GAFFERTEST_ASSERT( it1 != it1.end() );
+	GAFFERTEST_ASSERT( it2 != it2.end() );
+
+	it2 = it1;
+
+	GAFFERTEST_ASSERT( &*it1 == b->floatRangePlug()->getChild( 0 ) );
+	GAFFERTEST_ASSERT( &*it2 == b->floatRangePlug()->getChild( 0 ) );
+	GAFFERTEST_ASSERT( it1.upstream() == a->outFloatPlug() );
+	GAFFERTEST_ASSERT( it2.upstream() == a->outFloatPlug() );
+	GAFFERTEST_ASSERT( it1 == it2 );
+	GAFFERTEST_ASSERT( it1 != it1.end() );
+	GAFFERTEST_ASSERT( it2 != it2.end() );
+
+	std::vector<const Plug *> visited;
+	for( DownstreamIterator it( a->floatRangePlug()->getChild( 0 ) ); it != it.end(); ++it )
+	{
+		visited.push_back( &*it );
+	}
+
+	GAFFERTEST_ASSERT( visited.size() == 9 );
+	GAFFERTEST_ASSERT( visited[0] == a->outFloatPlug() );
+	GAFFERTEST_ASSERT( visited[1] == b->floatRangePlug()->getChild( 0 ) );
+	GAFFERTEST_ASSERT( visited[2] == b->outFloatPlug() );
+	GAFFERTEST_ASSERT( visited[3] == c->floatRangePlug()->getChild( 0 ) );
+	GAFFERTEST_ASSERT( visited[4] == c->outFloatPlug() );
+	GAFFERTEST_ASSERT( visited[5] == d->floatRangePlug()->getChild( 0 ) );
+	GAFFERTEST_ASSERT( visited[6] == d->outFloatPlug() );
+	GAFFERTEST_ASSERT( visited[7] == e->floatRangePlug()->getChild( 0 ) );
+	GAFFERTEST_ASSERT( visited[8] == e->outFloatPlug() );
+
+	// test pruning
+
+	visited.clear();
+	for( DownstreamIterator it( a->floatRangePlug()->getChild( 0 ) ); it != it.end(); ++it )
+	{
+		visited.push_back( &*it );
+		if( &*it == d->floatRangePlug()->getChild( 0 ) || &*it == c->outFloatPlug() )
+		{
+			it.prune();
+		}
+	}
+
+	GAFFERTEST_ASSERT( visited.size() == 6 );
+	GAFFERTEST_ASSERT( visited[0] == a->outFloatPlug() );
+	GAFFERTEST_ASSERT( visited[1] == b->floatRangePlug()->getChild( 0 ) );
+	GAFFERTEST_ASSERT( visited[2] == b->outFloatPlug() );
+	GAFFERTEST_ASSERT( visited[3] == c->floatRangePlug()->getChild( 0 ) );
+	GAFFERTEST_ASSERT( visited[4] == c->outFloatPlug() );
+	GAFFERTEST_ASSERT( visited[5] == d->floatRangePlug()->getChild( 0 ) );
+
+}


### PR DESCRIPTION
This fixes problems caused by not preventing users from connecting nodes in such a way that they would cause cyclic dependencies. The commits break down as follows :

- Make unit tests fail if IECore::MessageHandler messages are output unexpectedly (e0ba6a1..e77e92d).
- Patch up Plug dirtiness emission to prevent unexpected cycles from causing further problems by catching exceptions and converting them to messages (dadbe3c). There's really nothing a caller could do in these cases, and the new message handling in the unit tests ensures we're not hiding anything.
- Add additional test coverage for shader assignment dirty propagation (2db282c).
- Fix DependencyNodeWrapper GIL management (610ea80).
- Refactor graph dependency traversal out of private code in Plug.cpp and into a new public DownstreamIterator class (30bcb5f and 25a3481). For the first time it's now really straightforward to track dependencies through the graph.
- Stop users creating cyclic dependencies at all (e3c06cc).
- Fix everything else to be compatible with the above (334dc10..5f76b0f). The biggest thing here is that DownstreamIterator uses having-children-ness rather than being-a-deprecated-CompoundPlug-ness to determine compound-ness, and a few other spots in the code were clinging to the old ways.

This fixes Image Engine Shotgun ticket #8127. Old files with a cycle will break the cycle during load, and it should no longer be possible to create cycles after that.