### PR TITLE
Shader cycle detection

### DIFF
--- a/include/GafferScene/Shader.h
+++ b/include/GafferScene/Shader.h
@@ -38,6 +38,8 @@
 #ifndef GAFFERSCENE_SHADER_H
 #define GAFFERSCENE_SHADER_H
 
+#include "boost/unordered_set.hpp"
+
 #include "IECore/ObjectVector.h"
 #include "IECore/Shader.h"
 

--- a/include/GafferScene/Shader.h
+++ b/include/GafferScene/Shader.h
@@ -135,6 +135,8 @@ class Shader : public Gaffer::DependencyNode
 				void parameterHashWalk( const Shader *shaderNode, const Gaffer::Plug *parameterPlug, IECore::MurmurHash &h );
 				void parameterValueWalk( const Shader *shaderNode, const Gaffer::Plug *parameterPlug, const IECore::InternedString &parameterName, IECore::CompoundDataMap &values );
 
+				void throwCycleError( const Shader *shaderNode );
+
 				const Shader *m_rootNode;
 				IECore::ObjectVectorPtr m_state;
 
@@ -146,6 +148,9 @@ class Shader : public Gaffer::DependencyNode
 
 				typedef std::map<const Shader *, ShaderAndHash> ShaderMap;
 				ShaderMap m_shaders;
+
+				typedef boost::unordered_set<const Shader *> ShaderSet;
+				ShaderSet m_downstreamShaders; // Used for detecting cycles
 
 				unsigned int m_handleCount;
 

--- a/python/GafferSceneTest/PathFilterTest.py
+++ b/python/GafferSceneTest/PathFilterTest.py
@@ -44,7 +44,7 @@ import GafferTest
 import GafferScene
 import GafferSceneTest
 
-class PathFilterTest( unittest.TestCase ) :
+class PathFilterTest( GafferSceneTest.SceneTestCase ) :
 
 	def testConstruct( self ) :
 

--- a/python/GafferSceneTest/PathMatcherDataTest.py
+++ b/python/GafferSceneTest/PathMatcherDataTest.py
@@ -40,8 +40,9 @@ import IECore
 
 import Gaffer
 import GafferScene
+import GafferSceneTest
 
-class PathMatcherDataTest( unittest.TestCase ) :
+class PathMatcherDataTest( GafferSceneTest.SceneTestCase ) :
 
 	def test( self ) :
 

--- a/python/GafferSceneTest/PathMatcherTest.py
+++ b/python/GafferSceneTest/PathMatcherTest.py
@@ -44,7 +44,7 @@ import Gaffer
 import GafferScene
 import GafferSceneTest
 
-class PathMatcherTest( unittest.TestCase ) :
+class PathMatcherTest( GafferSceneTest.SceneTestCase ) :
 
 	@staticmethod
 	def generatePaths( seed, depthRange, numChildrenRange ) :

--- a/python/GafferSceneTest/ScenePathTest.py
+++ b/python/GafferSceneTest/ScenePathTest.py
@@ -40,8 +40,9 @@ import unittest
 import Gaffer
 import GafferTest
 import GafferScene
+import GafferSceneTest
 
-class ScenePathTest( unittest.TestCase ) :
+class ScenePathTest( GafferSceneTest.SceneTestCase ) :
 
 	def test( self ) :
 

--- a/python/GafferSceneTest/ScenePlugTest.py
+++ b/python/GafferSceneTest/ScenePlugTest.py
@@ -43,7 +43,7 @@ import Gaffer
 import GafferScene
 import GafferSceneTest
 
-class ScenePlugTest( unittest.TestCase ) :
+class ScenePlugTest( GafferSceneTest.SceneTestCase ) :
 
 	def testRunTimeTyped( self ) :
 

--- a/python/GafferSceneTest/SceneTimeWarpTest.py
+++ b/python/GafferSceneTest/SceneTimeWarpTest.py
@@ -44,7 +44,7 @@ import GafferTest
 import GafferScene
 import GafferSceneTest
 
-class SceneTimeWarpTest( unittest.TestCase ) :
+class SceneTimeWarpTest( GafferSceneTest.SceneTestCase ) :
 
 	def testConstruct( self ) :
 

--- a/python/GafferSceneTest/ShaderTest.py
+++ b/python/GafferSceneTest/ShaderTest.py
@@ -43,7 +43,7 @@ import GafferTest
 import GafferScene
 import GafferSceneTest
 
-class ShaderTest( unittest.TestCase ) :
+class ShaderTest( GafferSceneTest.SceneTestCase ) :
 
 	def testDirtyPropagation( self ) :
 

--- a/python/GafferSceneTest/ShaderTest.py
+++ b/python/GafferSceneTest/ShaderTest.py
@@ -156,5 +156,28 @@ class ShaderTest( GafferSceneTest.SceneTestCase ) :
 			],
 		)
 
+	def testDetectCyclicConnections( self ) :
+
+		n1 = GafferSceneTest.TestShader()
+		n2 = GafferSceneTest.TestShader()
+		n3 = GafferSceneTest.TestShader()
+
+		n2["parameters"]["i"].setInput( n1["out"]["r"] )
+		n3["parameters"]["i"].setInput( n2["out"]["g"] )
+
+		with IECore.CapturingMessageHandler() as mh :
+			n1["parameters"]["i"].setInput( n3["out"]["b"] )
+
+		# We expect a message warning of the cycle when the
+		# connection is made.
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertTrue( "Plug dirty propagation" in mh.messages[0].context )
+
+		# And a hard error when we attempt to actually generate
+		# the shader network.
+		for node in ( n1, n2, n3 ) :
+			self.assertRaisesRegexp( RuntimeError, "cycle", node.stateHash )
+			self.assertRaisesRegexp( RuntimeError, "cycle", node.state )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -356,7 +356,7 @@ IECore::StateRenderable *Shader::NetworkBuilder::shader( const Shader *shaderNod
 	shaderNode = effectiveNode( shaderNode );
 	if( !shaderNode )
 	{
-		return 0;
+		return NULL;
 	}
 
 	ShaderAndHash &shaderAndHash = m_shaders[shaderNode];
@@ -375,7 +375,7 @@ IECore::StateRenderable *Shader::NetworkBuilder::shader( const Shader *shaderNod
 			prefix = shaderType.substr( 0, colon + 1 );
 		}
 
-		IECore::Light *lightShader =  new IECore::Light( prefix + shaderNode->namePlug()->getValue(), "LIGHT_HANDLE_UNUSED" );
+		IECore::LightPtr lightShader = new IECore::Light( prefix + shaderNode->namePlug()->getValue(), "LIGHT_HANDLE_UNUSED" );
 		parameterValueWalk( shaderNode, shaderNode->parametersPlug(), IECore::InternedString(), lightShader->parameters() );
 		shaderAndHash.shader = lightShader;
 	}


### PR DESCRIPTION
This is a followup to #1644, adding cycle checking for shader networks at the point of evaluation rather than at the point of connection.