### PR TITLE
Error handling improvements

### DIFF
--- a/python/GafferDispatchTest/ExecuteApplicationTest.py
+++ b/python/GafferDispatchTest/ExecuteApplicationTest.py
@@ -196,7 +196,7 @@ class ExecuteApplicationTest( GafferTest.TestCase ) :
 
 		error = "".join( p.stderr.readlines() )
 		self.assertTrue( self.__scriptFileName in error )
-		self.assertTrue( "KeyError: 'badPlug'" in error )
+		self.assertTrue( "KeyError: \"'badPlug'" in error )
 		self.assertFalse( "Traceback" in error )
 		self.assertNotEqual( p.returncode, 0 )
 
@@ -208,7 +208,7 @@ class ExecuteApplicationTest( GafferTest.TestCase ) :
 		p.wait()
 
 		error = "".join( p.stderr.readlines() )
-		self.assertTrue( "KeyError: 'badPlug'" in error )
+		self.assertTrue( "KeyError: \"'badPlug'" in error )
 		self.assertFalse( "Traceback" in error )
 		self.assertEqual( p.returncode, 0 )
 

--- a/python/GafferTest/GraphComponentTest.py
+++ b/python/GafferTest/GraphComponentTest.py
@@ -754,5 +754,11 @@ class GraphComponentTest( GafferTest.TestCase ) :
 		self.assertEqual( len( c.parentChanges ), 1 )
 		self.assertEqual( c.parentChanges[-1], ( None, None ) )
 
+	def testDescriptiveKeyErrors( self ) :
+
+		g = Gaffer.GraphComponent()
+		self.assertRaisesRegexp( KeyError, "'a' is not a child of 'GraphComponent'", g.__getitem__, "a" )
+		self.assertRaisesRegexp( KeyError, "'a' is not a child of 'GraphComponent'", g.__delitem__, "a" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -906,7 +906,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		# Although we expect it to load OK, we do also expect to receive a
 		# warning message because we removed the fileName plug after version 0.14.
 		self.assertEqual( len( mh.messages ), 1 )
-		self.assertTrue( "KeyError: 'fileName'" in mh.messages[0].message )
+		self.assertTrue( "KeyError: \"'fileName'" in mh.messages[0].message )
 
 		self.assertEqual( s["Reference"]["testPlug"].getValue(), 2 )
 

--- a/src/GafferBindings/GraphComponentBinding.cpp
+++ b/src/GafferBindings/GraphComponentBinding.cpp
@@ -36,6 +36,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "boost/python.hpp"
+#include "boost/format.hpp"
 
 #include "Gaffer/GraphComponent.h"
 
@@ -117,6 +118,15 @@ GraphComponentPtr descendant( GraphComponent &g, const char *n )
 	return g.descendant<GraphComponent>( n );
 }
 
+void throwKeyError( const GraphComponent &g, const char *n )
+{
+	const std::string error = boost::str(
+		boost::format( "'%s' is not a child of '%s'" ) % n % g.getName()
+	);
+	PyErr_SetString( PyExc_KeyError, error.c_str() );
+	throw_error_already_set();
+}
+
 GraphComponentPtr getItem( GraphComponent &g, const char *n )
 {
 	GraphComponentPtr c = g.getChild<GraphComponent>( n );
@@ -125,8 +135,7 @@ GraphComponentPtr getItem( GraphComponent &g, const char *n )
 		return c;
 	}
 
-	PyErr_SetString( PyExc_KeyError, n );
-	throw_error_already_set();
+	throwKeyError( g, n );
 	return 0; // shouldn't get here
 }
 
@@ -157,8 +166,7 @@ void delItem( GraphComponent &g, const char *n )
 		return;
 	}
 
-	PyErr_SetString( PyExc_KeyError, n );
-	throw_error_already_set();
+	throwKeyError( g, n );
 }
 
 int length( GraphComponent &g )

--- a/src/GafferBindings/GraphComponentBinding.cpp
+++ b/src/GafferBindings/GraphComponentBinding.cpp
@@ -47,17 +47,20 @@ using namespace boost::python;
 using namespace GafferBindings;
 using namespace Gaffer;
 
