### PR TITLE
Python bindings : accept all iterable types where appropriate

### DIFF
--- a/include/GafferDispatchBindings/ExecutableNodeBinding.inl
+++ b/include/GafferDispatchBindings/ExecutableNodeBinding.inl
@@ -87,7 +87,7 @@ void execute( T &n )
 }
 
 template<typename T>
-void executeSequence( T &n, const boost::python::list &frameList )
+void executeSequence( T &n, const boost::python::object &frameList )
 {
 	std::vector<float> frames;
 	boost::python::container_utils::extend_container( frames, frameList );

--- a/python/GafferDispatchTest/DispatcherTest.py
+++ b/python/GafferDispatchTest/DispatcherTest.py
@@ -38,6 +38,7 @@ import os
 import stat
 import unittest
 import functools
+import itertools
 
 import IECore
 
@@ -1225,6 +1226,18 @@ class DispatcherTest( GafferTest.TestCase ) :
 		dispatcher = GafferDispatch.Dispatcher.create( "testDispatcher" )
 		dispatcher.dispatch( [ s["n3"] ] )
 		self.assertEqual( [ l.node for l in log ], [ s["n1"], s["i1"], s["n2"], s["n3"] ] )
+
+	def testDispatchIterable( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		log = []
+		s["n1"] = GafferDispatchTest.LoggingExecutableNode( log = log )
+		s["n2"] = GafferDispatchTest.LoggingExecutableNode( log = log )
+
+		dispatcher = GafferDispatch.Dispatcher.create( "testDispatcher" )
+		dispatcher.dispatch( itertools.chain( [ s["n1"], s["n2"] ] ) )
+		self.assertEqual( [ l.node for l in log ], [ s["n1"], s["n2"] ] )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferDispatchTest/ExecutableNodeTest.py
+++ b/python/GafferDispatchTest/ExecutableNodeTest.py
@@ -36,6 +36,7 @@
 
 import os
 import unittest
+import itertools
 
 import IECore
 
@@ -406,6 +407,16 @@ class ExecutableNodeTest( GafferTest.TestCase ) :
 
 		self.assertTrue( s["TaskList"]["preTasks"][0].getInput().isSame( s["SystemCommand"]["task"] ) )
 		self.assertTrue( s["TaskList"]["preTasks"][1].getInput() is None )
+
+	def testExecuteSequenceWithIterable( self ) :
+
+		n = GafferDispatchTest.LoggingExecutableNode()
+
+		n.executeSequence( tuple( [ 1, 2, 3 ] ) )
+		self.assertEqual( len( n.log ), 3 )
+
+		n.executeSequence( itertools.chain( [ 1, 2, 3 ], [ 4, 5, 6 ] ) )
+		self.assertEqual( len( n.log ), 9 )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/CompoundPathFilterTest.py
+++ b/python/GafferTest/CompoundPathFilterTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import itertools
 
 import Gaffer
 import GafferTest
@@ -173,6 +174,14 @@ class CompoundPathFilterTest( GafferTest.TestCase ) :
 		f2 = Gaffer.FileNamePathFilter( [ "b.*" ] )
 
 		f = Gaffer.CompoundPathFilter( [ f1, f2 ] )
+		self.assertFilterListsEqual( f.getFilters(), [ f1, f2 ] )
+
+	def testConstructFromIterable( self ) :
+
+		f1 = Gaffer.FileNamePathFilter( [ "a.*" ] )
+		f2 = Gaffer.FileNamePathFilter( [ "b.*" ] )
+
+		f = Gaffer.CompoundPathFilter( itertools.chain( [ f1 ], [ f2 ] ) )
 		self.assertFilterListsEqual( f.getFilters(), [ f1, f2 ] )
 
 if __name__ == "__main__":

--- a/python/GafferTest/MatchPatternPathFilterTest.py
+++ b/python/GafferTest/MatchPatternPathFilterTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import itertools
 
 import Gaffer
 import GafferTest
@@ -103,6 +104,14 @@ class MatchPatternPathFilterTest( GafferTest.TestCase ) :
 
 		f.setInverted( True )
 		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [ "/b" ] ) )
+
+	def testPatternsAsIterables( self ) :
+
+		f = Gaffer.MatchPatternPathFilter( itertools.chain( [ "a*" ], [ "b*"] ) )
+		self.assertEqual( f.getMatchPatterns(), [ "a*", "b*" ] )
+
+		f.setMatchPatterns( [ "c*", "d*" ] )
+		self.assertEqual( f.getMatchPatterns(), [ "c*", "d*" ] )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferBindings/CompoundPathFilterBinding.cpp
+++ b/src/GafferBindings/CompoundPathFilterBinding.cpp
@@ -51,7 +51,7 @@ using namespace GafferBindings;
 namespace
 {
 
-void setFilters( CompoundPathFilter &f, list pythonFilters )
+void setFilters( CompoundPathFilter &f, object pythonFilters )
 {
 	CompoundPathFilter::Filters filters;
 	boost::python::container_utils::extend_container( filters, pythonFilters );
@@ -71,7 +71,7 @@ list getFilters( const CompoundPathFilter &f )
 	return result;
 }
 
-CompoundPathFilterPtr construct( list filters, CompoundDataPtr userData )
+CompoundPathFilterPtr construct( object filters, CompoundDataPtr userData )
 {
 	CompoundPathFilterPtr result = new CompoundPathFilter( userData );
 	setFilters( *result, filters );

--- a/src/GafferBindings/MatchPatternPathFilterBinding.cpp
+++ b/src/GafferBindings/MatchPatternPathFilterBinding.cpp
@@ -50,14 +50,14 @@ using namespace GafferBindings;
 namespace
 {
 
-MatchPatternPathFilterPtr construct( list pythonPatterns, const char *propertyName, bool leafOnly )
+MatchPatternPathFilterPtr construct( object pythonPatterns, const char *propertyName, bool leafOnly )
 {
 	std::vector<MatchPattern> patterns;
 	boost::python::container_utils::extend_container( patterns, pythonPatterns );
 	return new MatchPatternPathFilter( patterns, propertyName, leafOnly );
 }
 
-void setMatchPatterns( MatchPatternPathFilter &f, list pythonPatterns )
+void setMatchPatterns( MatchPatternPathFilter &f, object pythonPatterns )
 {
 	std::vector<MatchPattern> patterns;
 	boost::python::container_utils::extend_container( patterns, pythonPatterns );


### PR DESCRIPTION
The other day I noticed someone trying to call something like `dispatcher.dispatch( xrange( 1, 10 ) )`, and getting a frustrating error because `xrange()` doesn't return a list. This PR updates our bindings in the spirit of python's duck typing, so they accept any python iterable in places that previously required a list.