### PR TITLE
Revert cycles checks

### DIFF
--- a/include/Gaffer/Plug.h
+++ b/include/Gaffer/Plug.h
@@ -231,7 +231,6 @@ class Plug : public GraphComponent
 
 		void setFlagsInternal( unsigned flags );
 
-		bool acceptsInputInternal( const Plug *input, boost::unordered_set<const Plug *> *dependencyCycleVisits ) const;
 		void setInput( PlugPtr input, bool setChildInputs, bool updateParentInput );
 		void setInputInternal( PlugPtr input, bool emit );
 		void emitInputChanged();

--- a/python/GafferSceneTest/ShaderTest.py
+++ b/python/GafferSceneTest/ShaderTest.py
@@ -156,17 +156,5 @@ class ShaderTest( unittest.TestCase ) :
 			],
 		)
 
-	def testDisallowCyclicConnections( self ) :
-
-		n1 = GafferSceneTest.TestShader()
-		n2 = GafferSceneTest.TestShader()
-		n3 = GafferSceneTest.TestShader()
-
-		n2["parameters"]["i"].setInput( n1["out"]["r"] )
-		n3["parameters"]["i"].setInput( n2["out"]["g"] )
-
-		self.assertFalse( n1["parameters"]["i"].acceptsInput( n3["out"]["b"] ) )
-		self.assertRaisesRegexp( RuntimeError, "rejects input", n1["parameters"]["i"].setInput, n3["out"]["b"] )
-
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/DependencyNodeTest.py
+++ b/python/GafferTest/DependencyNodeTest.py
@@ -612,17 +612,5 @@ class DependencyNodeTest( GafferTest.TestCase ) :
 
 		s["n2"]["op1"].setInput( s["n1"]["product"] )
 
-	def testDisallowCyclicConnections( self ) :
-
-		a1 = GafferTest.AddNode()
-		a2 = GafferTest.AddNode()
-		a3 = GafferTest.AddNode()
-
-		a2["op1"].setInput( a1["sum"] )
-		a3["op1"].setInput( a2["sum"] )
-
-		self.assertFalse( a1["op1"].acceptsInput( a3["sum"] ) )
-		self.assertRaisesRegexp( RuntimeError, "rejects input", a1["op1"].setInput, a3["sum"] )
-
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This reverts the ill-considered check-for-cycles-when-connecting-plugs changes from #1630, which resulted in significant slowdowns during loading. Tomorrow I'll add an alternative check-for-cycles-during-shader-generation approach, but for now we want to get a build out without the performance regression.