### PR TITLE
GafferDispatchUI fixes and improvements

### DIFF
--- a/python/GafferDispatchUI/DispatcherUI.py
+++ b/python/GafferDispatchUI/DispatcherUI.py
@@ -42,12 +42,13 @@ import IECore
 
 import Gaffer
 import GafferUI
+import GafferDispatch
 
 QtCore = GafferUI._qtImport( "QtCore" )
 
 Gaffer.Metadata.registerNode(
 
-	Gaffer.Dispatcher,
+	GafferDispatch.Dispatcher,
 
 	"description",
 	"""
@@ -124,7 +125,7 @@ Gaffer.Metadata.registerNode(
 
 Gaffer.Metadata.registerNode(
 
-	Gaffer.ExecutableNode,
+	GafferDispatch.ExecutableNode,
 
 	"layout:customWidget:dispatchButton:widgetType", "GafferUI.DispatcherUI._DispatchButton",
 
@@ -198,12 +199,12 @@ class DispatcherWindow( GafferUI.Window ) :
 		GafferUI.Window.__init__( self, **kw )
 
 		self.__dispatchers = {}
-		for dispatcherType in Gaffer.Dispatcher.registeredDispatchers() :
-			dispatcher = Gaffer.Dispatcher.create( dispatcherType )
+		for dispatcherType in GafferDispatch.Dispatcher.registeredDispatchers() :
+			dispatcher = GafferDispatch.Dispatcher.create( dispatcherType )
 			Gaffer.NodeAlgo.applyUserDefaults( dispatcher )
 			self.__dispatchers[dispatcherType] = dispatcher
 
-		defaultType = Gaffer.Dispatcher.getDefaultDispatcherType()
+		defaultType = GafferDispatch.Dispatcher.getDefaultDispatcherType()
 		self.__currentDispatcher = self.__dispatchers[ defaultType ]
 		self.__nodes = []
 
@@ -358,10 +359,10 @@ class _FramesModePlugValueWidget( GafferUI.PlugValueWidget ) :
 		GafferUI.PlugValueWidget.__init__( self, self.__selectionMenu, plug, **kw )
 
 		self.__labelsAndValues = (
-			( "CurrentFrame", Gaffer.Dispatcher.FramesMode.CurrentFrame ),
-			( "FullRange", Gaffer.Dispatcher.FramesMode.FullRange ),
-			( "PlaybackRange", Gaffer.Dispatcher.FramesMode.CustomRange ),
-			( "CustomRange", Gaffer.Dispatcher.FramesMode.CustomRange ),
+			( "CurrentFrame", GafferDispatch.Dispatcher.FramesMode.CurrentFrame ),
+			( "FullRange", GafferDispatch.Dispatcher.FramesMode.FullRange ),
+			( "PlaybackRange", GafferDispatch.Dispatcher.FramesMode.CustomRange ),
+			( "CustomRange", GafferDispatch.Dispatcher.FramesMode.CustomRange ),
 		)
 
 		for label, value in self.__labelsAndValues :
@@ -490,7 +491,7 @@ class _FrameRangePlugValueWidget( GafferUI.StringPlugValueWidget ) :
 			framesMode = self.getPlug().node()["framesMode"].getValue()
 
 		# we need to disable the normal update in CurrentFrame and FullRange modes
-		if framesMode == Gaffer.Dispatcher.FramesMode.CustomRange :
+		if framesMode == GafferDispatch.Dispatcher.FramesMode.CustomRange :
 			GafferUI.StringPlugValueWidget._updateFromPlug( self )
 
 		self.textWidget().setEditable( self._editable() )
@@ -531,10 +532,10 @@ def _showDispatcherWindow( nodes ) :
 def selectedNodes( script ) :
 	result = []
 	for n in script.selection() :
-		if isinstance( n, Gaffer.ExecutableNode):
+		if isinstance( n, GafferDispatch.ExecutableNode ) :
 			result.append( n )
 		elif isinstance( n, Gaffer.SubGraph ) :
-			for p in n.children( Gaffer.ExecutableNode.TaskPlug ) :
+			for p in n.children( GafferDispatch.ExecutableNode.TaskPlug ) :
 				if p.direction() == Gaffer.Plug.Direction.Out and p.source() :
 					result.append( n )
 

--- a/python/GafferDispatchUI/ExecutableNodeUI.py
+++ b/python/GafferDispatchUI/ExecutableNodeUI.py
@@ -52,6 +52,12 @@ Gaffer.Metadata.registerNode(
 
 	plugs = {
 
+		"*" : [
+
+			"nodule:type", lambda plug : "GafferUI::StandardNodule" if isinstance( plug, GafferDispatch.ExecutableNode.TaskPlug ) else "",
+
+		],
+
 		"preTasks" : (
 
 			"description",
@@ -108,7 +114,6 @@ Gaffer.Metadata.registerNode(
 			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
 			"layout:section", "Dispatcher",
 			"layout:index", -3, # Just before the node section,
-			"nodule:type", "",
 
 		),
 

--- a/python/GafferDispatchUI/ExecutableNodeUI.py
+++ b/python/GafferDispatchUI/ExecutableNodeUI.py
@@ -73,6 +73,12 @@ Gaffer.Metadata.registerNode(
 
 		),
 
+		"preTasks.*" : (
+
+			"plugValueWidget:type", "",
+
+		),
+
 		"postTasks" : (
 
 			"description",
@@ -88,6 +94,13 @@ Gaffer.Metadata.registerNode(
 			"compoundNodule:orientation", "y",
 
 			"plugValueWidget:type", "",
+
+		),
+
+		"postTasks.*" : (
+
+			"plugValueWidget:type", "",
+			"nodeGadget:nodulePosition", "right",
 
 		),
 

--- a/python/GafferDispatchUI/ExecutableNodeUI.py
+++ b/python/GafferDispatchUI/ExecutableNodeUI.py
@@ -35,11 +35,11 @@
 ##########################################################################
 
 import Gaffer
-import GafferUI
+import GafferDispatch
 
 Gaffer.Metadata.registerNode(
 
-	Gaffer.ExecutableNode,
+	GafferDispatch.ExecutableNode,
 
 	"description",
 	"""

--- a/python/GafferDispatchUI/LocalDispatcherUI.py
+++ b/python/GafferDispatchUI/LocalDispatcherUI.py
@@ -40,13 +40,14 @@ import IECore
 
 import Gaffer
 import GafferUI
+import GafferDispatch
 
 QtCore = GafferUI._qtImport( "QtCore" )
 QtGui = GafferUI._qtImport( "QtGui" )
 
 Gaffer.Metadata.registerNode(
 
-	Gaffer.LocalDispatcher,
+	GafferDispatch.LocalDispatcher,
 
 	"description",
 	"""
@@ -244,7 +245,7 @@ class _LocalJobsWindow( GafferUI.Window ) :
 	@staticmethod
 	def acquire( jobPool ) :
 
-		assert( isinstance( jobPool, Gaffer.LocalDispatcher.JobPool ) )
+		assert( isinstance( jobPool, GafferDispatch.LocalDispatcher.JobPool ) )
 
 		window = getattr( jobPool, "_window", None )
 		if window is not None and window() :
@@ -338,7 +339,7 @@ class _LocalJobsWindow( GafferUI.Window ) :
 
 def __showLocalDispatcherWindow( menu ) :
 
-	window = _LocalJobsWindow.acquire( Gaffer.LocalDispatcher.defaultJobPool() )
+	window = _LocalJobsWindow.acquire( GafferDispatch.LocalDispatcher.defaultJobPool() )
 	scriptWindow = menu.ancestor( GafferUI.ScriptWindow )
 	scriptWindow.addChildWindow( window )
 	window.setVisible( True )

--- a/python/GafferDispatchUI/PythonCommandUI.py
+++ b/python/GafferDispatchUI/PythonCommandUI.py
@@ -58,7 +58,6 @@ Gaffer.Metadata.registerNode(
 			and the current context as `context`.
 			""",
 
-			"nodule:type", "",
 			"plugValueWidget:type", "GafferUI.PythonCommandUI._CommandPlugValueWidget",
 
 		),
@@ -71,7 +70,6 @@ Gaffer.Metadata.registerNode(
 			the `variables` dictionary within the python command.
 			""",
 
-			"nodule:type", "",
 			"layout:section", "Variables",
 
 		),
@@ -104,7 +102,6 @@ Gaffer.Metadata.registerNode(
 			```
 			""",
 
-			"nodule:type", "",
 			"layout:section", "Advanced",
 
 		),

--- a/python/GafferDispatchUI/PythonCommandUI.py
+++ b/python/GafferDispatchUI/PythonCommandUI.py
@@ -36,10 +36,11 @@
 
 import Gaffer
 import GafferUI
+import GafferDispatch
 
 Gaffer.Metadata.registerNode(
 
-	Gaffer.PythonCommand,
+	GafferDispatch.PythonCommand,
 
 	"description",
 	"""

--- a/python/GafferDispatchUI/SystemCommandUI.py
+++ b/python/GafferDispatchUI/SystemCommandUI.py
@@ -56,8 +56,6 @@ Gaffer.Metadata.registerNode(
 			from substitutions with '{substitutionName}' syntax.
 			""",
 
-			"nodule:type", "",
-
 		),
 
 		"substitutions" : (
@@ -68,7 +66,6 @@ Gaffer.Metadata.registerNode(
 			referenced in command with '{substitutionsName}' syntax.
 			""",
 
-			"nodule:type", "",
 			"layout:section", "Settings.Substitutions",
 
 		),
@@ -81,7 +78,6 @@ Gaffer.Metadata.registerNode(
 			environment variables when running the command.
 			""",
 
-			"nodule:type", "",
 			"layout:section", "Settings.Environment Variables",
 
 		)

--- a/python/GafferDispatchUI/SystemCommandUI.py
+++ b/python/GafferDispatchUI/SystemCommandUI.py
@@ -35,11 +35,11 @@
 ##########################################################################
 
 import Gaffer
-import GafferUI
+import GafferDispatch
 
 Gaffer.Metadata.registerNode(
 
-	Gaffer.SystemCommand,
+	GafferDispatch.SystemCommand,
 
 	"description",
 	"""

--- a/python/GafferDispatchUI/TaskContextProcessorUI.py
+++ b/python/GafferDispatchUI/TaskContextProcessorUI.py
@@ -34,14 +34,12 @@
 #
 ##########################################################################
 
-import IECore
-
 import Gaffer
-import GafferUI
+import GafferDispatch
 
 Gaffer.Metadata.registerNode(
 
-	Gaffer.TaskContextProcessor,
+	GafferDispatch.TaskContextProcessor,
 
 	"description",
 	"""

--- a/python/GafferDispatchUI/TaskContextVariablesUI.py
+++ b/python/GafferDispatchUI/TaskContextVariablesUI.py
@@ -56,8 +56,6 @@ Gaffer.Metadata.registerNode(
 			can be added here.
 			""",
 
-			"nodule:type", "",
-
 		]
 
 	}

--- a/python/GafferDispatchUI/TaskContextVariablesUI.py
+++ b/python/GafferDispatchUI/TaskContextVariablesUI.py
@@ -34,14 +34,12 @@
 #
 ##########################################################################
 
-import IECore
-
 import Gaffer
-import GafferUI
+import GafferDispatch
 
 Gaffer.Metadata.registerNode(
 
-	Gaffer.TaskContextVariables,
+	GafferDispatch.TaskContextVariables,
 
 	"description",
 	"""

--- a/python/GafferDispatchUI/TaskListUI.py
+++ b/python/GafferDispatchUI/TaskListUI.py
@@ -35,10 +35,11 @@
 ##########################################################################
 
 import Gaffer
+import GafferDispatch
 
 Gaffer.Metadata.registerNode(
 
-	Gaffer.TaskList,
+	GafferDispatch.TaskList,
 
 	"description",
 	"""

--- a/python/GafferDispatchUI/TaskSwitchUI.py
+++ b/python/GafferDispatchUI/TaskSwitchUI.py
@@ -35,10 +35,11 @@
 ##########################################################################
 
 import Gaffer
+import GafferDispatch
 
 Gaffer.Metadata.registerNode(
 
-	Gaffer.TaskSwitch,
+	GafferDispatch.TaskSwitch,
 
 	"description",
 	"""

--- a/python/GafferDispatchUI/TaskSwitchUI.py
+++ b/python/GafferDispatchUI/TaskSwitchUI.py
@@ -59,8 +59,6 @@ Gaffer.Metadata.registerNode(
 			the beginning.
 			""",
 
-			"nodule:type", "",
-
 		],
 
 	}

--- a/python/GafferDispatchUI/WedgeUI.py
+++ b/python/GafferDispatchUI/WedgeUI.py
@@ -81,8 +81,6 @@ Gaffer.Metadata.registerNode(
 			wedged value to specific nodes.
 			""",
 
-			"nodule:type", "",
-
 		],
 
 		"indexVariable" : [
@@ -101,8 +99,6 @@ Gaffer.Metadata.registerNode(
 			wedged renders.
 			""",
 
-			"nodule:type", "",
-
 		],
 
 		"mode" : [
@@ -115,7 +111,6 @@ Gaffer.Metadata.registerNode(
 			strings.
 			""",
 
-			"nodule:type", "",
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 
 			"preset:Float Range", int( GafferDispatch.Wedge.Mode.FloatRange ),
@@ -138,7 +133,6 @@ Gaffer.Metadata.registerNode(
 			other modes.
 			""",
 
-			"nodule:type", "",
 			"layout:visibilityActivator", "modeIsFloatRange",
 
 		],
@@ -152,7 +146,6 @@ Gaffer.Metadata.registerNode(
 			effect in other modes.
 			""",
 
-			"nodule:type", "",
 			"layout:visibilityActivator", "modeIsFloatRange",
 
 		],
@@ -168,7 +161,6 @@ Gaffer.Metadata.registerNode(
 			other modes.
 			""",
 
-			"nodule:type", "",
 			"layout:visibilityActivator", "modeIsFloatRange",
 
 		],
@@ -184,7 +176,6 @@ Gaffer.Metadata.registerNode(
 			other modes.
 			""",
 
-			"nodule:type", "",
 			"layout:visibilityActivator", "modeIsIntRange",
 
 		],
@@ -198,7 +189,6 @@ Gaffer.Metadata.registerNode(
 			effect in other modes.
 			""",
 
-			"nodule:type", "",
 			"layout:visibilityActivator", "modeIsIntRange",
 
 		],
@@ -216,7 +206,6 @@ Gaffer.Metadata.registerNode(
 			be used at all. Has no effect in other modes.
 			""",
 
-			"nodule:type", "",
 			"layout:visibilityActivator", "modeIsIntRange",
 
 		],
@@ -232,7 +221,6 @@ Gaffer.Metadata.registerNode(
 			other modes.
 			""",
 
-			"nodule:type", "",
 			"layout:visibilityActivator", "modeIsColorRange",
 
 		],
@@ -249,7 +237,6 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"label", "Steps",
-			"nodule:type", "",
 			"layout:visibilityActivator", "modeIsColorRange",
 
 		],
@@ -264,7 +251,6 @@ Gaffer.Metadata.registerNode(
 			mode. Has no effect in other modes.
 			""",
 
-			"nodule:type", "",
 			"layout:visibilityActivator", "modeIsFloatList",
 
 		],
@@ -277,7 +263,6 @@ Gaffer.Metadata.registerNode(
 			mode. Has no effect in other modes.
 			""",
 
-			"nodule:type", "",
 			"layout:visibilityActivator", "modeIsIntList",
 
 		],
@@ -290,7 +275,6 @@ Gaffer.Metadata.registerNode(
 			mode. Has no effect in other modes.
 			""",
 
-			"nodule:type", "",
 			"layout:visibilityActivator", "modeIsStringList",
 
 		],

--- a/python/GafferDispatchUI/WedgeUI.py
+++ b/python/GafferDispatchUI/WedgeUI.py
@@ -38,10 +38,11 @@ import IECore
 
 import Gaffer
 import GafferUI
+import GafferDispatch
 
 Gaffer.Metadata.registerNode(
 
-	Gaffer.Wedge,
+	GafferDispatch.Wedge,
 
 	"description",
 	"""
@@ -117,12 +118,12 @@ Gaffer.Metadata.registerNode(
 			"nodule:type", "",
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 
-			"preset:Float Range", int( Gaffer.Wedge.Mode.FloatRange ),
-			"preset:Int Range", int( Gaffer.Wedge.Mode.IntRange ),
-			"preset:Color Range", int( Gaffer.Wedge.Mode.ColorRange ),
-			"preset:Float List", int( Gaffer.Wedge.Mode.FloatList ),
-			"preset:Int List", int( Gaffer.Wedge.Mode.IntList ),
-			"preset:String List", int( Gaffer.Wedge.Mode.StringList ),
+			"preset:Float Range", int( GafferDispatch.Wedge.Mode.FloatRange ),
+			"preset:Int Range", int( GafferDispatch.Wedge.Mode.IntRange ),
+			"preset:Color Range", int( GafferDispatch.Wedge.Mode.ColorRange ),
+			"preset:Float List", int( GafferDispatch.Wedge.Mode.FloatList ),
+			"preset:Int List", int( GafferDispatch.Wedge.Mode.IntList ),
+			"preset:String List", int( GafferDispatch.Wedge.Mode.StringList ),
 
 		],
 

--- a/python/GafferImageUI/ImageWriterUI.py
+++ b/python/GafferImageUI/ImageWriterUI.py
@@ -62,6 +62,8 @@ Gaffer.Metadata.registerNode(
 			The image to be written to disk.
 			""",
 
+			"nodule:type", "GafferUI::StandardNodule",
+
 		],
 
 		"fileName" : [
@@ -73,7 +75,6 @@ Gaffer.Metadata.registerNode(
 			as a placeholder for the frame numbers.
 			""",
 
-			"nodule:type", "",
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"pathPlugValueWidget:leaf", True,
 			"pathPlugValueWidget:bookmarks", "image",
@@ -90,8 +91,6 @@ Gaffer.Metadata.registerNode(
 			The channels to be written to the file.
 			""",
 
-			"nodule:type", "",
-
 		],
 
 		"out" : [
@@ -101,23 +100,22 @@ Gaffer.Metadata.registerNode(
 			A pass-through of the input image.
 			""",
 
-			"nodule:type", "",
-
 		],
 
 		"dpx" : [
+
 			"description",
 			"""
 			Format options specific to DPX files.
 			""",
 
-			"nodule:type", "",
 			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
 			"layout:section", "Settings.DPX",
 
 		],
 
 		"dpx.dataType" : [
+
 			"description",
 			"""
 			The data type to be written to the DPX file.
@@ -132,6 +130,7 @@ Gaffer.Metadata.registerNode(
 		],
 
 		"field3d" : [
+
 			"description",
 			"""
 			Format options specific to Field3D files.
@@ -144,6 +143,7 @@ Gaffer.Metadata.registerNode(
 		],
 
 		"field3d.mode" : [
+
 			"description",
 			"""
 			The write mode for the Field3D file - scanline or tiled data.
@@ -156,6 +156,7 @@ Gaffer.Metadata.registerNode(
 		],
 
 		"field3d.dataType" : [
+
 			"description",
 			"""
 			The data type to be written to the Field3D file.
@@ -169,17 +170,19 @@ Gaffer.Metadata.registerNode(
 		],
 
 		"fits" : [
+
 			"description",
 			"""
 			Format options specific to FITS files.
 			""",
 
-			"nodule:type", "",
 			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
 			"layout:section", "Settings.FITS",
+
 		],
 
 		"fits.dataType" : [
+
 			"description",
 			"""
 			The data type to be written to the FITS file.
@@ -191,20 +194,23 @@ Gaffer.Metadata.registerNode(
 			"preset:32-bit", "uint32",
 			"preset:Float", "float",
 			"preset:Double", "double",
+
 		],
 
 		"iff" : [
+
 			"description",
 			"""
 			Format options specific to IFF files.
 			""",
 
-			"nodule:type", "",
 			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
 			"layout:section", "Settings.IFF",
+
 		],
 
 		"iff.mode" : [
+
 			"description",
 			"""
 			The write mode for the IFF file - scanline or tiled data.
@@ -217,18 +223,19 @@ Gaffer.Metadata.registerNode(
 		],
 
 		"jpeg" : [
+
 			"description",
 			"""
 			Format options specific to Jpeg files.
 			""",
 
-			"nodule:type", "",
 			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
 			"layout:section", "Settings.Jpeg",
 
 		],
 
 		"jpeg.compressionQuality" : [
+
 			"description",
 			"""
 			The compression quality for the Jpeg file to be written.
@@ -239,17 +246,19 @@ Gaffer.Metadata.registerNode(
 		],
 
 		"jpeg2000" : [
+
 			"description",
 			"""
 			Format options specific to Jpeg2000 files.
 			""",
 
-			"nodule:type", "",
 			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
 			"layout:section", "Settings.Jpeg2000",
+
 		],
 
 		"jpeg2000.dataType" : [
+
 			"description",
 			"""
 			The data type to be written to the Jpeg2000 file.
@@ -258,21 +267,23 @@ Gaffer.Metadata.registerNode(
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 			"preset:8-bit", "uint8",
 			"preset:16-bit", "uint16",
+
 		],
 
 		"openexr" : [
+
 			"description",
 			"""
 			Format options specific to OpenEXR files.
 			""",
 
-			"nodule:type", "",
 			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
 			"layout:section", "Settings.OpenEXR",
 
 		],
 
 		"openexr.mode" : [
+
 			"description",
 			"""
 			The write mode for the OpenEXR file - scanline or tiled data.
@@ -285,6 +296,7 @@ Gaffer.Metadata.registerNode(
 		],
 
 		"openexr.compression" : [
+
 			"description",
 			"""
 			The compression method to use when writing the OpenEXR file.
@@ -303,6 +315,7 @@ Gaffer.Metadata.registerNode(
 		],
 
 		"openexr.dataType" : [
+
 			"description",
 			"""
 			The data type to be written to the OpenEXR file.
@@ -315,17 +328,19 @@ Gaffer.Metadata.registerNode(
 		],
 
 		"png" : [
+
 			"description",
 			"""
 			Format options specific to PNG files.
 			""",
 
-			"nodule:type", "",
 			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
 			"layout:section", "Settings.PNG",
+
 		],
 
 		"png.compression" : [
+
 			"description",
 			"""
 			The compression method to use when writing the PNG file.
@@ -337,28 +352,33 @@ Gaffer.Metadata.registerNode(
 			"preset:Huffman", "huffman",
 			"preset:RLE", "rle",
 			"preset:Fixed", "fixed",
+
 		],
 
 		"png.compressionLevel" : [
+
 			"description",
 			"""
 			The compression level of the PNG file. This is a value between
 			0 (no compression) and 9 (most compression).
 			""",
+
 		],
 
 		"rla" : [
+
 			"description",
 			"""
 			Format options specific to RLA files.
 			""",
 
-			"nodule:type", "",
 			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
 			"layout:section", "Settings.RLA",
+
 		],
 
 		"rla.dataType" : [
+
 			"description",
 			"""
 			The data type to be written to the RLA file.
@@ -368,20 +388,23 @@ Gaffer.Metadata.registerNode(
 			"preset:8-bit", "uint8",
 			"preset:16-bit", "uint16",
 			"preset:Float", "float",
+
 		],
 
 		"sgi" : [
+
 			"description",
 			"""
 			Format options specific to SGI files.
 			""",
 
-			"nodule:type", "",
 			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
 			"layout:section", "Settings.SGI",
+
 		],
 
 		"sgi.dataType" : [
+
 			"description",
 			"""
 			The data type to be written to the SGI file.
@@ -390,20 +413,23 @@ Gaffer.Metadata.registerNode(
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 			"preset:8-bit", "uint8",
 			"preset:16-bit", "uint16",
+
 		],
 
 		"targa" : [
+
 			"description",
 			"""
 			Format options specific to Targa files.
 			""",
 
-			"nodule:type", "",
 			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
 			"layout:section", "Settings.Targa",
+
 		],
 
 		"targa.compression" : [
+
 			"description",
 			"""
 			The compression method to use when writing the Targa file.
@@ -412,21 +438,23 @@ Gaffer.Metadata.registerNode(
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 			"preset:None", "none",
 			"preset:RLE", "rle",
+
 		],
 
 		"tiff" : [
+
 			"description",
 			"""
 			Format options specific to TIFF files.
 			""",
 
-			"nodule:type", "",
 			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
 			"layout:section", "Settings.TIFF",
 
 		],
 
 		"tiff.mode" : [
+
 			"description",
 			"""
 			The write mode for the TIFF file - scanline or tiled data.
@@ -439,6 +467,7 @@ Gaffer.Metadata.registerNode(
 		],
 
 		"tiff.compression" : [
+
 			"description",
 			"""
 			The compression method to use when writing the TIFF file.
@@ -453,6 +482,7 @@ Gaffer.Metadata.registerNode(
 		],
 
 		"tiff.dataType" : [
+
 			"description",
 			"""
 			The data type to be written to the TIFF file.
@@ -466,23 +496,26 @@ Gaffer.Metadata.registerNode(
 		],
 
 		"webp" : [
+
 			"description",
 			"""
 			Format options specific to WebP files.
 			""",
 
-			"nodule:type", "",
 			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
 			"layout:section", "Settings.WebP",
+
 		],
 
 		"webp.compressionQuality" : [
+
 			"description",
 			"""
 			The compression quality for the WebP file to be written.
 			A value between 0 (low quality, high compression) and
 			100 (high quality, low compression).
 			""",
+
 		],
 
 

--- a/python/GafferSceneUI/ExecutableRenderUI.py
+++ b/python/GafferSceneUI/ExecutableRenderUI.py
@@ -62,6 +62,8 @@ Gaffer.Metadata.registerNode(
 			The scene to be rendered.
 			""",
 
+			"nodule:type", "GafferUI::StandardNodule"
+
 		],
 
 		"out" : [
@@ -70,8 +72,6 @@ Gaffer.Metadata.registerNode(
 			"""
 			A pass-through of the input scene.
 			""",
-
-			"nodule:type", ""
 
 		],
 

--- a/python/GafferSceneUI/SceneWriterUI.py
+++ b/python/GafferSceneUI/SceneWriterUI.py
@@ -62,7 +62,6 @@ Gaffer.Metadata.registerNode(
 			number is generally not necessary.
 			""",
 
-			"nodule:type", "",
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"pathPlugValueWidget:leaf", True,
 			"pathPlugValueWidget:bookmarks", "sceneCache",
@@ -76,7 +75,9 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			The scene to be written.
-			"""
+			""",
+
+			"nodule:type", "GafferUI::StandardNodule",
 
 		],
 
@@ -86,8 +87,6 @@ Gaffer.Metadata.registerNode(
 			"""
 			A direct pass-through of the input scene.
 			""",
-
-			"nodule:type", "",
 
 		],
 

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -336,12 +336,15 @@ if moduleSearchPath.find( "GafferOSL" ) :
 
 # Dispatch nodes
 
-nodeMenu.append( "/Dispatch/System Command", Gaffer.SystemCommand, searchText = "SystemCommand" )
-nodeMenu.append( "/Dispatch/Python Command", Gaffer.PythonCommand, searchText = "PythonCommand" )
-nodeMenu.append( "/Dispatch/Task List", Gaffer.TaskList, searchText = "TaskList" )
-nodeMenu.append( "/Dispatch/Task Switch", Gaffer.TaskSwitch, searchText = "TaskSwitch" )
-nodeMenu.append( "/Dispatch/Wedge", Gaffer.Wedge )
-nodeMenu.append( "/Dispatch/Variables", Gaffer.TaskContextVariables, searchText = "TaskContextVariables" )
+import GafferDispatch
+import GafferDispatchUI
+
+nodeMenu.append( "/Dispatch/System Command", GafferDispatch.SystemCommand, searchText = "SystemCommand" )
+nodeMenu.append( "/Dispatch/Python Command", GafferDispatch.PythonCommand, searchText = "PythonCommand" )
+nodeMenu.append( "/Dispatch/Task List", GafferDispatch.TaskList, searchText = "TaskList" )
+nodeMenu.append( "/Dispatch/Task Switch", GafferDispatch.TaskSwitch, searchText = "TaskSwitch" )
+nodeMenu.append( "/Dispatch/Wedge", GafferDispatch.Wedge )
+nodeMenu.append( "/Dispatch/Variables", GafferDispatch.TaskContextVariables, searchText = "TaskContextVariables" )
 
 # Utility nodes
 

--- a/startup/gui/nodeGraph.py
+++ b/startup/gui/nodeGraph.py
@@ -41,18 +41,19 @@ import Gaffer
 import GafferUI
 import GafferScene
 import GafferSceneUI
+import GafferDispatch
 
 ##########################################################################
 # Colour
 ##########################################################################
 
-Gaffer.Metadata.registerNodeValue( Gaffer.ExecutableNode, "nodeGadget:color", IECore.Color3f( 0.61, 0.1525, 0.1525 ) )
-Gaffer.Metadata.registerPlugValue( Gaffer.ExecutableNode, "task", "nodule:color", IECore.Color3f( 0.645, 0.2483, 0.2483 ) )
-Gaffer.Metadata.registerPlugValue( Gaffer.ExecutableNode, "preTasks.*", "nodule:color", IECore.Color3f( 0.645, 0.2483, 0.2483 ) )
-Gaffer.Metadata.registerPlugValue( Gaffer.ExecutableNode, "postTasks.*", "nodule:color", IECore.Color3f( 0.645, 0.2483, 0.2483 ) )
-Gaffer.Metadata.registerPlugValue( Gaffer.ExecutableNode, "task", "connectionGadget:color", IECore.Color3f( 0.315, 0.0787, 0.0787 ) )
-Gaffer.Metadata.registerPlugValue( Gaffer.ExecutableNode, "preTasks.*", "connectionGadget:color", IECore.Color3f( 0.315, 0.0787, 0.0787 ) )
-Gaffer.Metadata.registerPlugValue( Gaffer.ExecutableNode, "postTasks.*", "connectionGadget:color", IECore.Color3f( 0.315, 0.0787, 0.0787 ) )
+Gaffer.Metadata.registerNodeValue( GafferDispatch.ExecutableNode, "nodeGadget:color", IECore.Color3f( 0.61, 0.1525, 0.1525 ) )
+Gaffer.Metadata.registerPlugValue( GafferDispatch.ExecutableNode, "task", "nodule:color", IECore.Color3f( 0.645, 0.2483, 0.2483 ) )
+Gaffer.Metadata.registerPlugValue( GafferDispatch.ExecutableNode, "preTasks.*", "nodule:color", IECore.Color3f( 0.645, 0.2483, 0.2483 ) )
+Gaffer.Metadata.registerPlugValue( GafferDispatch.ExecutableNode, "postTasks.*", "nodule:color", IECore.Color3f( 0.645, 0.2483, 0.2483 ) )
+Gaffer.Metadata.registerPlugValue( GafferDispatch.ExecutableNode, "task", "connectionGadget:color", IECore.Color3f( 0.315, 0.0787, 0.0787 ) )
+Gaffer.Metadata.registerPlugValue( GafferDispatch.ExecutableNode, "preTasks.*", "connectionGadget:color", IECore.Color3f( 0.315, 0.0787, 0.0787 ) )
+Gaffer.Metadata.registerPlugValue( GafferDispatch.ExecutableNode, "postTasks.*", "connectionGadget:color", IECore.Color3f( 0.315, 0.0787, 0.0787 ) )
 
 Gaffer.Metadata.registerNodeValue( Gaffer.SubGraph, "nodeGadget:color", IECore.Color3f( 0.225 ) )
 

--- a/startup/gui/project.py
+++ b/startup/gui/project.py
@@ -104,4 +104,4 @@ for dispatcher in dispatchers :
 	Gaffer.Metadata.registerPlugValue( dispatcher, "jobsDirectory", "userDefault", "${project:rootDirectory}/dispatcher/" + directoryName )
 
 Gaffer.Metadata.registerPlugValue( GafferDispatch.LocalDispatcher, "executeInBackground", "userDefault", True )
-Gaffer.Dispatcher.setDefaultDispatcherType( "Local" )
+GafferDispatch.Dispatcher.setDefaultDispatcherType( "Local" )


### PR DESCRIPTION
- Removed reliance on a compatibility config file that will one day be removed.
- Simplified nodule metadata for ExecutableNodes. This will mean that IE internal ExecutableNodes (RenderManNetRender, IERenderPass and LiveSceneCache at least) will need their UI files updating to explicitly request a nodule for anything they wish to be visible in the graph (typically the incoming scene). Adding a duplicate registration will do no harm in the current version of Gaffer, so we could update in advance of the release of the next version.
- Fixed UI appearance for individually promoted task plugs.