### PR TITLE
MultiLineStringPlugValueWidget error handling

### DIFF
--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -115,9 +115,18 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 		if not valueChanged and isinstance( plug, Gaffer.ValuePlug ) :
 			with self.getContext() :
 				if Gaffer.NodeAlgo.hasUserDefault( plug ) :
-					valueChanged = not Gaffer.NodeAlgo.isSetToUserDefault( plug )
+					try:
+						valueChanged = not Gaffer.NodeAlgo.isSetToUserDefault( plug )
+					except:
+						# an error here should not cause the ui to break, specially since the value widget corresponding could be indicating the error itself
+						valueChanged = True
 				else :
-					valueChanged = not plug.isSetToDefault()
+					try:
+						valueChanged = not plug.isSetToDefault()
+					except:
+						# an error here should not cause the ui to break, specially since the value widget corresponding could be indicating the error itself
+						valueChanged = True
+
 		self.__setValueChanged( valueChanged )
 
 	# Sets whether or not the label be rendered in a ValueChanged state.

--- a/python/GafferUI/MultiLineStringPlugValueWidget.py
+++ b/python/GafferUI/MultiLineStringPlugValueWidget.py
@@ -68,7 +68,15 @@ class MultiLineStringPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		if self.getPlug() is not None :
 			with self.getContext() :
-				self.__textWidget.setText( self.getPlug().getValue() )
+				try :
+					value = self.getPlug().getValue()
+				except :
+					value = None
+
+			if value is not None :
+				self.__textWidget.setText( value )
+
+			self.__textWidget.setErrored( value is None )
 
 			fixedLineHeight = Gaffer.Metadata.plugValue( self.getPlug(), "fixedLineHeight" )
 			self.__textWidget.setFixedLineHeight( fixedLineHeight )

--- a/python/GafferUI/MultiLineTextWidget.py
+++ b/python/GafferUI/MultiLineTextWidget.py
@@ -70,10 +70,10 @@ class MultiLineTextWidget( GafferUI.Widget ) :
 		self.setWrapMode( wrapMode )
 		self.setFixedLineHeight( fixedLineHeight )
 
- 		self.__dragEnterConnection = self.dragEnterSignal().connect( Gaffer.WeakMethod( self.__dragEnter ) )
- 		self.__dragMoveConnection = self.dragMoveSignal().connect( Gaffer.WeakMethod( self.__dragMove ) )
- 		self.__dragLeaveConnection = self.dragLeaveSignal().connect( Gaffer.WeakMethod( self.__dragLeave ) )
- 		self.__dropConnection = self.dropSignal().connect( Gaffer.WeakMethod( self.__drop ) )
+		self.__dragEnterConnection = self.dragEnterSignal().connect( Gaffer.WeakMethod( self.__dragEnter ) )
+		self.__dragMoveConnection = self.dragMoveSignal().connect( Gaffer.WeakMethod( self.__dragMove ) )
+		self.__dragLeaveConnection = self.dragLeaveSignal().connect( Gaffer.WeakMethod( self.__dragLeave ) )
+		self.__dropConnection = self.dropSignal().connect( Gaffer.WeakMethod( self.__drop ) )
 
 		self._qtWidget().setTabStopWidth( 20 ) # pixels
 
@@ -140,6 +140,18 @@ class MultiLineTextWidget( GafferUI.Widget ) :
 	def getFixedLineHeight( self ) :
 
 		return self._qtWidget().getFixedLineHeight()
+
+	def setErrored( self, errored ) :
+
+		if errored == self.getErrored() :
+			return
+
+		self._qtWidget().setProperty( "gafferError", GafferUI._Variant.toVariant( bool( errored ) ) )
+		self._repolish()
+
+	def getErrored( self ) :
+
+		return GafferUI._Variant.fromVariant( self._qtWidget().property( "gafferError" ) ) or False
 
 	def setCursorPosition( self, position ) :
 

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -203,7 +203,7 @@ _styleSheet = string.Template(
 
 	}
 
-	QLineEdit[gafferError="true"] {
+	QLineEdit[gafferError="true"], QPlainTextEdit[gafferError="true"] {
 
 		background-color: $errorColor;
 

--- a/python/GafferUITest/MultiLineTextWidgetTest.py
+++ b/python/GafferUITest/MultiLineTextWidgetTest.py
@@ -129,5 +129,16 @@ class MultiLineTextWidgetTest( GafferUITest.TestCase ) :
 		# checking if the geometry has been updated for the new line height
 		self.assertEqual( newHeight == oldHeight, False )
 
+	def testErrored( self ) :
+
+		w = GafferUI.TextWidget()
+		self.assertEqual( w.getErrored(), False )
+
+		w.setErrored( True )
+		self.assertEqual( w.getErrored(), True )
+
+		w.setErrored( False )
+		self.assertEqual( w.getErrored(), False )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This adds an error handling functionality to the MultiLineStringPlugValueWidget, based on what was found in StringPlugValueWidget and other widgets based on the GafferUI.TextWidget.
Also handles errors on the value changed icon in LabelPlugValueWidget.

Both are so we can use StringPlugs as outputs, and display them as multi line texts.
