### PR TITLE
GafferTractor : Prefer GafferDispatch.Dispatcher to Gaffer.Dispatcher.

### DIFF
--- a/python/GafferTractor/TractorDispatcher.py
+++ b/python/GafferTractor/TractorDispatcher.py
@@ -200,4 +200,4 @@ class TractorDispatcher( GafferDispatch.Dispatcher ) :
 
 IECore.registerRunTimeTyped( TractorDispatcher, typeName = "GafferTractor::TractorDispatcher" )
 
-Gaffer.Dispatcher.registerDispatcher( "Tractor", TractorDispatcher, TractorDispatcher._setupPlugs )
+GafferDispatch.Dispatcher.registerDispatcher( "Tractor", TractorDispatcher, TractorDispatcher._setupPlugs )


### PR DESCRIPTION
One day the config file supporting the old form will go away.