### PR TITLE
Improved motion sampling

### DIFF
--- a/include/GafferScene/RendererAlgo.h
+++ b/include/GafferScene/RendererAlgo.h
@@ -96,6 +96,16 @@ void createDisplayDirectories( const IECore::CompoundObject *globals );
 /// retrieved from ScenePlug:attributesPlug().
 void outputAttributes( const IECore::CompoundObject *attributes, IECore::Renderer *renderer );
 
+/// Samples the local transform from the current location in preparation for output to the renderer.
+/// If segments is 0, the transform is sampled at the time from the current context. If it is non-zero then
+/// the sampling is performed evenly across the shutter interval, which should have been obtained via
+/// SceneAlgo::shutter(). If all samples turn out to be identical, they will be collapsed automatically
+/// into a single sample. The sampleTimes container is only filled if there is more than one sample.
+void transformSamples( const ScenePlug *scene, size_t segments, const Imath::V2f &shutter, std::vector<Imath::M44f> &samples, std::set<float> &sampleTimes );
+
+/// Outputs the local transform for the current location, using transformSamples() to generate the samples.
+void outputTransform( const ScenePlug *scene, IECore::Renderer *renderer, size_t segments = 0, const Imath::V2f &shutter = Imath::V2i( 0 ) );
+
 } // namespace GafferScene
 
 #endif // GAFFERSCENE_RENDERERALGO_H

--- a/include/GafferScene/RendererAlgo.h
+++ b/include/GafferScene/RendererAlgo.h
@@ -40,6 +40,7 @@
 #include "IECore/Renderer.h"
 #include "IECore/CompoundObject.h"
 #include "IECore/Transform.h"
+#include "IECore/VisibleRenderable.h"
 
 #include "GafferScene/ScenePlug.h"
 
@@ -105,6 +106,14 @@ void transformSamples( const ScenePlug *scene, size_t segments, const Imath::V2f
 
 /// Outputs the local transform for the current location, using transformSamples() to generate the samples.
 void outputTransform( const ScenePlug *scene, IECore::Renderer *renderer, size_t segments = 0, const Imath::V2f &shutter = Imath::V2i( 0 ) );
+
+/// Samples the object from the current location in preparation for output to the renderer. Sampling parameters
+/// are as for the transformSamples() method. Multiple samples will only be generated for Primitives, since other
+/// object types cannot be interpolated anyway.
+void objectSamples( const ScenePlug *scene, size_t segments, const Imath::V2f &shutter, std::vector<IECore::ConstVisibleRenderablePtr> &samples, std::set<float> &sampleTimes );
+
+/// Outputs the object for the current location, using objectSamples() to generate the samples.
+void outputObject( const ScenePlug *scene, IECore::Renderer *renderer, size_t segments = 0, const Imath::V2f &shutter = Imath::V2i( 0 ) );
 
 } // namespace GafferScene
 

--- a/python/GafferRenderManTest/RenderManRenderTest.py
+++ b/python/GafferRenderManTest/RenderManRenderTest.py
@@ -800,5 +800,39 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 		r = self.__expandedRIB( s["options"]["out"] )
 		self.assertEqual( r.count( "MotionBegin" ), 1 )
 
