### PR TITLE
Python `DependencyNode.affects()` tidyup and subsequent iterator overhaul

### DIFF
--- a/include/Gaffer/ContextProcessor.inl
+++ b/include/Gaffer/ContextProcessor.inl
@@ -129,14 +129,14 @@ template<typename BaseType>
 void ContextProcessor<BaseType>::appendAffectedPlugs( DependencyNode::AffectedPlugsContainer &outputs ) const
 {
 	Node *n = const_cast<Node *>( static_cast<const Node *>( this ) );
-	for( OutputPlugIterator it( n ); it != it.end(); it++ )
+	for( OutputPlugIterator it( n ); !it.done(); ++it )
 	{
 		const ValuePlug *valuePlug = IECore::runTimeCast<const ValuePlug>( it->get() );
 		if( 0 == valuePlug->getName().string().compare( 0, 3, "out" ) && oppositePlug( valuePlug ) )
 		{
 			if( valuePlug->children().size() )
 			{
-				for( ValuePlugIterator cIt( valuePlug ); cIt != cIt.end(); cIt++ )
+				for( ValuePlugIterator cIt( valuePlug ); !cIt.done(); ++cIt )
 				{
 					outputs.push_back( cIt->get() );
 				}

--- a/include/Gaffer/ContextVariables.inl
+++ b/include/Gaffer/ContextVariables.inl
@@ -94,7 +94,7 @@ template<typename BaseType>
 void ContextVariables<BaseType>::processContext( Context *context ) const
 {
 	std::string name;
-	for( CompoundDataPlug::MemberPlugIterator it( variablesPlug() ); it != it.end(); it++ )
+	for( CompoundDataPlug::MemberPlugIterator it( variablesPlug() ); !it.done(); ++it )
 	{
 		IECore::DataPtr data = variablesPlug()->memberDataAndName( it->get(), name );
 		if( data )

--- a/include/Gaffer/DownstreamIterator.h
+++ b/include/Gaffer/DownstreamIterator.h
@@ -88,16 +88,25 @@ class DownstreamIterator : public boost::iterator_facade<DownstreamIterator, con
 			m_pruned = true;
 		}
 
+		/// Returns true when iteration is complete.
+		bool done() const
+		{
+			return m_stack.size() == 1 && m_stack[0].it == m_stack[0].end;
+		}
+
+		/// \deprecated Comparison to end() is unreliable. Use done() instead.
 		bool operator==( const DependencyNode::AffectedPlugsContainer::const_iterator &rhs ) const
 		{
 			return stackTop().it == rhs ;
 		}
 
+		/// \deprecated Comparison to end() is unreliable. Use done() instead.
 		bool operator!=( const DependencyNode::AffectedPlugsContainer::const_iterator &rhs ) const
 		{
 			return stackTop().it != rhs;
 		}
 
+		/// \deprecated Comparison to end() is unreliable. Use done() instead.
 		const DependencyNode::AffectedPlugsContainer::const_iterator &end() const
 		{
 			return m_stack[0].end;

--- a/include/Gaffer/FilteredChildIterator.h
+++ b/include/Gaffer/FilteredChildIterator.h
@@ -64,6 +64,11 @@ class FilteredChildIterator : public boost::filter_iterator<Predicate, GraphComp
 		typedef typename Predicate::ChildType ChildType;
 		typedef boost::filter_iterator<Predicate, GraphComponent::ChildIterator> BaseIterator;
 
+		/// \todo It's inconvenient that our reference type
+		/// is ChildType::Ptr rather than just ChildType. It
+		/// leads to lots of ugly `it->get()` and `(*it)->`
+		/// calls. Change this for this class and also for
+		/// the RecursiveIterator classes.
 		typedef const typename ChildType::Ptr &reference;
 		typedef const typename ChildType::Ptr *pointer;
 

--- a/include/Gaffer/FilteredChildIterator.h
+++ b/include/Gaffer/FilteredChildIterator.h
@@ -88,16 +88,6 @@ class FilteredChildIterator : public boost::filter_iterator<Predicate, GraphComp
 		{
 		}
 
-		bool operator==( const GraphComponent::ChildIterator &rhs ) const
-		{
-			return BaseIterator::base()==( rhs );
-		}
-
-		bool operator!=( const GraphComponent::ChildIterator &rhs ) const
-		{
-			return BaseIterator::base()!=( rhs );
-		}
-
 		reference operator*() const
 		{
 			// cast should be safe as predicate has checked type, and the layout of
@@ -121,6 +111,23 @@ class FilteredChildIterator : public boost::filter_iterator<Predicate, GraphComp
 			FilteredChildIterator r( *this );
 			BaseIterator::operator++();
 			return r;
+		}
+
+		bool done() const
+		{
+			return BaseIterator::base() == this->end();
+		}
+
+		/// \deprecated Prefer done() over comparison against end().
+		bool operator==( const GraphComponent::ChildIterator &rhs ) const
+		{
+			return BaseIterator::base()==( rhs );
+		}
+
+		/// \deprecated Prefer done() over comparison against end().
+		bool operator!=( const GraphComponent::ChildIterator &rhs ) const
+		{
+			return BaseIterator::base()!=( rhs );
 		}
 
 };

--- a/include/Gaffer/FilteredRecursiveChildIterator.h
+++ b/include/Gaffer/FilteredRecursiveChildIterator.h
@@ -84,16 +84,6 @@ class FilteredRecursiveChildIterator : public boost::iterator_adaptor<FilteredRe
 			satisfyPredicate();
 		}
 
-		bool operator==( const RecursiveChildIterator &rhs ) const
-		{
-			return BaseIterator::base()==( rhs );
-		}
-
-		bool operator!=( const RecursiveChildIterator &rhs ) const
-		{
-			return BaseIterator::base()!=( rhs );
-		}
-
 		/// Calling prune() causes the next increment to skip any recursion
 		/// that it would normally perform.
 		void prune()
@@ -101,6 +91,24 @@ class FilteredRecursiveChildIterator : public boost::iterator_adaptor<FilteredRe
 			const_cast<RecursiveChildIterator &>( BaseIterator::base() ).prune();
 		}
 
+		bool done() const
+		{
+			return BaseIterator::base().done();
+		}
+
+		/// \deprecated Comparison to end() is unreliable. Use done() instead.
+		bool operator==( const RecursiveChildIterator &rhs ) const
+		{
+			return BaseIterator::base()==( rhs );
+		}
+
+		/// \deprecated Comparison to end() is unreliable. Use done() instead.
+		bool operator!=( const RecursiveChildIterator &rhs ) const
+		{
+			return BaseIterator::base()!=( rhs );
+		}
+
+		/// \deprecated Comparison to end() is unreliable. Use done() instead.
 		RecursiveChildIterator end()
 		{
 			return m_end;

--- a/include/Gaffer/Loop.inl
+++ b/include/Gaffer/Loop.inl
@@ -276,7 +276,7 @@ bool Loop<BaseType>::setupPlugs()
 	// hash()/compute() because each iteration changes the context and we bottom
 	// out after the specified number of iterations.
 	previousPlug()->setFlags( Plug::AcceptsDependencyCycles, true );
-	for( Gaffer::RecursivePlugIterator it( previousPlug() ); it != it.end(); ++it )
+	for( Gaffer::RecursivePlugIterator it( previousPlug() ); !it.done(); ++it )
 	{
 		(*it)->setFlags( Plug::AcceptsDependencyCycles, true );
 	}
@@ -313,7 +313,7 @@ void Loop<BaseType>::addAffectedPlug( const ValuePlug *output, DependencyNode::A
 {
 	if( output->children().size() )
 	{
-		for( RecursiveOutputPlugIterator it( output ); it != it.end(); ++it )
+		for( RecursiveOutputPlugIterator it( output ); !it.done(); ++it )
 		{
 			if( !(*it)->children().size() )
 			{

--- a/include/Gaffer/RecursiveChildIterator.h
+++ b/include/Gaffer/RecursiveChildIterator.h
@@ -47,7 +47,7 @@ namespace Gaffer
 /// RecursiveChildIterator provides a depth-first traversal over all the children of
 /// a GraphComponent. Use as follows :
 ///
-/// for( RecursiveChildIterator it( parent ); it != it.end(); ++it )
+/// for( RecursiveChildIterator it( parent ); !it.done(); ++it )
 /// ...
 class RecursiveChildIterator : public boost::iterator_facade<RecursiveChildIterator, const GraphComponentPtr, boost::forward_traversal_tag>
 {
@@ -93,16 +93,24 @@ class RecursiveChildIterator : public boost::iterator_facade<RecursiveChildItera
 			m_pruned = true;
 		}
 
+		bool done() const
+		{
+			return m_stack.size() == 1 && m_stack[0].it == m_stack[0].end;
+		}
+
+		/// \deprecated Comparison to end() is unreliable. Use done() instead.
 		bool operator==( const GraphComponent::ChildIterator &rhs ) const
 		{
 			return stackTop().it == rhs ;
 		}
 
+		/// \deprecated Comparison to end() is unreliable. Use done() instead.
 		bool operator!=( const GraphComponent::ChildIterator &rhs ) const
 		{
 			return stackTop().it != rhs;
 		}
 
+		/// \deprecated Comparison to end() is unreliable. Use done() instead.
 		const GraphComponent::ChildIterator &end() const
 		{
 			return m_stack[0].end;

--- a/include/Gaffer/Switch.inl
+++ b/include/Gaffer/Switch.inl
@@ -139,7 +139,7 @@ void Switch<BaseType>::affects( const Plug *input, DependencyNode::AffectedPlugs
 		{
 			if( out->children().size() )
 			{
-				for( RecursiveOutputPlugIterator it( out ); it != it.end(); ++it )
+				for( RecursiveOutputPlugIterator it( out ); !it.done(); ++it )
 				{
 					if( !(*it)->children().size() )
 					{

--- a/include/GafferImage/ImagePrimitiveSource.inl
+++ b/include/GafferImage/ImagePrimitiveSource.inl
@@ -59,7 +59,7 @@ ImagePrimitiveSource<BaseType>::ImagePrimitiveSource( const std::string &name )
 
 	// disable caching on our outputs, as we're basically caching the entire
 	// image ourselves in __inputImagePrimitive.
-	for( Gaffer::OutputPlugIterator it( BaseType::outPlug() ); it!=it.end(); it++ )
+	for( Gaffer::OutputPlugIterator it( BaseType::outPlug() ); !it.done(); ++it )
 	{
 		(*it)->setFlags( Gaffer::Plug::Cacheable, false );
 	}
@@ -77,7 +77,7 @@ void ImagePrimitiveSource<BaseType>::affects( const Gaffer::Plug *input, Gaffer:
 
 	if( input == inputImagePrimitivePlug() )
 	{
-		for( Gaffer::ValuePlugIterator it( BaseType::outPlug() ); it != it.end(); it++ )
+		for( Gaffer::ValuePlugIterator it( BaseType::outPlug() ); !it.done(); ++it )
 		{
 			outputs.push_back( it->get() );
 		}

--- a/python/GafferCortex/ObjectReader.py
+++ b/python/GafferCortex/ObjectReader.py
@@ -54,7 +54,7 @@ class ObjectReader( Gaffer.ComputeNode ) :
 
 	def affects( self, input ) :
 
-		outputs = []
+		outputs = Gaffer.ComputeNode.affects( self, input )
 		if input.isSame( self["fileName"] ) :
 			outputs.append( self["out"] )
 

--- a/python/GafferTest/AddNode.py
+++ b/python/GafferTest/AddNode.py
@@ -72,7 +72,7 @@ class AddNode( Gaffer.ComputeNode ) :
 
 	def affects( self, input ) :
 
-		outputs = []
+		outputs = Gaffer.ComputeNode.affects( self, input )
 		if input.getName() in ( "enabled", "op1", "op2" ) :
 			outputs.append( self.getChild( "sum" ) )
 

--- a/python/GafferTest/BadNode.py
+++ b/python/GafferTest/BadNode.py
@@ -54,7 +54,7 @@ class BadNode( Gaffer.ComputeNode ) :
 
 	def affects( self, input ) :
 
-		outputs = []
+		outputs = Gaffer.ComputeNode.affects( self, input )
 		if input.isSame( self["in1"] ) :
 			outputs.append( self["out1"] )
 		elif input.isSame( self["in2"] ) :

--- a/python/GafferTest/CachingTestNode.py
+++ b/python/GafferTest/CachingTestNode.py
@@ -51,10 +51,12 @@ class CachingTestNode( Gaffer.ComputeNode ) :
 
 	def affects( self, input ) :
 
-		if input.isSame( self["in"] ) :
-			return [ self["out"] ]
+		outputs = Gaffer.ComputeNode.affects( self, input )
 
-		return []
+		if input.isSame( self["in"] ) :
+			outputs.append( self["out"] )
+
+		return outputs
 
 	def hash( self, output, context, h ) :
 

--- a/python/GafferTest/ComputeNodeTest.py
+++ b/python/GafferTest/ComputeNodeTest.py
@@ -246,10 +246,6 @@ class ComputeNodeTest( GafferTest.TestCase ) :
 				self.addChild( Gaffer.ObjectPlug( "oOut", Gaffer.Plug.Direction.Out, IECore.NullObject() ) )
 				self.addChild( Gaffer.FloatPlug( "fOut", Gaffer.Plug.Direction.Out ) )
 
-			def affects( self, input ) :
-
-				return []
-
 			def hash( self, output, context, h ) :
 
 				h.append( context.getFrame() )
@@ -315,10 +311,12 @@ class ComputeNodeTest( GafferTest.TestCase ) :
 
 		def affects( self, input ) :
 
-			if input.isSame( self["in"] ) :
-				return [ self["out"] ]
+			outputs = Gaffer.ComputeNode.affects( self, input )
 
-			return []
+			if input.isSame( self["in"] ) :
+				outputs.append( self["out"] )
+
+			return outputs
 
 		def hash( self, output, context, h ) :
 

--- a/python/GafferTest/DependencyNodeTest.py
+++ b/python/GafferTest/DependencyNodeTest.py
@@ -119,10 +119,12 @@ class DependencyNodeTest( GafferTest.TestCase ) :
 				# leaf level plugs.
 				assert( not input.isSame( self["in"] ) )
 
-				if self["in"].isAncestorOf( input ) :
-					return [ self["out"] ]
+				outputs = Gaffer.DependencyNode.affects( self, input )
 
-				return []
+				if self["in"].isAncestorOf( input ) :
+					outputs.append( self["out"] )
+
+				return outputs
 
 		src = CompoundOut()
 		dst = CompoundIn()

--- a/python/GafferTest/SphereNode.py
+++ b/python/GafferTest/SphereNode.py
@@ -62,7 +62,8 @@ class SphereNode( Gaffer.ComputeNode ) :
 
 	def affects( self, input ) :
 
-		outputs = []
+		outputs = Gaffer.ComputeNode.affects( self, input )
+
 		if input.getName() in ( "radius", "zMin", "zMax", "theta" ) :
 			outputs.append( self["out"] )
 

--- a/python/GafferTest/StringInOutNode.py
+++ b/python/GafferTest/StringInOutNode.py
@@ -51,10 +51,12 @@ class StringInOutNode( Gaffer.ComputeNode ) :
 
 	def affects( self, input ) :
 
-		 if input.isSame( self["in"] ) :
-			return [ self["out"] ]
+		outputs = Gaffer.ComputeNode.affects( self, input )
 
-		 return []
+		if input.isSame( self["in"] ) :
+			outputs.append( self["out"] )
+
+		return outputs
 
 	def hash( self, output, context, h ) :
 

--- a/src/Gaffer/Animation.cpp
+++ b/src/Gaffer/Animation.cpp
@@ -324,7 +324,7 @@ Animation::CurvePlug *Animation::acquire( ValuePlug *plug )
 		throw IECore::Exception( "Plug does not belong to a node" );
 	}
 
-	for( RecursivePlugIterator it( plug->node() ); it != it.end(); ++it )
+	for( RecursivePlugIterator it( plug->node() ); !it.done(); ++it )
 	{
 		ValuePlug *valuePlug = runTimeCast<ValuePlug>( it->get() );
 		if( !valuePlug )

--- a/src/Gaffer/ArrayPlug.cpp
+++ b/src/Gaffer/ArrayPlug.cpp
@@ -114,7 +114,7 @@ void ArrayPlug::setInput( PlugPtr input )
 PlugPtr ArrayPlug::createCounterpart( const std::string &name, Direction direction ) const
 {
 	ArrayPlugPtr result = new ArrayPlug( name, direction, NULL, m_minSize, m_maxSize, getFlags() );
-	for( PlugIterator it( this ); it != it.end(); it++ )
+	for( PlugIterator it( this ); !it.done(); ++it )
 	{
 		result->addChild( (*it)->createCounterpart( (*it)->getName(), direction ) );
 	}

--- a/src/Gaffer/Box.cpp
+++ b/src/Gaffer/Box.cpp
@@ -84,7 +84,7 @@ Plug *Box::promotePlug( Plug *descendantPlug )
 	const Gaffer::TypeId *compoundTypesEnd = compoundTypes + 4;
 	if( find( compoundTypes, compoundTypesEnd, (Gaffer::TypeId)externalPlug->typeId() ) != compoundTypesEnd )
 	{
-		for( RecursivePlugIterator it( externalPlug.get() ); it != it.end(); ++it )
+		for( RecursivePlugIterator it( externalPlug.get() ); !it.done(); ++it )
 		{
 			(*it)->setFlags( Plug::Dynamic, true );
 			if( find( compoundTypes, compoundTypesEnd, (Gaffer::TypeId)(*it)->typeId() ) != compoundTypesEnd )
@@ -333,7 +333,7 @@ bool Box::validatePromotability( const Plug *descendantPlug, bool throwException
 	}
 
 	// check all the children of this plug too
-	for( RecursivePlugIterator it( descendantPlug ); it != it.end(); ++it )
+	for( RecursivePlugIterator it( descendantPlug ); !it.done(); ++it )
 	{
 		if( !validatePromotability( it->get(), throwExceptions, /* childPlug = */ true ) )
 		{
@@ -414,7 +414,7 @@ BoxPtr Box::create( Node *parent, const Set *childNodes )
 	{
 		Node *childNode = static_cast<Node *>( verifiedChildNodes->member( i ) );
 		// reroute any connections to external nodes
-		for( RecursivePlugIterator plugIt( childNode ); plugIt != plugIt.end(); plugIt++ )
+		for( RecursivePlugIterator plugIt( childNode ); !plugIt.done(); ++plugIt )
 		{
 			Plug *plug = plugIt->get();
 			if( plug->direction() == Plug::In )

--- a/src/Gaffer/Box.cpp
+++ b/src/Gaffer/Box.cpp
@@ -190,7 +190,7 @@ void Box::unpromotePlug( Plug *promotedDescendantPlug )
 	while( plugToRemove->parent<Plug>() && plugToRemove->parent<Plug>() != userPlug() )
 	{
 		plugToRemove = plugToRemove->parent<Plug>();
-		for( PlugIterator it( plugToRemove ); it != it.end(); ++it )
+		for( PlugIterator it( plugToRemove ); !it.done(); ++it )
 		{
 			if(
 				( (*it)->direction() == Plug::In && (*it)->outputs().size() ) ||
@@ -394,7 +394,7 @@ BoxPtr Box::create( Node *parent, const Set *childNodes )
 	// the changing contents. we can use this opportunity to weed out anything in childNodes
 	// which isn't a direct child of parent though.
 	StandardSetPtr verifiedChildNodes = new StandardSet();
-	for( NodeIterator nodeIt( parent ); nodeIt != nodeIt.end(); nodeIt++ )
+	for( NodeIterator nodeIt( parent ); !nodeIt.done(); ++nodeIt )
 	{
 		if( childNodes->contains( nodeIt->get() ) )
 		{
@@ -506,7 +506,7 @@ void Box::copyMetadata( const Plug *from, Plug *to )
 		Metadata::registerPlugValue( to, *it, Metadata::plugValue<IECore::Data>( from, *it ) );
 	}
 
-	for( PlugIterator it( from ); it != it.end(); ++it )
+	for( PlugIterator it( from ); !it.done(); ++it )
 	{
 		if( Plug *childTo = to->getChild<Plug>( (*it)->getName() ) )
 		{

--- a/src/Gaffer/CompoundDataPlug.cpp
+++ b/src/Gaffer/CompoundDataPlug.cpp
@@ -119,7 +119,7 @@ bool CompoundDataPlug::MemberPlug::acceptsChild( const Gaffer::GraphComponent *p
 PlugPtr CompoundDataPlug::MemberPlug::createCounterpart( const std::string &name, Direction direction ) const
 {
 	PlugPtr result = new MemberPlug( name, direction, getFlags() );
-	for( PlugIterator it( this ); it != it.end(); it++ )
+	for( PlugIterator it( this ); !it.done(); ++it )
 	{
 		result->addChild( (*it)->createCounterpart( (*it)->getName(), direction ) );
 	}
@@ -154,7 +154,7 @@ bool CompoundDataPlug::acceptsChild( const GraphComponent *potentialChild ) cons
 PlugPtr CompoundDataPlug::createCounterpart( const std::string &name, Direction direction ) const
 {
 	CompoundDataPlugPtr result = new CompoundDataPlug( name, direction, getFlags() );
-	for( PlugIterator it( this ); it != it.end(); it++ )
+	for( PlugIterator it( this ); !it.done(); ++it )
 	{
 		result->addChild( (*it)->createCounterpart( (*it)->getName(), direction ) );
 	}
@@ -212,7 +212,7 @@ void CompoundDataPlug::addMembers( const IECore::CompoundData *parameters, bool 
 void CompoundDataPlug::fillCompoundData( IECore::CompoundDataMap &compoundDataMap ) const
 {
 	std::string name;
-	for( MemberPlugIterator it( this ); it != it.end(); it++ )
+	for( MemberPlugIterator it( this ); !it.done(); ++it )
 	{
 		IECore::DataPtr data = memberDataAndName( it->get(), name );
 		if( data )
@@ -225,7 +225,7 @@ void CompoundDataPlug::fillCompoundData( IECore::CompoundDataMap &compoundDataMa
 IECore::MurmurHash CompoundDataPlug::hash() const
 {
 	IECore::MurmurHash h;
-	for( MemberPlugIterator it( this ); it != it.end(); ++it )
+	for( MemberPlugIterator it( this ); !it.done(); ++it )
 	{
 		const MemberPlug *plug = it->get();
 		bool active = true;
@@ -250,7 +250,7 @@ void CompoundDataPlug::hash( IECore::MurmurHash &h ) const
 void CompoundDataPlug::fillCompoundObject( IECore::CompoundObject::ObjectMap &compoundObjectMap ) const
 {
 	std::string name;
-	for( MemberPlugIterator it( this ); it != it.end(); it++ )
+	for( MemberPlugIterator it( this ); !it.done(); ++it )
 	{
 		IECore::DataPtr data = memberDataAndName( it->get(), name );
 		if( data )

--- a/src/Gaffer/CompoundPlug.cpp
+++ b/src/Gaffer/CompoundPlug.cpp
@@ -62,7 +62,7 @@ CompoundPlug::~CompoundPlug()
 PlugPtr CompoundPlug::createCounterpart( const std::string &name, Direction direction ) const
 {
 	CompoundPlugPtr result = new CompoundPlug( name, direction, getFlags() );
-	for( PlugIterator it( this ); it != it.end(); it++ )
+	for( PlugIterator it( this ); !it.done(); ++it )
 	{
 		result->addChild( (*it)->createCounterpart( (*it)->getName(), direction ) );
 	}

--- a/src/Gaffer/Expression.cpp
+++ b/src/Gaffer/Expression.cpp
@@ -278,7 +278,7 @@ void Expression::hash( const ValuePlug *output, const Context *context, IECore::
 	{
 		enginePlug()->hash( h );
 		expressionPlug()->hash( h );
-		for( ValuePlugIterator it( inPlug() ); it!=it.end(); it++ )
+		for( ValuePlugIterator it( inPlug() ); !it.done(); ++it )
 		{
 			(*it)->hash( h );
 			// We must hash the types of the input plugs, because
@@ -286,7 +286,7 @@ void Expression::hash( const ValuePlug *output, const Context *context, IECore::
 			// types may yield a different result from Engine::execute().
 			h.append( (*it)->typeId() );
 		}
-		for( ValuePlugIterator it( outPlug() ); it!=it.end(); it++ )
+		for( ValuePlugIterator it( outPlug() ); !it.done(); ++it )
 		{
 			// We also need to hash the types of the output plugs,
 			// because an identical expression with different output
@@ -323,7 +323,7 @@ void Expression::compute( ValuePlug *output, const Context *context ) const
 		if( m_engine )
 		{
 			std::vector<const ValuePlug *> inputs;
-			for( ValuePlugIterator it( inPlug() ); it != it.end(); ++it )
+			for( ValuePlugIterator it( inPlug() ); !it.done(); ++it )
 			{
 				inputs.push_back( it->get() );
 			}
@@ -356,7 +356,7 @@ void Expression::compute( ValuePlug *output, const Context *context ) const
 	{
 		ConstObjectVectorPtr values = executePlug()->getValue();
 		size_t index = 0;
-		for( ValuePlugIterator it( outPlug() ); it != it.end() && *it != outPlugChild; ++it )
+		for( ValuePlugIterator it( outPlug() ); !it.done() && *it != outPlugChild; ++it )
 		{
 			index++;
 		}
@@ -445,13 +445,13 @@ std::string Expression::transcribe( const std::string &expression, bool toIntern
 	}
 
 	std::vector<const ValuePlug *> internalPlugs, externalPlugs;
-	for( ValuePlugIterator it( inPlug() ); it != it.end(); ++it )
+	for( ValuePlugIterator it( inPlug() ); !it.done(); ++it )
 	{
 		internalPlugs.push_back( it->get() );
 		externalPlugs.push_back( (*it)->getInput<ValuePlug>() );
 	}
 
-	for( ValuePlugIterator it( outPlug() ); it != it.end(); ++it )
+	for( ValuePlugIterator it( outPlug() ); !it.done(); ++it )
 	{
 		internalPlugs.push_back( it->get() );
 		if( !(*it)->outputs().empty() )

--- a/src/Gaffer/Expression.cpp
+++ b/src/Gaffer/Expression.cpp
@@ -260,7 +260,7 @@ void Expression::affects( const Plug *input, AffectedPlugsContainer &outputs ) c
 	}
 	else if( input == executePlug() )
 	{
-		for( RecursiveValuePlugIterator it( outPlug() ); it != it.end(); ++it )
+		for( RecursiveValuePlugIterator it( outPlug() ); !it.done(); ++it )
 		{
 			if( !(*it)->children().size() )
 			{

--- a/src/Gaffer/Metadata.cpp
+++ b/src/Gaffer/Metadata.cpp
@@ -481,8 +481,7 @@ std::vector<Node*> Metadata::nodesWithMetadata( GraphComponent *root, IECore::In
 	}
 	else
 	{
-		RecursiveNodeIterator it( root );
-		for( ; it != it.end(); ++it )
+		for( RecursiveNodeIterator it( root ); !it.done(); ++it )
 		{
 			if( nodeValueInternal( it->get(), key, inherit, instanceOnly ) )
 			{
@@ -681,8 +680,7 @@ std::vector<Plug*> Metadata::plugsWithMetadata( GraphComponent *root, IECore::In
 	}
 	else
 	{
-		FilteredRecursiveChildIterator<TypePredicate<Plug> > it( root );
-		for( ; it != it.end(); ++it )
+		for( FilteredRecursiveChildIterator<TypePredicate<Plug> > it( root ); !it.done(); ++it )
 		{
 			if( plugValueInternal( it->get(), key, inherit, false ) )
 			{

--- a/src/Gaffer/Node.cpp
+++ b/src/Gaffer/Node.cpp
@@ -147,7 +147,7 @@ void Node::parentChanging( Gaffer::GraphComponent *newParent )
 		// process to avoid such changes invalidating our
 		// iterators.
 		vector<PlugPtr> toDisconnect;
-		for( RecursivePlugIterator it( this ); it!=it.end(); ++it )
+		for( RecursivePlugIterator it( this ); !it.done(); ++it )
 		{
 			if( Plug *input = (*it)->getInput<Plug>() )
 			{

--- a/src/Gaffer/Plug.cpp
+++ b/src/Gaffer/Plug.cpp
@@ -651,7 +651,7 @@ class Plug::DirtyPlugs
 				return;
 			}
 
-			for( DownstreamIterator it( plugToDirty ); it != it.end(); ++it )
+			for( DownstreamIterator it( plugToDirty ); !it.done(); ++it )
 			{
 				InsertedVertex v = insertVertex( &*it );
 				if( !it->getFlags( Plug::AcceptsDependencyCycles ) )

--- a/src/Gaffer/Plug.cpp
+++ b/src/Gaffer/Plug.cpp
@@ -269,7 +269,7 @@ bool Plug::acceptsInput( const Plug *input ) const
 	{
 		return false;
 	}
-	for( PlugIterator it1( this ), it2( input ); it1!=it1.end(); ++it1, ++it2 )
+	for( PlugIterator it1( this ), it2( input ); !it1.done(); ++it1, ++it2 )
 	{
 		if( !( *it1 )->acceptsInput( it2->get() ) )
 		{
@@ -312,14 +312,14 @@ void Plug::setInput( PlugPtr input, bool setChildInputs, bool updateParentInput 
 	{
 		if( !input )
 		{
-			for( PlugIterator it( this ); it!=it.end(); ++it )
+			for( PlugIterator it( this ); !it.done(); ++it )
 			{
 				(*it)->setInput( NULL, /* setChildInputs = */ true, /* updateParentInput = */ false );
 			}
 		}
 		else
 		{
-			for( PlugIterator it1( this ), it2( input.get() ); it1!=it1.end(); ++it1, ++it2 )
+			for( PlugIterator it1( this ), it2( input.get() ); !it1.done(); ++it1, ++it2 )
 			{
 				(*it1)->setInput( *it2, /* setChildInputs = */ true, /* updateParentInput = */ false );
 			}
@@ -444,7 +444,7 @@ void Plug::updateInputFromChildInputs( Plug *checkFirst )
 		return;
 	}
 
-	for( PlugIterator it1( this ), it2( candidateInput ); it1 != it1.end(); ++it1, ++it2 )
+	for( PlugIterator it1( this ), it2( candidateInput ); !it1.done(); ++it1, ++it2 )
 	{
 		if( (*it1)->getInput<Plug>() != it2->get() )
 		{
@@ -473,7 +473,7 @@ const Plug::OutputContainer &Plug::outputs() const
 PlugPtr Plug::createCounterpart( const std::string &name, Direction direction ) const
 {
 	PlugPtr result = new Plug( name, direction, getFlags() );
-	for( PlugIterator it( this ); it != it.end(); ++it )
+	for( PlugIterator it( this ); !it.done(); ++it )
 	{
 		result->addChild( (*it)->createCounterpart( (*it)->getName(), direction ) );
 	}
@@ -599,7 +599,7 @@ void Plug::propagateDirtinessForParentChange( Plug *plugToDirty )
 	// find them, propagating dirtiness at the leaves.
 	if( plugToDirty->children().size() )
 	{
-		for( PlugIterator it( plugToDirty ); it != it.end(); ++it )
+		for( PlugIterator it( plugToDirty ); !it.done(); ++it )
 		{
 			propagateDirtinessForParentChange( it->get() );
 		}

--- a/src/Gaffer/Random.cpp
+++ b/src/Gaffer/Random.cpp
@@ -172,7 +172,7 @@ void Random::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
 	if( input == seedPlug() || input == contextEntryPlug() )
 	{
 		outputs.push_back( outFloatPlug() );
-		for( ValuePlugIterator componentIt( outColorPlug() ); componentIt != componentIt.end(); componentIt++ )
+		for( ValuePlugIterator componentIt( outColorPlug() ); !componentIt.done(); ++componentIt )
 		{
 			outputs.push_back( componentIt->get() );
 		}
@@ -188,7 +188,7 @@ void Random::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
 		input == valuePlug()
 	)
 	{
-		for( ValuePlugIterator componentIt( outColorPlug() ); componentIt != componentIt.end(); componentIt++ )
+		for( ValuePlugIterator componentIt( outColorPlug() ); !componentIt.done(); ++componentIt )
 		{
 			outputs.push_back( componentIt->get() );
 		}

--- a/src/Gaffer/Reference.cpp
+++ b/src/Gaffer/Reference.cpp
@@ -167,7 +167,7 @@ void Reference::loadInternal( const std::string &fileName )
 		{
 			plug->setFlags( Plug::Dynamic, false );
 			convertPersistentMetadata( plug );
-			for( RecursivePlugIterator it( plug ); it != it.end(); ++it )
+			for( RecursivePlugIterator it( plug ); !it.done(); ++it )
 			{
 				(*it)->setFlags( Plug::Dynamic, false );
 				convertPersistentMetadata( it->get() );

--- a/src/Gaffer/Reference.cpp
+++ b/src/Gaffer/Reference.cpp
@@ -102,7 +102,7 @@ void Reference::loadInternal( const std::string &fileName )
 	// incoming plugs don't get renamed.
 
 	std::map<std::string, Plug *> previousPlugs;
-	for( PlugIterator it( this ); it != it.end(); ++it )
+	for( PlugIterator it( this ); !it.done(); ++it )
 	{
 		Plug *plug = it->get();
 		if( isReferencePlug( plug ) )
@@ -115,7 +115,7 @@ void Reference::loadInternal( const std::string &fileName )
 	// We don't export user plugs to references, but old versions of
 	// Gaffer did, so as above, we must get them out of the way during
 	// the load.
-	for( PlugIterator it( userPlug() ); it != it.end(); ++it )
+	for( PlugIterator it( userPlug() ); !it.done(); ++it )
 	{
 		Plug *plug = it->get();
 		if( isReferencePlug( plug ) )
@@ -327,7 +327,7 @@ void Reference::transferPersistentMetadata( const Plug *srcPlug, Plug *dstPlug )
 		Metadata::registerPlugValue( dstPlug, *it, value );
 	}
 
-	for( PlugIterator it( srcPlug ); it != it.end(); ++it )
+	for( PlugIterator it( srcPlug ); !it.done(); ++it )
 	{
 		if( Plug *dstChildPlug = dstPlug->getChild<Plug>( (*it)->getName() ) )
 		{

--- a/src/Gaffer/ScriptNode.cpp
+++ b/src/Gaffer/ScriptNode.cpp
@@ -543,7 +543,7 @@ void ScriptNode::deleteNodes( Node *parent, const Set *filter, bool reconnect )
 			DependencyNode *dependencyNode = IECore::runTimeCast<DependencyNode>( node );
 			if( reconnect && dependencyNode )
 			{
-				for( OutputPlugIterator it( node ); it != it.end(); ++it )
+				for( OutputPlugIterator it( node ); !it.done(); ++it )
 				{
 					Plug *inPlug = dependencyNode->correspondingInput( it->get() );
 					if ( !inPlug )

--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -629,7 +629,7 @@ void ValuePlug::setInput( PlugPtr input )
 PlugPtr ValuePlug::createCounterpart( const std::string &name, Direction direction ) const
 {
 	PlugPtr result = new ValuePlug( name, direction, getFlags() );
-	for( PlugIterator it( this ); it != it.end(); ++it )
+	for( PlugIterator it( this ); !it.done(); ++it )
 	{
 		result->addChild( (*it)->createCounterpart( (*it)->getName(), direction ) );
 	}
@@ -658,7 +658,7 @@ bool ValuePlug::settable() const
 		{
 			return false;
 		}
-		for( PlugIterator it( this ); it!=it.end(); ++it )
+		for( PlugIterator it( this ); !it.done(); ++it )
 		{
 			ValuePlug *valuePlug = IECore::runTimeCast<ValuePlug>( it->get() );
 			if( !valuePlug || !valuePlug->settable() )
@@ -699,7 +699,7 @@ void ValuePlug::setToDefault()
 	}
 	else
 	{
-		for( ValuePlugIterator it( this ); it != it.end(); ++it )
+		for( ValuePlugIterator it( this ); !it.done(); ++it )
 		{
 			(*it)->setToDefault();
 		}
@@ -714,7 +714,7 @@ bool ValuePlug::isSetToDefault() const
 	}
 	else
 	{
-		for( ValuePlugIterator it( this ); it != it.end(); ++it )
+		for( ValuePlugIterator it( this ); !it.done(); ++it )
 		{
 			if( !(*it)->isSetToDefault() )
 			{
@@ -733,7 +733,7 @@ IECore::MurmurHash ValuePlug::hash() const
 		// being used as a parent for other ValuePlugs. So
 		// return the combined hashes of our children.
 		IECore::MurmurHash result;
-		for( ValuePlugIterator it( this ); it!=it.end(); it++ )
+		for( ValuePlugIterator it( this ); !it.done(); ++it )
 		{
 			(*it)->hash( result );
 		}

--- a/src/GafferAppleseed/AppleseedLight.cpp
+++ b/src/GafferAppleseed/AppleseedLight.cpp
@@ -97,7 +97,7 @@ void AppleseedLight::loadShader( const std::string &shaderName )
 
 void AppleseedLight::hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	for( ValuePlugIterator it( parametersPlug() ); it != it.end(); ++it )
+	for( ValuePlugIterator it( parametersPlug() ); !it.done(); ++it )
 	{
 		(*it)->hash( h );
 	}
@@ -107,7 +107,7 @@ void AppleseedLight::hashLight( const Gaffer::Context *context, IECore::MurmurHa
 IECore::ObjectVectorPtr AppleseedLight::computeLight( const Gaffer::Context *context ) const
 {
 	IECore::LightPtr result = new IECore::Light( "as:" + modelPlug()->getValue() );
-	for( InputValuePlugIterator it( parametersPlug() ); it!=it.end(); it++ )
+	for( InputValuePlugIterator it( parametersPlug() ); !it.done(); ++it )
 	{
 		result->parameters()[(*it)->getName()] = CompoundDataPlug::extractDataFromPlug( it->get() );
 	}

--- a/src/GafferArnold/ArnoldLight.cpp
+++ b/src/GafferArnold/ArnoldLight.cpp
@@ -82,7 +82,7 @@ void ArnoldLight::loadShader( const std::string &shaderName )
 
 void ArnoldLight::hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	for( ValuePlugIterator it( parametersPlug() ); it != it.end(); ++it )
+	for( ValuePlugIterator it( parametersPlug() ); !it.done(); ++it )
 	{
 		(*it)->hash( h );
 	}
@@ -92,7 +92,7 @@ void ArnoldLight::hashLight( const Gaffer::Context *context, IECore::MurmurHash 
 IECore::ObjectVectorPtr ArnoldLight::computeLight( const Gaffer::Context *context ) const
 {
 	IECore::LightPtr result = new IECore::Light( "ai:" + shaderNamePlug()->getValue() );
-	for( InputValuePlugIterator it( parametersPlug() ); it!=it.end(); it++ )
+	for( InputValuePlugIterator it( parametersPlug() ); !it.done(); ++it )
 	{
 		result->parameters()[(*it)->getName()] = CompoundDataPlug::extractDataFromPlug( it->get() );
 	}

--- a/src/GafferBindings/CompoundNumericPlugBinding.cpp
+++ b/src/GafferBindings/CompoundNumericPlugBinding.cpp
@@ -74,7 +74,7 @@ class CompoundNumericPlugSerialiser : public ValuePlugSerialiser
 				return false;
 			}
 
-			for( PlugIterator it( plug ); it != it.end(); ++it )
+			for( PlugIterator it( plug ); !it.done(); ++it )
 			{
 				if( (*it)->getInput<Plug>() )
 				{

--- a/src/GafferCortex/CompoundParameterHandler.cpp
+++ b/src/GafferCortex/CompoundParameterHandler.cpp
@@ -108,7 +108,7 @@ Gaffer::Plug *CompoundParameterHandler::setupPlug( Gaffer::GraphComponent *plugP
 	// remove any child plugs we don't need
 
 	std::vector<Gaffer::PlugPtr> toRemove;
-	for( Gaffer::PlugIterator pIt( m_plug->children().begin(), m_plug->children().end() ); pIt!=pIt.end(); pIt++ )
+	for( Gaffer::PlugIterator pIt( m_plug.get() ); !pIt.done(); ++pIt )
 	{
 		if( (*pIt)->getName().string().compare( 0, 2, "__" ) == 0 )
 		{

--- a/src/GafferDispatch/Dispatcher.cpp
+++ b/src/GafferDispatch/Dispatcher.cpp
@@ -588,7 +588,7 @@ void Dispatcher::dispatch( const std::vector<NodePtr> &nodes ) const
 		}
 		else if ( const SubGraph *subGraph = runTimeCast<const SubGraph>( nIt->get() ) )
 		{
-			for ( RecursiveOutputPlugIterator plugIt( subGraph ); plugIt != plugIt.end(); ++plugIt )
+			for ( RecursiveOutputPlugIterator plugIt( subGraph ); !plugIt.done(); ++plugIt )
 			{
 				Node *sourceNode = plugIt->get()->source<Plug>()->node();
 				if ( ExecutableNode *executable = runTimeCast<ExecutableNode>( sourceNode ) )

--- a/src/GafferDispatch/ExecutableNode.cpp
+++ b/src/GafferDispatch/ExecutableNode.cpp
@@ -211,7 +211,7 @@ const Plug *ExecutableNode::dispatcherPlug() const
 
 void ExecutableNode::preTasks( const Context *context, Tasks &tasks ) const
 {
-	for( PlugIterator cIt( preTasksPlug() ); cIt != cIt.end(); ++cIt )
+	for( PlugIterator cIt( preTasksPlug() ); !cIt.done(); ++cIt )
 	{
 		Plug *source = (*cIt)->source<Plug>();
 		if( source != *cIt )
@@ -226,7 +226,7 @@ void ExecutableNode::preTasks( const Context *context, Tasks &tasks ) const
 
 void ExecutableNode::postTasks( const Context *context, Tasks &tasks ) const
 {
-	for( PlugIterator cIt( postTasksPlug() ); cIt != cIt.end(); ++cIt )
+	for( PlugIterator cIt( postTasksPlug() ); !cIt.done(); ++cIt )
 	{
 		Plug *source = (*cIt)->source<Plug>();
 		if( source != *cIt )

--- a/src/GafferImage/Display.cpp
+++ b/src/GafferImage/Display.cpp
@@ -362,7 +362,7 @@ void Display::affects( const Gaffer::Plug *input, AffectedPlugsContainer &output
 
 	if( input == portPlug() || input == updateCountPlug() )
 	{
-		for( ValuePlugIterator it( outPlug() ); it != it.end(); it++ )
+		for( ValuePlugIterator it( outPlug() ); !it.done(); ++it )
 		{
 			outputs.push_back( it->get() );
 		}

--- a/src/GafferImage/ImageMetadata.cpp
+++ b/src/GafferImage/ImageMetadata.cpp
@@ -98,7 +98,7 @@ IECore::ConstCompoundObjectPtr ImageMetadata::computeProcessedMetadata( const Ga
 	result->members() = inputMetadata->members();
 
 	std::string name;
-	for ( CompoundDataPlug::MemberPlugIterator it( p ); it != it.end(); ++it )
+	for ( CompoundDataPlug::MemberPlugIterator it( p ); !it.done(); ++it )
 	{
 		IECore::DataPtr d = p->memberDataAndName( it->get(), name );
 		if ( d )

--- a/src/GafferImage/ImageNode.cpp
+++ b/src/GafferImage/ImageNode.cpp
@@ -272,7 +272,7 @@ void ImageNode::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outp
 
 	if( input == enabledPlug() )
 	{
-		for( ValuePlugIterator it( outPlug() ); it != it.end(); it++ )
+		for( ValuePlugIterator it( outPlug() ); !it.done(); ++it )
 		{
 			outputs.push_back( it->get() );
 		}

--- a/src/GafferImage/ImageReader.cpp
+++ b/src/GafferImage/ImageReader.cpp
@@ -254,7 +254,7 @@ void ImageReader::affects( const Plug *input, AffectedPlugsContainer &outputs ) 
 		input == endModePlug()
 	)
 	{
-		for( ValuePlugIterator it( outPlug() ); it != it.end(); ++it )
+		for( ValuePlugIterator it( outPlug() ); !it.done(); ++it )
 		{
 			outputs.push_back( it->get() );
 		}

--- a/src/GafferImage/ImageSampler.cpp
+++ b/src/GafferImage/ImageSampler.cpp
@@ -104,7 +104,7 @@ void ImageSampler::affects( const Gaffer::Plug *input, AffectedPlugsContainer &o
 		input->parent<Plug>() == pixelPlug()
 	)
 	{
-		for( ValuePlugIterator componentIt( colorPlug() ); componentIt != componentIt.end(); ++componentIt )
+		for( ValuePlugIterator componentIt( colorPlug() ); !componentIt.done(); ++componentIt )
 		{
 			outputs.push_back( componentIt->get() );
 		}

--- a/src/GafferImage/Merge.cpp
+++ b/src/GafferImage/Merge.cpp
@@ -124,7 +124,7 @@ void Merge::hashDataWindow( const GafferImage::ImagePlug *output, const Gaffer::
 {
 	ImageProcessor::hashDataWindow( output, context, h );
 
-	for( ImagePlugIterator it( inPlugs() ); it != it.end(); ++it )
+	for( ImagePlugIterator it( inPlugs() ); !it.done(); ++it )
 	{
 		(*it)->dataWindowPlug()->hash( h );
 	}
@@ -133,7 +133,7 @@ void Merge::hashDataWindow( const GafferImage::ImagePlug *output, const Gaffer::
 Imath::Box2i Merge::computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const
 {
 	Imath::Box2i dataWindow;
-	for( ImagePlugIterator it( inPlugs() ); it != it.end(); ++it )
+	for( ImagePlugIterator it( inPlugs() ); !it.done(); ++it )
 	{
 		// We don't need to check that the plug is connected here as unconnected plugs don't have data windows.
 		dataWindow.extendBy( (*it)->dataWindowPlug()->getValue() );
@@ -146,7 +146,7 @@ void Merge::hashChannelNames( const GafferImage::ImagePlug *output, const Gaffer
 {
 	ImageProcessor::hashChannelNames( output, context, h );
 
-	for( ImagePlugIterator it( inPlugs() ); it != it.end(); ++it )
+	for( ImagePlugIterator it( inPlugs() ); !it.done(); ++it )
 	{
 		if( (*it)->getInput<ValuePlug>() )
 		{
@@ -160,7 +160,7 @@ IECore::ConstStringVectorDataPtr Merge::computeChannelNames( const Gaffer::Conte
 	IECore::StringVectorDataPtr outChannelStrVectorData( new IECore::StringVectorData() );
 	std::vector<std::string> &outChannels( outChannelStrVectorData->writable() );
 
-	for( ImagePlugIterator it( inPlugs() ); it != it.end(); ++it )
+	for( ImagePlugIterator it( inPlugs() ); !it.done(); ++it )
 	{
 		if( (*it)->getInput<ValuePlug>() )
 		{
@@ -192,7 +192,7 @@ void Merge::hashChannelData( const GafferImage::ImagePlug *output, const Gaffer:
 	const V2i tileOrigin = context->get<V2i>( ImagePlug::tileOriginContextName );
 	const Box2i tileBound( tileOrigin, tileOrigin + V2i( ImagePlug::tileSize() ) );
 
-	for( ImagePlugIterator it( inPlugs() ); it != it.end(); ++it )
+	for( ImagePlugIterator it( inPlugs() ); !it.done(); ++it )
 	{
 		if( !(*it)->getInput<ValuePlug>() )
 		{
@@ -271,7 +271,7 @@ IECore::ConstFloatVectorDataPtr Merge::merge( F f, const std::string &channelNam
 
 	const Box2i tileBound( tileOrigin, tileOrigin + V2i( ImagePlug::tileSize() ) );
 
-	for( ImagePlugIterator it( inPlugs() ); it != it.end(); ++it )
+	for( ImagePlugIterator it( inPlugs() ); !it.done(); ++it )
 	{
 		if( !(*it)->getInput<ValuePlug>() )
 		{

--- a/src/GafferImage/ObjectToImage.cpp
+++ b/src/GafferImage/ObjectToImage.cpp
@@ -73,7 +73,7 @@ void ObjectToImage::affects( const Gaffer::Plug *input, AffectedPlugsContainer &
 
 	if( input == objectPlug() )
 	{
-		for( ValuePlugIterator it( outPlug() ); it != it.end(); it++ )
+		for( ValuePlugIterator it( outPlug() ); !it.done(); ++it )
 		{
 			outputs.push_back( it->get() );
 		}

--- a/src/GafferImage/OpenImageIOReader.cpp
+++ b/src/GafferImage/OpenImageIOReader.cpp
@@ -370,7 +370,7 @@ OpenImageIOReader::OpenImageIOReader( const std::string &name )
 	addChild( new IntVectorDataPlug( "availableFrames", Plug::Out, new IntVectorData ) );
 
 	// disable caching on our outputs, as OIIO is already doing caching for us.
-	for( OutputPlugIterator it( outPlug() ); it!=it.end(); it++ )
+	for( OutputPlugIterator it( outPlug() ); !it.done(); ++it )
 	{
 		(*it)->setFlags( Plug::Cacheable, false );
 	}
@@ -457,7 +457,7 @@ void OpenImageIOReader::affects( const Gaffer::Plug *input, AffectedPlugsContain
 
 	if( input == fileNamePlug() || input == refreshCountPlug() || input == missingFrameModePlug() )
 	{
-		for( ValuePlugIterator it( outPlug() ); it != it.end(); it++ )
+		for( ValuePlugIterator it( outPlug() ); !it.done(); ++it )
 		{
 			outputs.push_back( it->get() );
 		}

--- a/src/GafferImage/Shuffle.cpp
+++ b/src/GafferImage/Shuffle.cpp
@@ -151,7 +151,7 @@ void Shuffle::hashChannelNames( const GafferImage::ImagePlug *parent, const Gaff
 {
 	ImageProcessor::hashChannelNames( parent, context, h );
 	inPlug()->channelNamesPlug()->hash( h );
-	for( ChannelPlugIterator it( channelsPlug() ); it != it.end(); ++it )
+	for( ChannelPlugIterator it( channelsPlug() ); !it.done(); ++it )
 	{
 		(*it)->outPlug()->hash( h );
 	}
@@ -161,7 +161,7 @@ IECore::ConstStringVectorDataPtr Shuffle::computeChannelNames( const Gaffer::Con
 {
 	StringVectorDataPtr resultData = inPlug()->channelNamesPlug()->getValue()->copy();
 	vector<string> &result = resultData->writable();
-	for( ChannelPlugIterator it( channelsPlug() ); it != it.end(); ++it )
+	for( ChannelPlugIterator it( channelsPlug() ); !it.done(); ++it )
 	{
 		string channelName = (*it)->outPlug()->getValue();
 		if( channelName != "" && find( result.begin(), result.end(), channelName ) == result.end() )
@@ -218,7 +218,7 @@ IECore::ConstFloatVectorDataPtr Shuffle::computeChannelData( const std::string &
 
 std::string Shuffle::inChannelName( const std::string &outChannelName ) const
 {
-	for( ChannelPlugIterator it( channelsPlug() ); it != it.end(); ++it )
+	for( ChannelPlugIterator it( channelsPlug() ); !it.done(); ++it )
 	{
 		if( (*it)->outPlug()->getValue() == outChannelName )
 		{

--- a/src/GafferRenderMan/RenderManLight.cpp
+++ b/src/GafferRenderMan/RenderManLight.cpp
@@ -67,7 +67,7 @@ void RenderManLight::loadShader( const std::string &shaderName )
 
 void RenderManLight::hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	for( ValuePlugIterator it( parametersPlug() ); it != it.end(); ++it )
+	for( ValuePlugIterator it( parametersPlug() ); !it.done(); ++it )
 	{
 		(*it)->hash( h );
 	}
@@ -77,7 +77,7 @@ void RenderManLight::hashLight( const Gaffer::Context *context, IECore::MurmurHa
 IECore::ObjectVectorPtr RenderManLight::computeLight( const Gaffer::Context *context ) const
 {
 	IECore::LightPtr result = new IECore::Light( "ri:" + shaderNamePlug()->getValue() );
-	for( InputValuePlugIterator it( parametersPlug() ); it!=it.end(); it++ )
+	for( InputValuePlugIterator it( parametersPlug() ); !it.done(); ++it )
 	{
 		result->parameters()[(*it)->getName()] = CompoundDataPlug::extractDataFromPlug( it->get() );
 	}

--- a/src/GafferRenderMan/RenderManShader.cpp
+++ b/src/GafferRenderMan/RenderManShader.cpp
@@ -257,7 +257,7 @@ void RenderManShader::parameterHash( const Gaffer::Plug *parameterPlug, NetworkB
 	if( parameterPlug->isInstanceOf( ArrayPlug::staticTypeId() ) )
 	{
 		// coshader array parameter
-		for( InputPlugIterator cIt( parameterPlug ); cIt != cIt.end(); ++cIt )
+		for( InputPlugIterator cIt( parameterPlug ); !cIt.done(); ++cIt )
 		{
 			Shader::parameterHash( cIt->get(), network, h );
 		}
@@ -291,7 +291,7 @@ IECore::DataPtr RenderManShader::parameterValue( const Gaffer::Plug *parameterPl
 	{
 		// coshader array parameter
 		StringVectorDataPtr value = new StringVectorData();
-		for( InputPlugIterator cIt( parameterPlug ); cIt != cIt.end(); ++cIt )
+		for( InputPlugIterator cIt( parameterPlug ); !cIt.done(); ++cIt )
 		{
 			const Plug *inputPlug = (*cIt)->source<Plug>();
 			const RenderManShader *inputShader = inputPlug && inputPlug != *cIt ? inputPlug->parent<RenderManShader>() : 0;

--- a/src/GafferScene/Attributes.cpp
+++ b/src/GafferScene/Attributes.cpp
@@ -131,7 +131,7 @@ IECore::ConstCompoundObjectPtr Attributes::computeGlobals( const Gaffer::Context
 	result->members() = inputGlobals->members();
 
 	std::string name;
-	for( CompoundDataPlug::MemberPlugIterator it( p ); it != it.end(); ++it )
+	for( CompoundDataPlug::MemberPlugIterator it( p ); !it.done(); ++it )
 	{
 		IECore::DataPtr d = p->memberDataAndName( it->get(), name );
 		if( d )

--- a/src/GafferScene/FilterProcessor.cpp
+++ b/src/GafferScene/FilterProcessor.cpp
@@ -106,7 +106,7 @@ const Gaffer::ArrayPlug *FilterProcessor::inPlugs() const
 
 bool FilterProcessor::sceneAffectsMatch( const ScenePlug *scene, const Gaffer::ValuePlug *child ) const
 {
-	for( InputIntPlugIterator it( inPlugs() ); it != it.end(); ++it )
+	for( InputIntPlugIterator it( inPlugs() ); !it.done(); ++it )
 	{
 		const Filter *filter = IECore::runTimeCast<const Filter>( (*it)->source<Plug>()->node() );
 		if( filter && filter != this && filter->sceneAffectsMatch( scene, child ) )

--- a/src/GafferScene/Group.cpp
+++ b/src/GafferScene/Group.cpp
@@ -124,7 +124,7 @@ void Group::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
 
 	if( input == namePlug() )
 	{
-		for( ValuePlugIterator it( outPlug() ); it != it.end(); it++ )
+		for( ValuePlugIterator it( outPlug() ); !it.done(); ++it )
 		{
 			outputs.push_back( it->get() );
 		}
@@ -150,7 +150,7 @@ void Group::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
 	else if( input == mappingPlug() )
 	{
 		// the mapping affects everything about the output
-		for( ValuePlugIterator it( outPlug() ); it != it.end(); it++ )
+		for( ValuePlugIterator it( outPlug() ); !it.done(); ++it )
 		{
 			outputs.push_back( it->get() );
 		}
@@ -167,7 +167,7 @@ void Group::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *contex
 		ContextPtr tmpContext = new Context( *context, Context::Borrowed );
 		tmpContext->set( ScenePlug::scenePathContextName, ScenePath() );
 		Context::Scope scopedContext( tmpContext.get() );
-		for( ScenePlugIterator it( inPlugs() ); it != it.end(); ++it )
+		for( ScenePlugIterator it( inPlugs() ); !it.done(); ++it )
 		{
 			(*it)->childNamesPlug()->hash( h );
 		}
@@ -190,7 +190,7 @@ void Group::hashBound( const ScenePath &path, const Gaffer::Context *context, co
 	if( path.size() == 0 ) // "/"
 	{
 		SceneProcessor::hashBound( path, context, parent, h );
-		for( ScenePlugIterator it( inPlugs() ); it != it.end(); ++it )
+		for( ScenePlugIterator it( inPlugs() ); !it.done(); ++it )
 		{
 			(*it)->boundPlug()->hash( h );
 		}
@@ -202,7 +202,7 @@ void Group::hashBound( const ScenePath &path, const Gaffer::Context *context, co
 		ContextPtr tmpContext = new Context( *context, Context::Borrowed );
 		tmpContext->set( ScenePlug::scenePathContextName, ScenePath() );
 		Context::Scope scopedContext( tmpContext.get() );
-		for( ScenePlugIterator it( inPlugs() ); it != it.end(); ++it )
+		for( ScenePlugIterator it( inPlugs() ); !it.done(); ++it )
 		{
 			(*it)->boundPlug()->hash( h );
 		}
@@ -224,7 +224,7 @@ Imath::Box3f Group::computeBound( const ScenePath &path, const Gaffer::Context *
 	{
 		// either / or /groupName
 		Box3f combinedBound;
-		for( ScenePlugIterator it( inPlugs() ); it != it.end(); ++it )
+		for( ScenePlugIterator it( inPlugs() ); !it.done(); ++it )
 		{
 			// we don't need to transform these bounds, because the SceneNode
 			// guarantees that the transform for root nodes is always identity.
@@ -394,7 +394,7 @@ IECore::ConstInternedStringVectorDataPtr Group::computeChildNames( const ScenePa
 void Group::hashSetNames( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
 	SceneProcessor::hashSetNames( context, parent, h );
-	for( ScenePlugIterator it( inPlugs() ); it != it.end(); ++it )
+	for( ScenePlugIterator it( inPlugs() ); !it.done(); ++it )
 	{
 		(*it)->setNamesPlug()->hash( h );
 	}
@@ -404,7 +404,7 @@ IECore::ConstInternedStringVectorDataPtr Group::computeSetNames( const Gaffer::C
 {
 	InternedStringVectorDataPtr resultData = new InternedStringVectorData;
 	vector<InternedString> &result = resultData->writable();
-	for( ScenePlugIterator it( inPlugs() ); it != it.end(); ++it )
+	for( ScenePlugIterator it( inPlugs() ); !it.done(); ++it )
 	{
 		// This naive approach to merging set names preserves the order of the incoming names,
 		// but at the expense of using linear search. We assume that the number of sets is small
@@ -426,7 +426,7 @@ IECore::ConstInternedStringVectorDataPtr Group::computeSetNames( const Gaffer::C
 void Group::hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
 	SceneProcessor::hashSet( setName, context, parent, h );
-	for( ScenePlugIterator it( inPlugs() ); it != it.end(); ++it )
+	for( ScenePlugIterator it( inPlugs() ); !it.done(); ++it )
 	{
 		(*it)->setPlug()->hash( h );
 	}
@@ -496,7 +496,7 @@ IECore::ObjectPtr Group::computeMapping( const Gaffer::Context *context ) const
 	boost::format namePrefixSuffixFormatter( "%s%d" );
 
 	set<InternedString> allNames;
-	for( ScenePlugIterator it( inPlugs() ); it != it.end(); ++it )
+	for( ScenePlugIterator it( inPlugs() ); !it.done(); ++it )
 	{
 		ConstInternedStringVectorDataPtr inChildNamesData = (*it)->childNames( ScenePath() );
 		CompoundDataPtr forwardMapping = new CompoundData;

--- a/src/GafferScene/Options.cpp
+++ b/src/GafferScene/Options.cpp
@@ -97,7 +97,7 @@ IECore::ConstCompoundObjectPtr Options::computeProcessedGlobals( const Gaffer::C
 	result->members() = inputGlobals->members();
 
 	std::string name;
-	for( CompoundDataPlug::MemberPlugIterator it( p ); it != it.end(); ++it )
+	for( CompoundDataPlug::MemberPlugIterator it( p ); !it.done(); ++it )
 	{
 		IECore::DataPtr d = p->memberDataAndName( it->get(), name );
 		if( d )

--- a/src/GafferScene/Outputs.cpp
+++ b/src/GafferScene/Outputs.cpp
@@ -187,7 +187,7 @@ IECore::ConstCompoundObjectPtr Outputs::computeProcessedGlobals( const Gaffer::C
 	result->members() = inputGlobals->members();
 
 	// add our outputs to the result
-	for( InputValuePlugIterator it( dsp ); it != it.end(); it++ )
+	for( InputValuePlugIterator it( dsp ); !it.done(); ++it )
 	{
 		const ValuePlug *outputPlug = it->get();
 		if( outputPlug->getChild<BoolPlug>( "active" )->getValue() )

--- a/src/GafferScene/PrimitiveVariables.cpp
+++ b/src/GafferScene/PrimitiveVariables.cpp
@@ -109,7 +109,7 @@ IECore::ConstObjectPtr PrimitiveVariables::computeProcessedObject( const ScenePa
 	PrimitivePtr result = inputPrimitive->copy();
 
 	std::string name;
-	for( CompoundDataPlug::MemberPlugIterator it( p ); it != it.end(); ++it )
+	for( CompoundDataPlug::MemberPlugIterator it( p ); !it.done(); ++it )
 	{
 		IECore::DataPtr d = p->memberDataAndName( it->get(), name );
 		if( d )

--- a/src/GafferScene/SceneElementProcessor.cpp
+++ b/src/GafferScene/SceneElementProcessor.cpp
@@ -81,7 +81,7 @@ void SceneElementProcessor::affects( const Plug *input, AffectedPlugsContainer &
 	}
 	else if( input == filterPlug() )
 	{
-		for( ValuePlugIterator it( outPlug() ); it != it.end(); it++ )
+		for( ValuePlugIterator it( outPlug() ); !it.done(); ++it )
 		{
 			outputs.push_back( it->get() );
 		}

--- a/src/GafferScene/SceneNode.cpp
+++ b/src/GafferScene/SceneNode.cpp
@@ -87,7 +87,7 @@ void SceneNode::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outp
 
 	if( input == enabledPlug() )
 	{
-		for( ValuePlugIterator it( outPlug() ); it != it.end(); it++ )
+		for( ValuePlugIterator it( outPlug() ); !it.done(); ++it )
 		{
 			outputs.push_back( it->get() );
 		}

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -374,7 +374,7 @@ IECore::MurmurHash Shader::NetworkBuilder::shaderHash( const Shader *shaderNode 
 
 void Shader::NetworkBuilder::parameterHashWalk( const Shader *shaderNode, const Gaffer::Plug *parameterPlug, IECore::MurmurHash &h )
 {
-	for( InputPlugIterator it( parameterPlug ); it != it.end(); ++it )
+	for( InputPlugIterator it( parameterPlug ); !it.done(); ++it )
 	{
 		if( (*it)->typeId() == CompoundPlug::staticTypeId() )
 		{
@@ -434,7 +434,7 @@ IECore::StateRenderable *Shader::NetworkBuilder::shader( const Shader *shaderNod
 
 void Shader::NetworkBuilder::parameterValueWalk( const Shader *shaderNode, const Gaffer::Plug *parameterPlug, const IECore::InternedString &parameterName, IECore::CompoundDataMap &values )
 {
-	for( InputPlugIterator it( parameterPlug ); it != it.end(); ++it )
+	for( InputPlugIterator it( parameterPlug ); !it.done(); ++it )
 	{
 		IECore::InternedString childParameterName;
 		if( parameterName.string().size() )

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -192,7 +192,7 @@ void Shader::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs
 		{
 			if( !out->children().empty() )
 			{
-				for( RecursivePlugIterator it( out ); it != it.end(); it++ )
+				for( RecursivePlugIterator it( out ); !it.done(); it++ )
 				{
 					if( (*it)->children().empty() )
 					{

--- a/src/GafferScene/UnionFilter.cpp
+++ b/src/GafferScene/UnionFilter.cpp
@@ -65,7 +65,7 @@ void UnionFilter::affects( const Gaffer::Plug *input, AffectedPlugsContainer &ou
 
 void UnionFilter::hashMatch( const ScenePlug *scene, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	for( InputIntPlugIterator it( inPlugs() ); it != it.end(); ++it )
+	for( InputIntPlugIterator it( inPlugs() ); !it.done(); ++it )
 	{
 		(*it)->hash( h );
 	}
@@ -74,7 +74,7 @@ void UnionFilter::hashMatch( const ScenePlug *scene, const Gaffer::Context *cont
 unsigned UnionFilter::computeMatch( const ScenePlug *scene, const Gaffer::Context *context ) const
 {
 	unsigned result = NoMatch;
-	for( InputIntPlugIterator it( inPlugs() ); it != it.end(); ++it )
+	for( InputIntPlugIterator it( inPlugs() ); !it.done(); ++it )
 	{
 		result |= (*it)->getValue();
 	}

--- a/src/GafferSceneTest/CompoundObjectSource.cpp
+++ b/src/GafferSceneTest/CompoundObjectSource.cpp
@@ -70,7 +70,7 @@ void CompoundObjectSource::affects( const Plug *input, AffectedPlugsContainer &o
 	SceneNode::affects( input, outputs );
 	if( input == inPlug() )
 	{
-		for( ValuePlugIterator it( outPlug() ); it != it.end(); it++ )
+		for( ValuePlugIterator it( outPlug() ); !it.done(); ++it )
 		{
 			outputs.push_back( it->get() );
 		}

--- a/src/GafferSceneTest/TestLight.cpp
+++ b/src/GafferSceneTest/TestLight.cpp
@@ -56,7 +56,7 @@ TestLight::~TestLight()
 
 void TestLight::hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	for( ValuePlugIterator it( parametersPlug() ); it != it.end(); ++it )
+	for( ValuePlugIterator it( parametersPlug() ); !it.done(); ++it )
 	{
 		(*it)->hash( h );
 	}

--- a/src/GafferSceneUI/CropWindowTool.cpp
+++ b/src/GafferSceneUI/CropWindowTool.cpp
@@ -624,7 +624,7 @@ bool CropWindowTool::findCropWindowPlugFromNode( GafferScene::ScenePlug *scene, 
 		return false;
 	}
 
-	for( CompoundDataPlug::MemberPlugIterator it( options->optionsPlug() ); it != it.end(); ++it )
+	for( CompoundDataPlug::MemberPlugIterator it( options->optionsPlug() ); !it.done(); ++it )
 	{
 		CompoundDataPlug::MemberPlug *memberPlug = it->get();
 		if( memberPlug->namePlug()->getValue() != "render:cropWindow" )

--- a/src/GafferSceneUIBindings/SceneHierarchyBinding.cpp
+++ b/src/GafferSceneUIBindings/SceneHierarchyBinding.cpp
@@ -95,7 +95,7 @@ class SceneHierarchyFilter : public Gaffer::PathFilter
 			if( m_scene )
 			{
 				node = const_cast<Node *>( m_scene->node() );
-				for( ValuePlugIterator it( m_scene.get() ); it != it.end(); ++it )
+				for( ValuePlugIterator it( m_scene.get() ); !it.done(); ++it )
 				{
 					sceneDirtied( it->get() );
 				}

--- a/src/GafferTest/DownstreamIteratorTest.cpp
+++ b/src/GafferTest/DownstreamIteratorTest.cpp
@@ -72,8 +72,8 @@ void GafferTest::testDownstreamIterator()
 	GAFFERTEST_ASSERT( it1.upstream() == a->floatRangePlug()->getChild( 0 ) );
 	GAFFERTEST_ASSERT( it2.upstream() == a->floatRangePlug()->getChild( 0 ) );
 	GAFFERTEST_ASSERT( it1 == it2 );
-	GAFFERTEST_ASSERT( it1 != it1.end() );
-	GAFFERTEST_ASSERT( it2 != it2.end() );
+	GAFFERTEST_ASSERT( !it1.done() );
+	GAFFERTEST_ASSERT( !it2.done() );
 
 	it1++;
 
@@ -82,8 +82,8 @@ void GafferTest::testDownstreamIterator()
 	GAFFERTEST_ASSERT( it1.upstream() == a->outFloatPlug() );
 	GAFFERTEST_ASSERT( it2.upstream() == a->floatRangePlug()->getChild( 0 ) );
 	GAFFERTEST_ASSERT( it1 != it2 );
-	GAFFERTEST_ASSERT( it1 != it1.end() );
-	GAFFERTEST_ASSERT( it2 != it2.end() );
+	GAFFERTEST_ASSERT( !it1.done() );
+	GAFFERTEST_ASSERT( !it2.done() );
 
 	it2 = it1;
 
@@ -92,11 +92,11 @@ void GafferTest::testDownstreamIterator()
 	GAFFERTEST_ASSERT( it1.upstream() == a->outFloatPlug() );
 	GAFFERTEST_ASSERT( it2.upstream() == a->outFloatPlug() );
 	GAFFERTEST_ASSERT( it1 == it2 );
-	GAFFERTEST_ASSERT( it1 != it1.end() );
-	GAFFERTEST_ASSERT( it2 != it2.end() );
+	GAFFERTEST_ASSERT( !it1.done() );
+	GAFFERTEST_ASSERT( !it2.done() );
 
 	std::vector<const Plug *> visited;
-	for( DownstreamIterator it( a->floatRangePlug()->getChild( 0 ) ); it != it.end(); ++it )
+	for( DownstreamIterator it( a->floatRangePlug()->getChild( 0 ) ); !it.done(); ++it )
 	{
 		visited.push_back( &*it );
 	}
@@ -115,7 +115,7 @@ void GafferTest::testDownstreamIterator()
 	// test pruning
 
 	visited.clear();
-	for( DownstreamIterator it( a->floatRangePlug()->getChild( 0 ) ); it != it.end(); ++it )
+	for( DownstreamIterator it( a->floatRangePlug()->getChild( 0 ) ); !it.done(); ++it )
 	{
 		visited.push_back( &*it );
 		if( &*it == d->floatRangePlug()->getChild( 0 ) || &*it == c->outFloatPlug() )

--- a/src/GafferTest/FilteredRecursiveChildIteratorTest.cpp
+++ b/src/GafferTest/FilteredRecursiveChildIteratorTest.cpp
@@ -71,7 +71,7 @@ void GafferTest::testFilteredRecursiveChildIterator()
 	//       - h
 
 	std::vector<NodePtr> nodes;
-	for( RecursiveNodeIterator it( a.get() ); it != it.end(); it++ )
+	for( RecursiveNodeIterator it( a.get() ); !it.done(); it++ )
 	{
 		nodes.push_back( *it );
 	}
@@ -89,7 +89,7 @@ void GafferTest::testFilteredRecursiveChildIterator()
 
 	typedef FilteredRecursiveChildIterator<PlugPredicate<>, TypePredicate<GraphComponent> > DeepRecursivePlugIterator;
 	std::vector<PlugPtr> plugs;
-	for( DeepRecursivePlugIterator it( a.get() ); it != it.end(); it++ )
+	for( DeepRecursivePlugIterator it( a.get() ); !it.done(); it++ )
 	{
 		plugs.push_back( *it );
 	}
@@ -106,7 +106,7 @@ void GafferTest::testFilteredRecursiveChildIterator()
 
 	typedef FilteredRecursiveChildIterator<PlugPredicate<Plug::Invalid, FloatPlug>, TypePredicate<GraphComponent> > DeepRecursiveFloatPlugIterator;
 	plugs.clear();
-	for( DeepRecursiveFloatPlugIterator it( a.get() ); it != it.end(); it++ )
+	for( DeepRecursiveFloatPlugIterator it( a.get() ); !it.done(); it++ )
 	{
 		plugs.push_back( *it );
 	}
@@ -118,7 +118,7 @@ void GafferTest::testFilteredRecursiveChildIterator()
 
 	typedef FilteredRecursiveChildIterator<PlugPredicate<Plug::Out, FloatPlug>, TypePredicate<GraphComponent> > DeepRecursiveOutputFloatPlugIterator;
 	plugs.clear();
-	for( DeepRecursiveOutputFloatPlugIterator it( a.get() ); it != it.end(); it++ )
+	for( DeepRecursiveOutputFloatPlugIterator it( a.get() ); !it.done(); it++ )
 	{
 		plugs.push_back( *it );
 	}
@@ -133,7 +133,7 @@ void GafferTest::testFilteredRecursiveChildIterator()
 
 	typedef FilteredRecursiveChildIterator<PlugPredicate<>, PlugPredicate<> > ShallowRecursivePlugIterator;
 	plugs.clear();
-	for( ShallowRecursivePlugIterator it( a.get() ); it != it.end(); it++ )
+	for( ShallowRecursivePlugIterator it( a.get() ); !it.done(); it++ )
 	{
 		plugs.push_back( *it );
 	}
@@ -141,7 +141,7 @@ void GafferTest::testFilteredRecursiveChildIterator()
 	GAFFERTEST_ASSERT( plugs[0] == a->userPlug() );
 
 	plugs.clear();
-	for( ShallowRecursivePlugIterator it( b.get() ); it != it.end(); it++ )
+	for( ShallowRecursivePlugIterator it( b.get() ); !it.done(); it++ )
 	{
 		plugs.push_back( *it );
 	}
@@ -150,7 +150,7 @@ void GafferTest::testFilteredRecursiveChildIterator()
 	GAFFERTEST_ASSERT( plugs[1] == c );
 
 	plugs.clear();
-	for( ShallowRecursivePlugIterator it( e.get() ); it != it.end(); it++ )
+	for( ShallowRecursivePlugIterator it( e.get() ); !it.done(); it++ )
 	{
 		plugs.push_back( *it );
 	}

--- a/src/GafferTest/RecursiveChildIteratorTest.cpp
+++ b/src/GafferTest/RecursiveChildIteratorTest.cpp
@@ -89,7 +89,7 @@ void GafferTest::testRecursiveChildIterator()
 	GAFFERTEST_ASSERT( it1 == it2 );
 
 	std::vector<GraphComponentPtr> visited;
-	for( RecursiveChildIterator it( a.get() ); it != it.end(); ++it )
+	for( RecursiveChildIterator it( a.get() ); !it.done(); ++it )
 	{
 		visited.push_back( *it );
 	}
@@ -105,7 +105,7 @@ void GafferTest::testRecursiveChildIterator()
 	// test pruning
 
 	visited.clear();
-	for( RecursiveChildIterator it( a.get() ); it != it.end(); ++it )
+	for( RecursiveChildIterator it( a.get() ); !it.done(); ++it )
 	{
 		if( *it == e || *it == b )
 		{
@@ -122,7 +122,7 @@ void GafferTest::testRecursiveChildIterator()
 	GAFFERTEST_ASSERT( visited[4] == f );
 
 	visited.clear();
-	for( RecursiveChildIterator it( a.get() ); it != it.end(); ++it )
+	for( RecursiveChildIterator it( a.get() ); !it.done(); ++it )
 	{
 		if( *it == b || *it == d )
 		{

--- a/src/GafferUI/BackdropNodeGadget.cpp
+++ b/src/GafferUI/BackdropNodeGadget.cpp
@@ -185,7 +185,7 @@ void BackdropNodeGadget::framed( std::vector<Gaffer::Node *> &nodes ) const
 	const Box3f bound3 = transformedBound( graphGadget );
 	const Box2f bound2( V2f( bound3.min.x, bound3.min.y ), V2f( bound3.max.x, bound3.max.y ) );
 
-	for( NodeIterator it( nodeParent ); it != it.end(); ++it )
+	for( NodeIterator it( nodeParent ); !it.done(); ++it )
 	{
 		if( node() == it->get() )
 		{

--- a/src/GafferUI/CompoundNodule.cpp
+++ b/src/GafferUI/CompoundNodule.cpp
@@ -101,7 +101,7 @@ CompoundNodule::CompoundNodule( Gaffer::PlugPtr plug, LinearContainer::Orientati
 	plug->childAddedSignal().connect( boost::bind( &CompoundNodule::childAdded, this, ::_1,  ::_2 ) );
 	plug->childRemovedSignal().connect( boost::bind( &CompoundNodule::childRemoved, this, ::_1,  ::_2 ) );
 
-	for( Gaffer::PlugIterator it( plug.get() ); it!=it.end(); it++ )
+	for( Gaffer::PlugIterator it( plug.get() ); !it.done(); ++it )
 	{
 		NodulePtr nodule = Nodule::create( *it );
 		if( nodule )
@@ -132,7 +132,7 @@ bool CompoundNodule::acceptsChild( const Gaffer::GraphComponent *potentialChild 
 
 Nodule *CompoundNodule::nodule( const Gaffer::Plug *plug )
 {
-	for( NoduleIterator it( m_row.get() ); it!=it.end(); it++ )
+	for( NoduleIterator it( m_row.get() ); !it.done(); ++it )
 	{
 		if( (*it)->plug() == plug )
 		{
@@ -171,7 +171,7 @@ void CompoundNodule::childRemoved( Gaffer::GraphComponent *parent, Gaffer::Graph
 		return;
 	}
 
-	for( NoduleIterator it( m_row.get() ); it!=it.end(); it++ )
+	for( NoduleIterator it( m_row.get() ); !it.done(); ++it )
 	{
 		if( (*it)->plug() == plug )
 		{

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -266,7 +266,7 @@ size_t GraphGadget::connectionGadgets( const Gaffer::Plug *plug, std::vector<con
 
 size_t GraphGadget::connectionGadgets( const Gaffer::Node *node, std::vector<ConnectionGadget *> &connections, const Gaffer::Set *excludedNodes )
 {
-	for( Gaffer::RecursivePlugIterator it( node ); it != it.end(); ++it )
+	for( Gaffer::RecursivePlugIterator it( node ); !it.done(); ++it )
 	{
 		this->connectionGadgets( it->get(), connections, excludedNodes );
 	}
@@ -276,7 +276,7 @@ size_t GraphGadget::connectionGadgets( const Gaffer::Node *node, std::vector<Con
 
 size_t GraphGadget::connectionGadgets( const Gaffer::Node *node, std::vector<const ConnectionGadget *> &connections, const Gaffer::Set *excludedNodes ) const
 {
-	for( Gaffer::RecursivePlugIterator it( node ); it != it.end(); ++it )
+	for( Gaffer::RecursivePlugIterator it( node ); !it.done(); ++it )
 	{
 		this->connectionGadgets( it->get(), connections, excludedNodes );
 	}
@@ -357,7 +357,7 @@ void GraphGadget::connectedNodeGadgetsWalk( NodeGadget *gadget, std::set<NodeGad
 		return;
 	}
 
-	for( Gaffer::RecursivePlugIterator it( gadget->node() ); it != it.end(); ++it )
+	for( Gaffer::RecursivePlugIterator it( gadget->node() ); !it.done(); ++it )
 	{
 		Gaffer::Plug *plug = it->get();
 		if( ( direction != Gaffer::Plug::Invalid ) && ( plug->direction() != direction ) )
@@ -1069,7 +1069,7 @@ void GraphGadget::updateDragReconnectCandidate( const DragDropEvent &event )
 	}
 
 	Gaffer::DependencyNode *depNode = IECore::runTimeCast<Gaffer::DependencyNode>( node );
-	for ( Gaffer::RecursiveOutputPlugIterator cIt( node ); cIt != cIt.end(); ++cIt )
+	for ( Gaffer::RecursiveOutputPlugIterator cIt( node ); !cIt.done(); ++cIt )
 	{
 		// must be compatible
 		Gaffer::Plug *p = cIt->get();
@@ -1127,7 +1127,7 @@ void GraphGadget::updateDragReconnectCandidate( const DragDropEvent &event )
 	// check input plugs on non-dependencyNodes
 	if ( !depNode && !m_dragReconnectDstNodule )
 	{
-		for ( Gaffer::RecursiveInputPlugIterator cIt( node ); cIt != cIt.end(); ++cIt )
+		for ( Gaffer::RecursiveInputPlugIterator cIt( node ); !cIt.done(); ++cIt )
 		{
 			Gaffer::Plug *p = cIt->get();
 			if ( !p->getInput<Gaffer::Plug>() && p->acceptsInput( srcPlug ) )

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -1366,7 +1366,7 @@ void GraphGadget::updateGraph()
 	}
 
 	// now make sure we have gadgets for all the nodes we're meant to display
-	for( Gaffer::NodeIterator it( m_root.get() ); it != it.end(); it++ )
+	for( Gaffer::NodeIterator it( m_root.get() ); !it.done(); ++it )
 	{
 		if( !m_filter || m_filter->contains( it->get() ) )
 		{
@@ -1379,7 +1379,7 @@ void GraphGadget::updateGraph()
 
 	// and that we have gadgets for each connection
 
-	for( Gaffer::NodeIterator it( m_root.get() ); it != it.end(); it++ )
+	for( Gaffer::NodeIterator it( m_root.get() ); !it.done(); ++it )
 	{
 		if( !m_filter || m_filter->contains( it->get() ) )
 		{
@@ -1494,7 +1494,7 @@ void GraphGadget::addConnectionGadgets( Gaffer::GraphComponent *nodeOrPlug )
 		}
 	}
 
-	for( Gaffer::PlugIterator pIt( nodeOrPlug ); pIt != pIt.end(); ++pIt )
+	for( Gaffer::PlugIterator pIt( nodeOrPlug ); !pIt.done(); ++pIt )
 	{
 		addConnectionGadgets( pIt->get() );
 	}
@@ -1567,7 +1567,7 @@ void GraphGadget::removeConnectionGadgets( const Gaffer::GraphComponent *nodeOrP
 		}
 	}
 
-	for( Gaffer::PlugIterator pIt( nodeOrPlug ); pIt != pIt.end(); ++pIt )
+	for( Gaffer::PlugIterator pIt( nodeOrPlug ); !pIt.done(); ++pIt )
 	{
 		removeConnectionGadgets( pIt->get() );
 	}

--- a/src/GafferUI/StandardGraphLayout.cpp
+++ b/src/GafferUI/StandardGraphLayout.cpp
@@ -214,7 +214,7 @@ class LayoutEngine
 
 			for( NodesToVertices::const_iterator it = m_nodesToVertices.begin(), eIt = m_nodesToVertices.end(); it != eIt; ++it )
 			{
-				for( RecursiveInputPlugIterator pIt( it->first ); pIt != pIt.end(); ++pIt )
+				for( RecursiveInputPlugIterator pIt( it->first ); !pIt.done(); ++pIt )
 				{
 					ConnectionGadget *connection = graphGadget->connectionGadget( pIt->get() );
 					if( !connection || connection->getMinimised() )
@@ -936,7 +936,7 @@ bool StandardGraphLayout::connectNodes( GraphGadget *graph, Gaffer::Set *nodes, 
 		}
 
 		bool hasInputs = false;
-		for( RecursiveInputPlugIterator it( node ); it != it.end(); ++it )
+		for( RecursiveInputPlugIterator it( node ); !it.done(); ++it )
 		{
 			if( (*it)->getInput<Plug>() && nodeGadget->nodule( it->get() ) )
 			{
@@ -1124,7 +1124,7 @@ bool StandardGraphLayout::connectNodeInternal( GraphGadget *graph, Gaffer::Node 
 
 size_t StandardGraphLayout::outputPlugs( NodeGadget *nodeGadget, std::vector<Gaffer::Plug *> &plugs ) const
 {
-	for( RecursiveOutputPlugIterator it( nodeGadget->node() ); it != it.end(); it++ )
+	for( RecursiveOutputPlugIterator it( nodeGadget->node() ); !it.done(); it++ )
 	{
 		if( nodeGadget->nodule( it->get() ) )
 		{
@@ -1155,7 +1155,7 @@ size_t StandardGraphLayout::outputPlugs( GraphGadget *graph, Gaffer::Set *nodes,
 size_t StandardGraphLayout::unconnectedInputPlugs( NodeGadget *nodeGadget, std::vector<Plug *> &plugs ) const
 {
 	plugs.clear();
-	for( RecursiveInputPlugIterator it( nodeGadget->node() ); it != it.end(); it++ )
+	for( RecursiveInputPlugIterator it( nodeGadget->node() ); !it.done(); it++ )
 	{
 		if( (*it)->getInput<Plug>() == 0 and nodeGadget->nodule( it->get() ) )
 		{
@@ -1176,7 +1176,7 @@ Gaffer::Plug *StandardGraphLayout::correspondingOutput( const Gaffer::Plug *inpu
 		return 0;
 	}
 
-	for( RecursiveOutputPlugIterator it( dependencyNode ); it != it.end(); ++it )
+	for( RecursiveOutputPlugIterator it( dependencyNode ); !it.done(); ++it )
 	{
 		if( dependencyNode->correspondingInput( it->get() ) == input )
 		{

--- a/src/GafferUI/StandardGraphLayout.cpp
+++ b/src/GafferUI/StandardGraphLayout.cpp
@@ -190,7 +190,7 @@ class LayoutEngine
 			// Build a map from node to vertex so we can use it to lookup nodes
 			// when inserting edges.
 
-			for( NodeIterator it( graphGadget->getRoot() ); it != it.end(); ++it )
+			for( NodeIterator it( graphGadget->getRoot() ); !it.done(); ++it )
 			{
 				Node *node = it->get();
 				const NodeGadget *nodeGadget = graphGadget->nodeGadget( node );

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -572,7 +572,7 @@ void StandardNodeGadget::enter( Gadget *gadget )
 {
 	if( m_labelsVisibleOnHover )
 	{
-		for( RecursiveStandardNoduleIterator it( gadget  ); it != it.end(); ++it )
+		for( RecursiveStandardNoduleIterator it( gadget  ); !it.done(); ++it )
 		{
 			(*it)->setLabelVisible( true );
 		}
@@ -583,7 +583,7 @@ void StandardNodeGadget::leave( Gadget *gadget )
 {
 	if( m_labelsVisibleOnHover )
 	{
-		for( RecursiveStandardNoduleIterator it( gadget  ); it != it.end(); ++it )
+		for( RecursiveStandardNoduleIterator it( gadget  ); !it.done(); ++it )
 		{
 			(*it)->setLabelVisible( false );
 		}
@@ -670,7 +670,7 @@ Nodule *StandardNodeGadget::closestCompatibleNodule( const DragDropEvent &event 
 {
 	Nodule *result = 0;
 	float maxDist = Imath::limits<float>::max();
-	for( RecursiveNoduleIterator it( this ); it != it.end(); it++ )
+	for( RecursiveNoduleIterator it( this ); !it.done(); it++ )
 	{
 		if( noduleIsCompatible( it->get(), event ) )
 		{

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -737,7 +737,7 @@ void StandardNodeGadget::updateNodules( std::vector<Nodule *> &nodules, std::vec
 	// Update the nodules for all our plugs, and build a vector
 	// of IndexAndNodule to sort ready for layout.
 	vector<IndexAndNodule> sortedNodules;
-	for( PlugIterator plugIt( node() ); plugIt != plugIt.end(); ++plugIt )
+	for( PlugIterator plugIt( node() ); !plugIt.done(); ++plugIt )
 	{
 		Plug *plug = plugIt->get();
 		if( plug->getName().string().compare( 0, 2, "__" )==0 )

--- a/src/GafferUI/StandardNodule.cpp
+++ b/src/GafferUI/StandardNodule.cpp
@@ -409,7 +409,7 @@ void StandardNodule::setCompatibleLabelsVisible( const DragDropEvent &event, boo
 		return;
 	}
 
-	for( RecursiveStandardNoduleIterator it( nodeGadget ); it != it.end(); ++it )
+	for( RecursiveStandardNoduleIterator it( nodeGadget ); !it.done(); ++it )
 	{
 		Gaffer::PlugPtr input, output;
 		(*it)->connection( event, input, output );


### PR DESCRIPTION
This started off as a quick bit of work to finish the day yesterday, tidying up all python overrides for `DependencyNode::affects()` so that they call the base class appropriately. But doing that triggered a really bizarre test failure on OS X only, which took the whole of this morning to get to the bottom of, and led to changes in our iterator APIs. I'll let the commit messages themselves do the explaining.