-static const char *setName( GraphComponent &c, const char *name )
+namespace
+{
+
+const char *setName( GraphComponent &c, const char *name )
 {
 	return c.setName( name ).c_str();
 }
 
-static const char *getName( GraphComponent &c )
+const char *getName( GraphComponent &c )
 {
 	return c.getName().c_str();
 }
 
-static boost::python::list items( GraphComponent &c )
+boost::python::list items( GraphComponent &c )
 {
 	const GraphComponent::ChildContainer &ch = c.children();
 	boost::python::list l;
@@ -68,7 +71,7 @@ static boost::python::list items( GraphComponent &c )
 	return l;
 }
 
-static boost::python::list keys( GraphComponent &c )
+boost::python::list keys( GraphComponent &c )
 {
 	const GraphComponent::ChildContainer &ch = c.children();
 	boost::python::list l;
@@ -79,7 +82,7 @@ static boost::python::list keys( GraphComponent &c )
 	return l;
 }
 
-static boost::python::list values( GraphComponent &c )
+boost::python::list values( GraphComponent &c )
 {
 	const GraphComponent::ChildContainer &ch = c.children();
 	boost::python::list l;
@@ -90,7 +93,7 @@ static boost::python::list values( GraphComponent &c )
 	return l;
 }
 
-static boost::python::tuple children( GraphComponent &c, IECore::TypeId typeId )
+boost::python::tuple children( GraphComponent &c, IECore::TypeId typeId )
 {
 	const GraphComponent::ChildContainer &ch = c.children();
 	boost::python::list l;
@@ -104,17 +107,17 @@ static boost::python::tuple children( GraphComponent &c, IECore::TypeId typeId )
 	return boost::python::tuple( l );
 }
 
-static GraphComponentPtr getChild( GraphComponent &g, const char *n )
+GraphComponentPtr getChild( GraphComponent &g, const char *n )
 {
 	return g.getChild<GraphComponent>( n );
 }
 
-static GraphComponentPtr descendant( GraphComponent &g, const char *n )
+GraphComponentPtr descendant( GraphComponent &g, const char *n )
 {
 	return g.descendant<GraphComponent>( n );
 }
 
-static GraphComponentPtr getItem( GraphComponent &g, const char *n )
+GraphComponentPtr getItem( GraphComponent &g, const char *n )
 {
 	GraphComponentPtr c = g.getChild<GraphComponent>( n );
 	if( c )
@@ -127,7 +130,7 @@ static GraphComponentPtr getItem( GraphComponent &g, const char *n )
 	return 0; // shouldn't get here
 }
 
-static GraphComponentPtr getItem( GraphComponent &g, long index )
+GraphComponentPtr getItem( GraphComponent &g, long index )
 {
 	long s = g.children().size();
 
@@ -145,7 +148,7 @@ static GraphComponentPtr getItem( GraphComponent &g, long index )
 	return g.getChild<GraphComponent>( index );
 }
 
-static void delItem( GraphComponent &g, const char *n )
+void delItem( GraphComponent &g, const char *n )
 {
 	GraphComponentPtr c = g.getChild<GraphComponent>( n );
 	if( c )
@@ -158,37 +161,37 @@ static void delItem( GraphComponent &g, const char *n )
 	throw_error_already_set();
 }
 
-static int length( GraphComponent &g )
+int length( GraphComponent &g )
 {
 	return g.children().size();
 }
 
-static bool nonZero( GraphComponent &g )
+bool nonZero( GraphComponent &g )
 {
 	return true;
 }
 
-static bool contains( GraphComponent &g, const char *n )
+bool contains( GraphComponent &g, const char *n )
 {
 	return g.getChild<GraphComponent>( n );
 }
 
-static GraphComponentPtr parent( GraphComponent &g )
+GraphComponentPtr parent( GraphComponent &g )
 {
 	return g.parent<GraphComponent>();
 }
 
-static GraphComponentPtr ancestor( GraphComponent &g, IECore::TypeId t )
+GraphComponentPtr ancestor( GraphComponent &g, IECore::TypeId t )
 {
 	return g.ancestor( t );
 }
 
-static GraphComponentPtr commonAncestor( GraphComponent &g, const GraphComponent *other, IECore::TypeId t )
+GraphComponentPtr commonAncestor( GraphComponent &g, const GraphComponent *other, IECore::TypeId t )
 {
 	return g.commonAncestor( other, t );
 }
 
-static std::string repr( const GraphComponent *g )
+std::string repr( const GraphComponent *g )
 {
 	return Serialisation::classPath( g ) + "( \"" + g->getName().string() + "\" )";
 }
@@ -225,6 +228,8 @@ struct BinarySlotCaller
 		return boost::signals::detail::unusable();
 	}
 };
+
+} // namespace
 
 void GafferBindings::bindGraphComponent()
 {


### PR DESCRIPTION
This improves the reporting of loading errors to users, as requested in #1341. That ticket says "exact wording to be determined", and I've currently determined it to be like this :

```
ERROR : Line 335 of /whatever/file/that/was.gfr 
KeyError: "'sets' is not a child of 'whateverNode'"
```

Note that it can't be exactly as requested in #1341 for a couple of reasons :

- https://github.com/python/cpython/blob/master/Objects/exceptions.c#L1478
- We don't know that it's a _plug_ that doesn't exist, because it doesn't exist. It could just as well be a node or anything else (the child lookups are performed in a base class anyway).

But if anyone has other preferences for wording then shout up...