### PR TITLE
Maya/PySide GLWidget fix

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -767,9 +767,11 @@ for library in ( "GafferUI", ) :
 		libraries[library]["pythonEnvAppends"].setdefault( "FRAMEWORKPATH", [] ).append( "$BUILD_DIR/lib" )
 		libraries[library]["pythonEnvAppends"].setdefault( "FRAMEWORKS", [] ).append( "QtCore" )
 		libraries[library]["pythonEnvAppends"].setdefault( "FRAMEWORKS", [] ).append( "QtGui" )
+		libraries[library]["pythonEnvAppends"].setdefault( "FRAMEWORKS", [] ).append( "QtOpenGL" )
 	else :
 		libraries[library]["pythonEnvAppends"]["LIBS"].append( "QtCore" )
 		libraries[library]["pythonEnvAppends"]["LIBS"].append( "QtGui" )
+		libraries[library]["pythonEnvAppends"]["LIBS"].append( "QtOpenGL" )
 
 
 ###############################################################################################

--- a/include/GafferUIBindings/GLWidgetBinding.h
+++ b/include/GafferUIBindings/GLWidgetBinding.h
@@ -1,0 +1,50 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERUIBINDINGS_GLWIDGETBINDING_H
+#define GAFFERUIBINDINGS_GLWIDGETBINDING_H
+
+namespace GafferUIBindings
+{
+
+/// This doesn't actually bind GLWidget, because that is implemented
+/// in Python at present. Instead, it binds C++ support functions that GLWidget
+/// uses internally.
+void bindGLWidget();
+
+} // namespace GafferUIBindings
+
+#endif // GAFFERUIBINDINGS_GLWIDGETBINDING_H

--- a/src/GafferUIBindings/GLWidgetBinding.cpp
+++ b/src/GafferUIBindings/GLWidgetBinding.cpp
@@ -38,9 +38,11 @@
 
 #include "QtOpenGL/QGLWidget"
 
+#if defined( __linux__ )
 #include "GL/glx.h" // Must come after Qt!
+#endif
 
-#include "IECorePython/ScopedGILLock.h"
+#include "IECore/MessageHandler.h"
 
 #include "GafferUIBindings/GLWidgetBinding.h"
 
@@ -48,6 +50,8 @@ using namespace boost::python;
 
 namespace
 {
+
+#if defined( __linux__ )
 
 class HostedGLContext : public QGLContext
 {
@@ -57,6 +61,7 @@ class HostedGLContext : public QGLContext
 		HostedGLContext( const QGLFormat &format, QPaintDevice *device )
 			:	QGLContext( format, device )
 		{
+
 			GLXContext hostContext = glXGetCurrentContext();
 			m_display = glXGetCurrentDisplay();
 
@@ -88,6 +93,23 @@ class HostedGLContext : public QGLContext
 		GLXContext m_context;
 
 };
+
+#else
+
+class HostedGLContext : public QGLContext
+{
+
+	public :
+
+		HostedGLContext( const QGLFormat &format, QPaintDevice *device )
+			:	QGLContext( format, device )
+		{
+			IECore::msg( IECore::Msg::Warning, "HostedGLContext", "Not implemented on this platform." );
+		}
+
+};
+
+#endif
 
 void setHostedContext( uint64_t glWidgetAddress, uint64_t glFormatAddress )
 {

--- a/src/GafferUIBindings/GLWidgetBinding.cpp
+++ b/src/GafferUIBindings/GLWidgetBinding.cpp
@@ -1,0 +1,106 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "QtOpenGL/QGLWidget"
+
+#include "GL/glx.h" // Must come after Qt!
+
+#include "IECorePython/ScopedGILLock.h"
+
+#include "GafferUIBindings/GLWidgetBinding.h"
+
+using namespace boost::python;
+
+namespace
+{
+
+class HostedGLContext : public QGLContext
+{
+
+	public :
+
+		HostedGLContext( const QGLFormat &format, QPaintDevice *device )
+			:	QGLContext( format, device )
+		{
+			GLXContext hostContext = glXGetCurrentContext();
+			m_display = glXGetCurrentDisplay();
+
+			// Get a visual - we let the base class figure this out.
+			XVisualInfo *visual = (XVisualInfo *)chooseVisual();
+
+			// Make our context.
+			m_context = glXCreateContext(
+				m_display,
+				visual,
+				hostContext,
+				true
+			);
+		}
+
+		virtual ~HostedGLContext()
+		{
+			glXDestroyContext( m_display, m_context );
+		}
+
+		virtual void makeCurrent()
+		{
+			glXMakeCurrent( m_display, static_cast<QWidget *>( device() )->effectiveWinId(), m_context );
+		}
+
+	private :
+
+		Display *m_display;
+		GLXContext m_context;
+
+};
+
+void setHostedContext( uint64_t glWidgetAddress, uint64_t glFormatAddress )
+{
+	QGLWidget *glWidget = reinterpret_cast<QGLWidget *>( glWidgetAddress );
+	QGLFormat *glFormat = reinterpret_cast<QGLFormat *>( glFormatAddress );
+	glWidget->setContext( new HostedGLContext( *glFormat, glWidget ) );
+}
+
+} // namespace
+
+void GafferUIBindings::bindGLWidget()
+{
+
+	def( "_glWidgetSetHostedContext", &setHostedContext );
+
+}

--- a/src/GafferUIModule/GafferUIModule.cpp
+++ b/src/GafferUIModule/GafferUIModule.cpp
@@ -75,6 +75,7 @@
 #include "GafferUIBindings/ToolBinding.h"
 #include "GafferUIBindings/DotNodeGadgetBinding.h"
 #include "GafferUIBindings/PathListingWidgetBinding.h"
+#include "GafferUIBindings/GLWidgetBinding.h"
 
 using namespace GafferUIBindings;
 
@@ -119,5 +120,6 @@ BOOST_PYTHON_MODULE( _GafferUI )
 	bindTool();
 	bindDotNodeGadget();
 	bindPathListingWidget();
+	bindGLWidget();
 
 }


### PR DESCRIPTION
This allows GafferUI.GLWidget to be used in Maya when using the PySide Qt bindings that ship with Maya (tested in Maya 2016). PySide has some holes compared to PyQt when it comes to implementing custom QGLContexts, so we now just do all the hard work in C++ instead.