### PR TITLE
Shader : Fix bug in cycle detection.

### DIFF
--- a/include/GafferScene/Shader.h
+++ b/include/GafferScene/Shader.h
@@ -137,8 +137,6 @@ class Shader : public Gaffer::DependencyNode
 				void parameterHashWalk( const Shader *shaderNode, const Gaffer::Plug *parameterPlug, IECore::MurmurHash &h );
 				void parameterValueWalk( const Shader *shaderNode, const Gaffer::Plug *parameterPlug, const IECore::InternedString &parameterName, IECore::CompoundDataMap &values );
 
-				void throwCycleError( const Shader *shaderNode );
-
 				const Shader *m_rootNode;
 				IECore::ObjectVectorPtr m_state;
 
@@ -153,6 +151,7 @@ class Shader : public Gaffer::DependencyNode
 
 				typedef boost::unordered_set<const Shader *> ShaderSet;
 				ShaderSet m_downstreamShaders; // Used for detecting cycles
+				struct CycleDetector;
 
 				unsigned int m_handleCount;
 

--- a/python/GafferOSLTest/OSLShaderTest.py
+++ b/python/GafferOSLTest/OSLShaderTest.py
@@ -432,5 +432,31 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 
 		self.assertTrue( n["parameters"]["i"].acceptsInput( None ) )
 
+	def testOverzealousCycleDetection( self ) :
+
+		globals = GafferOSL.OSLShader( "Globals" )
+		globals.loadShader( "Utility/Globals" )
+
+		point = GafferOSL.OSLShader( "Point" )
+		point.loadShader( "Utility/BuildPoint" )
+
+		noise = GafferOSL.OSLShader( "Noise" )
+		noise.loadShader( "Pattern/Noise" )
+
+		color = GafferOSL.OSLShader( "Color" )
+		color.loadShader( "Utility/BuildColor" )
+
+		point["parameters"]["x"].setInput( globals["out"]["globalU"] )
+		point["parameters"]["y"].setInput( globals["out"]["globalV"] )
+
+		noise["parameters"]["p"].setInput( point["out"]["p"] )
+
+		color["parameters"]["r"].setInput( globals["out"]["globalU"] )
+		color["parameters"]["g"].setInput( noise["out"]["n"] )
+
+		# Should not throw - there are no cycles above.
+		color.stateHash()
+		color.state()
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
The early return conditionals were skipping the removal of the current shader from the downstream shaders set. We now use an RAII style CycleDetector class to do both the insertion and removal, so we know we always remove the shader appropriately.