### PR TITLE
Prune/Isolate bug fixes

### DIFF
--- a/src/GafferScene/Isolate.cpp
+++ b/src/GafferScene/Isolate.cpp
@@ -175,8 +175,18 @@ void Isolate::hashChildNames( const ScenePath &path, const Gaffer::Context *cont
 	{
 		// we might be computing new childnames for this level.
 		FilteredSceneProcessor::hashChildNames( path, context, parent, h );
-		inPlug()->childNamesPlug()->hash( h );
-		filterPlug()->hash( h );
+
+		ConstInternedStringVectorDataPtr inputChildNamesData = inPlug()->childNamesPlug()->getValue();
+		const vector<InternedString> &inputChildNames = inputChildNamesData->readable();
+
+		ScenePath childPath = path;
+		childPath.push_back( InternedString() ); // for the child name
+		for( vector<InternedString>::const_iterator it = inputChildNames.begin(), eIt = inputChildNames.end(); it != eIt; ++it )
+		{
+			childPath[path.size()] = *it;
+			tmpContext->set( ScenePlug::scenePathContextName, childPath );
+			filterPlug()->hash( h );
+		}
 	}
 	else
 	{


### PR DESCRIPTION
This fixes a bug in the Prune and Isolate nodes, which only shows itself in conjunction with one of Image Engine's internal filter nodes. This PR is a little unusual then in that the fix is here, and the test cases are in a PR I'm about to make on the internal project. Perhaps at some point we could consider moving some of the internal filters to the Gaffer project itself...