### PR TITLE
FilterProcessor : Implement pass-through when disabled.

### DIFF
--- a/include/GafferScene/FilterProcessor.h
+++ b/include/GafferScene/FilterProcessor.h
@@ -83,9 +83,18 @@ class FilterProcessor : public Filter
 
 		virtual bool sceneAffectsMatch( const ScenePlug *scene, const Gaffer::ValuePlug *child ) const;
 
+		/// Returns inPlug() as the correspondingInput of outPlug();
+		virtual Gaffer::Plug *correspondingInput( const Gaffer::Plug *output );
+		virtual const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const;
+
 	protected :
 
 		virtual bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const;
+
+		/// Reimplemented to pass through the inPlug() hash when the node is disabled.
+		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		/// Reimplemented to pass through the inPlug() result when the node is disabled.
+		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
 
 	private :
 

--- a/python/GafferSceneTest/UnionFilterTest.py
+++ b/python/GafferSceneTest/UnionFilterTest.py
@@ -221,5 +221,33 @@ class UnionFilterTest( GafferSceneTest.SceneTestCase ) :
 		self.assertTrue( s["UnionFilter"]["in"][1].getInput().isSame( s["PathFilter1"]["out"] ) )
 		self.assertTrue( s["UnionFilter"]["in"][2].getInput().isSame( s["PathFilter2"]["out"] ) )
 
+	def testDisabling( self ) :
+
+		pathFilterA = GafferScene.PathFilter()
+		pathFilterB = GafferScene.PathFilter()
+
+		pathFilterA["paths"].setValue( IECore.StringVectorData( [ "/a" ] ) )
+		pathFilterB["paths"].setValue( IECore.StringVectorData( [ "/b" ] ) )
+
+		unionFilter = GafferScene.UnionFilter()
+		unionFilter["in"][0].setInput( pathFilterA["out"] )
+		unionFilter["in"][1].setInput( pathFilterB["out"] )
+
+		self.assertTrue( unionFilter.correspondingInput( unionFilter["out"] ).isSame( unionFilter["in"][0] ) )
+
+		with Gaffer.Context() as c :
+			c["scene:path"] = IECore.InternedStringVectorData( [ "a" ] )
+			self.assertEqual( unionFilter["out"].getValue(), unionFilter.Result.ExactMatch )
+			c["scene:path"] = IECore.InternedStringVectorData( [ "b" ] )
+			self.assertEqual( unionFilter["out"].getValue(), unionFilter.Result.ExactMatch )
+
+		unionFilter["enabled"].setValue( False )
+
+		with Gaffer.Context() as c :
+			c["scene:path"] = IECore.InternedStringVectorData( [ "a" ] )
+			self.assertEqual( unionFilter["out"].getValue(), unionFilter.Result.ExactMatch )
+			c["scene:path"] = IECore.InternedStringVectorData( [ "b" ] )
+			self.assertEqual( unionFilter["out"].getValue(), unionFilter.Result.NoMatch )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUI/FilterProcessorUI.py
+++ b/python/GafferSceneUI/FilterProcessorUI.py
@@ -51,6 +51,17 @@ Gaffer.Metadata.registerNode(
 
 	plugs = {
 
+
+		"enabled" : [
+
+			"description",
+			"""
+			The on/off state of the filter. When it is off, the
+			result of the first input is passed through unchanged.
+			""",
+
+		],
+
 		"in" : [
 
 			"description", lambda plug : "The input filter" + ( "s" if isinstance( plug, Gaffer.ArrayPlug ) else "" ),

--- a/src/GafferScene/FilterProcessor.cpp
+++ b/src/GafferScene/FilterProcessor.cpp
@@ -117,6 +117,24 @@ bool FilterProcessor::sceneAffectsMatch( const ScenePlug *scene, const Gaffer::V
 	return false;
 }
 
+Gaffer::Plug *FilterProcessor::correspondingInput( const Gaffer::Plug *output )
+{
+	if( output == outPlug() )
+	{
+		return inPlug();
+	}
+	return Filter::correspondingInput( output );
+}
+
+const Gaffer::Plug *FilterProcessor::correspondingInput( const Gaffer::Plug *output ) const
+{
+	if( output == outPlug() )
+	{
+		return inPlug();
+	}
+	return Filter::correspondingInput( output );
+}
+
 bool FilterProcessor::acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const
 {
 	if( !Filter::acceptsInput( plug, inputPlug ) )
@@ -136,4 +154,28 @@ bool FilterProcessor::acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug
 	}
 
 	return true;
+}
+
+void FilterProcessor::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	if( output == outPlug() && !enabledPlug()->getValue() )
+	{
+		h = inPlug()->hash();
+	}
+	else
+	{
+		Filter::hash( output, context, h );
+	}
+}
+
+void FilterProcessor::compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const
+{
+	if( output == outPlug() && !enabledPlug()->getValue() )
+	{
+		output->setFrom( inPlug() );
+	}
+	else
+	{
+		Filter::compute( output, context );
+	}
 }


### PR DESCRIPTION
This matches the pass-through behaviour of all our other Processor nodes. I realised that most of the internal Image Engine filters are doing something like this manually (none of them derive from FilterProcessor at present), and it was about time we had proper support in Gaffer itself. This does change the behaviour of disabled UnionFilters (which I would consider a bugfix), so we might want to wait to merge this. I just wanted to get it up while it's fresh in my mind since I think this is definitely the way to go. Hopefully at some point we'll reimplement the internal filters using this base class, and potentially move a few of them to Gaffer itself. 