### PR TITLE
File load performance regression fix

### DIFF
--- a/include/Gaffer/DownstreamIterator.h
+++ b/include/Gaffer/DownstreamIterator.h
@@ -47,6 +47,11 @@ namespace Gaffer
 {
 
 /// Performs a depth-first iteration of a plug's outputs and affected plugs.
+/// Note that this performs a totally naive traversal, and may visit the same
+/// plug multiple times in the event that multiple upstream plugs affect it -
+/// a diamond graph being the simplest example. Typically you will want to
+/// track visited plugs and prune traversal when revisiting.
+/// See DependencyNodeTest.testEfficiency and Plug.cpp.
 class DownstreamIterator : public boost::iterator_facade<DownstreamIterator, const Plug, boost::forward_traversal_tag>
 {
 

--- a/include/Gaffer/Plug.h
+++ b/include/Gaffer/Plug.h
@@ -38,6 +38,8 @@
 #ifndef GAFFER_PLUG_H
 #define GAFFER_PLUG_H
 
+#include "boost/unordered_set.hpp"
+
 #include "IECore/Object.h"
 
 #include "Gaffer/GraphComponent.h"
@@ -229,7 +231,7 @@ class Plug : public GraphComponent
 
 		void setFlagsInternal( unsigned flags );
 
-		bool acceptsInputInternal( const Plug *input, bool detectDependencyCycles ) const;
+		bool acceptsInputInternal( const Plug *input, boost::unordered_set<const Plug *> *dependencyCycleVisits ) const;
 		void setInput( PlugPtr input, bool setChildInputs, bool updateParentInput );
 		void setInputInternal( PlugPtr input, bool emit );
 		void emitInputChanged();

--- a/include/GafferBindings/DependencyNodeBinding.h
+++ b/include/GafferBindings/DependencyNodeBinding.h
@@ -86,6 +86,17 @@ class DependencyNodeWrapper : public NodeWrapper<WrappedType>
 		{
 		}
 
+		virtual bool isInstanceOf( IECore::TypeId typeId ) const
+		{
+			if( typeId == (IECore::TypeId)Gaffer::DependencyNodeTypeId )
+			{
+				// Correct for the slightly overzealous (but hugely beneficial)
+				// optimisation in NodeWrapper::isInstanceOf().
+				return true;
+			}
+			return NodeWrapper<WrappedType>::isInstanceOf( typeId );
+		}
+
 		virtual void affects( const Gaffer::Plug *input, Gaffer::DependencyNode::AffectedPlugsContainer &outputs ) const
 		{
 			if( this->isSubclassed() )

--- a/include/GafferBindings/NodeBinding.h
+++ b/include/GafferBindings/NodeBinding.h
@@ -97,12 +97,14 @@ class NodeWrapper : public GraphComponentWrapper<T>
 			// so this optimisation is well worth it.
 			//
 			// Note that we can't actually guarantee that we're not a
-			// ScriptNode, but ScriptNode queries are so common that we
-			// must accelerate them. We adjust for this slightly overzealous
-			// optimisation in ScriptNodeWrapper where we also override
+			// ScriptNode or DependencyNode, but those queries are so
+			// common that we simply must accelerate them. We adjust for
+			// this slightly overzealous optimisation in ScriptNodeWrapper
+			// and DependencyNodeWrapper where we also override
 			// isInstanceOf() and make the necessary correction.
 			if(
 				typeId == (IECore::TypeId)Gaffer::ScriptNodeTypeId ||
+				typeId == (IECore::TypeId)Gaffer::DependencyNodeTypeId ||
 				typeId == (IECore::TypeId)Gaffer::PlugTypeId ||
 				typeId == (IECore::TypeId)Gaffer::ValuePlugTypeId ||
 				typeId == (IECore::TypeId)Gaffer::CompoundPlugTypeId

--- a/python/GafferRenderManTest/InteractiveRenderManRenderTest.py
+++ b/python/GafferRenderManTest/InteractiveRenderManRenderTest.py
@@ -695,7 +695,7 @@ class InteractiveRenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 		s["o"] = GafferScene.StandardOptions()
 		s["o"]["in"].setInput( s["d"]["out"] )
 		s["o"]["options"]["renderCamera"]["enabled"].setValue( True )
-		s["o"]["options"]["renderCamera"]["value"].setValue( "/group/plane" )
+		s["o"]["options"]["renderCamera"]["value"].setValue( "/group/camera" )
 
 		s["r"] = GafferRenderMan.InteractiveRenderManRender()
 		s["r"]["in"].setInput( s["o"]["out"] )

--- a/src/Gaffer/GraphComponent.cpp
+++ b/src/Gaffer/GraphComponent.cpp
@@ -47,6 +47,7 @@
 #include "Gaffer/GraphComponent.h"
 #include "Gaffer/StringAlgo.h"
 #include "Gaffer/Action.h"
+#include "Gaffer/DirtyPropagationScope.h"
 
 using namespace Gaffer;
 using namespace IECore;
@@ -61,6 +62,8 @@ GraphComponent::GraphComponent( const std::string &name )
 
 GraphComponent::~GraphComponent()
 {
+	DirtyPropagationScope dirtyPropagationScope;
+
 	// notify all the children that the parent is gone.
 	// we don't call removeChild to achieve this, as that would also emit
 	// childRemoved signals for this object, which is undesirable as it's dying.

--- a/src/Gaffer/Plug.cpp
+++ b/src/Gaffer/Plug.cpp
@@ -316,6 +316,19 @@ bool Plug::acceptsInputInternal( const Plug *input, boost::unordered_set<const P
 		return false;
 	}
 
+	// We should always accept a disconnection - how else could undo work?
+	if( !input )
+	{
+		return true;
+	}
+
+	// If we accepted it previously, we can't change our minds now.
+	if( input == getInput<Plug>() )
+	{
+		return true;
+	}
+
+	// Give the node a say.
 	if( const Node *n = node() )
 	{
 		if( !n->acceptsInput( this, input ) )
@@ -334,12 +347,6 @@ bool Plug::acceptsInputInternal( const Plug *input, boost::unordered_set<const P
 		{
 			return false;
 		}
-	}
-
-	// We should always accept a disconnection - how else could undo work?
-	if( !input )
-	{
-		return true;
 	}
 
 	// Make sure our children are happy to accept the equivalent child inputs.

--- a/src/GafferBindings/ScriptNodeBinding.cpp
+++ b/src/GafferBindings/ScriptNodeBinding.cpp
@@ -113,6 +113,7 @@ class ScriptNodeWrapper : public NodeWrapper<ScriptNode>
 
 		virtual bool execute( const std::string &pythonScript, Node *parent = 0, bool continueOnError = false )
 		{
+			DirtyPropagationScope dirtyScope;
 			IECorePython::ScopedGILLock gilLock;
 			boost::python::object e = executionDict( parent );
 
@@ -188,6 +189,8 @@ class ScriptNodeWrapper : public NodeWrapper<ScriptNode>
 
 		virtual bool load( bool continueOnError = false )
 		{
+			DirtyPropagationScope dirtyScope;
+
 			const std::string s = readFile( fileNamePlug()->getValue() );
 
 			deleteNodes();


### PR DESCRIPTION
This is a critical fix for a performance regression introduced in #1630 - the cycle detection checks being performed in `Plug::acceptsInput()` had woeful performance, and severely affected file load times among other things.

The first two commits address the basic problem, which gets the file load times back into the right ballpark (they were on another planet before). The next three commits are smaller optimisations which get file load times back to within a percent or two of 0.21.0.0, which I think is reasonable given that we do need to do some work to detect and prevent cycles. The last two commits address some problems related to dirty propagation and the InteractiveRenderManRender node, which were exposed by the recent messages-are-errors change in GafferTest.TestCase.