+	def testDeformationMotionBlur( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["sphere"] = GafferScene.Sphere()
+		s["sphere"]["type"].setValue( s["sphere"].Type.Primitive )
+
+		s["attributes"] = GafferScene.StandardAttributes()
+		s["attributes"]["in"].setInput( s["sphere"]["out"] )
+
+		s["options"] = GafferScene.StandardOptions()
+		s["options"]["in"].setInput( s["attributes"]["out"] )
+
+		# Deformation motion off, we should have no motion statements
+
+		r = self.__expandedRIB( s["options"]["out"] )
+		self.assertEqual( r.count( "MotionBegin" ), 0 )
+
+		# Deformation motion on, but no motion, so we should still have no motion statements
+
+		s["options"]["options"]["deformationBlur"]["enabled"].setValue( True )
+		s["options"]["options"]["deformationBlur"]["value"].setValue( True )
+
+		r = self.__expandedRIB( s["options"]["out"] )
+		self.assertEqual( r.count( "MotionBegin" ), 0 )
+
+		# With some motion - we should have a motion block.
+
+		s["expression"] = Gaffer.Expression()
+		s["expression"].setExpression( 'parent["sphere"]["radius"] = context.getFrame()' )
+
+		r = self.__expandedRIB( s["options"]["out"] )
+		self.assertEqual( r.count( "MotionBegin" ), 1 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/SceneProcedural.cpp
+++ b/src/GafferScene/SceneProcedural.cpp
@@ -381,20 +381,7 @@ void SceneProcedural::render( Renderer *renderer ) const
 
 		// transform
 
-		std::set<float> transformTimes;
-		motionTimes( ( m_options.transformBlur && m_attributes.transformBlur ) ? m_attributes.transformBlurSegments : 0, transformTimes );
-		{
-			ContextPtr timeContext = new Context( *m_context, Context::Borrowed );
-			Context::Scope scopedTimeContext( timeContext.get() );
-
-			MotionBlock motionBlock( renderer, transformTimes, transformTimes.size() > 1 );
-
-			for( std::set<float>::const_iterator it = transformTimes.begin(), eIt = transformTimes.end(); it != eIt; it++ )
-			{
-				timeContext->setFrame( *it );
-				renderer->concatTransform( m_scenePlug->transformPlug()->getValue() );
-			}
-		}
+		outputTransform( m_scenePlug.get(), renderer, ( m_options.transformBlur && m_attributes.transformBlur ) ? m_attributes.transformBlurSegments : 0, m_options.shutter );
 
 		// attributes
 

--- a/src/GafferScene/SceneProcedural.cpp
+++ b/src/GafferScene/SceneProcedural.cpp
@@ -389,39 +389,7 @@ void SceneProcedural::render( Renderer *renderer ) const
 
 		// object
 
-		std::set<float> deformationTimes;
-		motionTimes( ( m_options.deformationBlur && m_attributes.deformationBlur ) ? m_attributes.deformationBlurSegments : 0, deformationTimes );
-		{
-			ContextPtr timeContext = new Context( *m_context, Context::Borrowed );
-			Context::Scope scopedTimeContext( timeContext.get() );
-
-			unsigned timeIndex = 0;
-			for( std::set<float>::const_iterator it = deformationTimes.begin(), eIt = deformationTimes.end(); it != eIt; it++, timeIndex++ )
-			{
-				timeContext->setFrame( *it );
-				ConstObjectPtr object = m_scenePlug->objectPlug()->getValue();
-				if( const Primitive *primitive = runTimeCast<const Primitive>( object.get() ) )
-				{
-					if( deformationTimes.size() > 1 && timeIndex == 0 )
-					{
-						renderer->motionBegin( deformationTimes );
-					}
-
-						primitive->render( renderer );
-
-					if( deformationTimes.size() > 1 && timeIndex == deformationTimes.size() - 1 )
-					{
-						renderer->motionEnd();
-					}
-				}
-				else if( const VisibleRenderable* renderable = runTimeCast< const VisibleRenderable >( object.get() ) )
-				{
-					renderable->render( renderer );
-					break; // no motion blur for these chappies.
-				}
-
-			}
-		}
+		outputObject( m_scenePlug.get(), renderer, ( m_options.deformationBlur && m_attributes.deformationBlur ) ? m_attributes.deformationBlurSegments : 0, m_options.shutter );
 
 		// children
 


### PR DESCRIPTION
This improves motion sampling by detecting cases where all samples are identical and omitting the motion block in that case. It also adds a few useful methods to RendererAlgo that will come in handy when writing alternative renderer output code (I'm planning on trying something more along the lines of InteractiveRender startup for batch renders at some point).

Since this is a fairly core change, I think it'd be worth considering getting out a release before we merge this, so it gets a bit more testing in R&D before entering production.