### PR TITLE
Reduced hash cache clear frequency

### DIFF
--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -219,14 +219,15 @@ class ValuePlug::Computation
 		{
 			if( m_threadData->computationStack.empty() )
 			{
-				if( ++(m_threadData->hashCacheClearCount) == 100 || m_threadData->clearHashCache )
+				if( ++(m_threadData->hashCacheClearCount) == 3200 || m_threadData->clearHashCache )
 				{
 					// Prevent unbounded growth in the hash cache
 					// if many computations are being performed
 					// without any plugs being dirtied in between,
 					// by clearing it after every Nth computation.
-					// N == 100 was chosen based on memory/performance
-					// analysis of a particularly heavy render process.
+					// N == 3200 was observed to be 6x faster than
+					// N == 100 for a procedural instancing scene at
+					// a memory cost of about 100 mb.
 					m_threadData->hashCache.clear();
 					m_threadData->hashCacheClearCount = 0;
 					m_threadData->clearHashCache = 0;


### PR DESCRIPTION
It looks like computing hashes in the instance scene is quite a bottleneck when using an instancer node. It turns out you can reduce procedural expansion time in an instancing scene by a factor of 6 by turning down the hash cache clearing frequency, at a memory cost of about 100 mb, which seems acceptable. This change does not appear to affect performance on scenes with no instancer.

Here is a table of traversal times from some testing I did on production scenes:

```
instancer scene:

freq	time/s	peak res mem/gb
100		45.94	1.175
200		26.0	1.231
400		16.94	1.224
800		11.69	1.254
1000	10.64	1.298
1600	9.04	1.217
3200	7.64	1.308
6400	7.12	1.281

non instancer scene:
100		24.96	2.75
200		26.1	2.82
400		25.6	2.81
800		26.27	2.89
1000	25.8	2.837
1600	26.5	2.92
3200	25.6	2.94
6400	25.96	3.19

```