### PR TITLE
Misc optimisations and fixes

### DIFF
--- a/include/Gaffer/Switch.h
+++ b/include/Gaffer/Switch.h
@@ -116,7 +116,7 @@ class Switch : public BaseType
 		void childAdded( GraphComponent *child );
 		void plugSet( Plug *plug );
 		void plugInputChanged( Plug *plug );
-		size_t inputIndex() const;
+		size_t inputIndex( const Context *context = NULL ) const;
 
 		// Returns the input corresponding to the output and vice versa. Returns NULL
 		// if plug is not meaningful to the switching process.
@@ -128,6 +128,26 @@ class Switch : public BaseType
 
 		IE_CORE_DECLARERUNTIMETYPEDDESCRIPTION( Switch<BaseType> );
 		static size_t g_firstPlugIndex;
+
+};
+
+namespace Detail
+{
+
+struct IdentityContext;
+
+} // namespace Detail
+
+/// May be specialised to control the behaviour of
+/// Switch<BaseType>.
+template<typename BaseType>
+struct SwitchTraits
+{
+
+	/// A class which will be instantiated as
+	/// `IndexContext indexContext( Context::current() )`
+	/// to modify the context when evaluating the switch index.
+	typedef Detail::IdentityContext IndexContext;
 
 };
 

--- a/include/GafferBindings/TypedObjectPlugBinding.inl
+++ b/include/GafferBindings/TypedObjectPlugBinding.inl
@@ -94,7 +94,7 @@ IECore::ObjectPtr getValue( typename T::Ptr p, const IECore::MurmurHash *precomp
 			return boost::const_pointer_cast<IECore::Object>( v );
 		}
 	}
-	return 0;
+	return NULL;
 }
 
 template<typename T>
@@ -105,7 +105,7 @@ typename T::ValuePtr defaultValue( typename T::Ptr p )
 	{
 		return v->copy();
 	}
-	return 0;
+	return NULL;
 }
 
 template<typename T>

--- a/include/GafferBindings/TypedObjectPlugBinding.inl
+++ b/include/GafferBindings/TypedObjectPlugBinding.inl
@@ -98,12 +98,12 @@ IECore::ObjectPtr getValue( typename T::Ptr p, const IECore::MurmurHash *precomp
 }
 
 template<typename T>
-typename T::ValuePtr defaultValue( typename T::Ptr p )
+typename T::ValuePtr defaultValue( typename T::Ptr p, bool copy )
 {
 	typename T::ConstValuePtr v = p->defaultValue();
 	if( v )
 	{
-		return v->copy();
+		return copy ? v->copy() : boost::const_pointer_cast<typename T::ValueType>( v );
 	}
 	return NULL;
 }
@@ -140,7 +140,7 @@ TypedObjectPlugClass<T, TWrapper>::TypedObjectPlugClass( const char *docString )
 			)
 		)
 	);
-	this->def( "defaultValue", &Detail::defaultValue<T> );
+	this->def( "defaultValue", &Detail::defaultValue<T>, ( boost::python::arg_( "_copy" ) = true ) );
 	this->def( "setValue", Detail::setValue<T>, ( boost::python::arg_( "value" ), boost::python::arg_( "_copy" ) = true ) );
 	this->def( "getValue", Detail::getValue<T>, ( boost::python::arg_( "_precomputedHash" ) = boost::python::object(), boost::python::arg_( "_copy" ) = true ) );
 

--- a/include/GafferScene/DeleteSets.h
+++ b/include/GafferScene/DeleteSets.h
@@ -72,6 +72,9 @@ class DeleteSets : public SceneProcessor
 		virtual void hashSetNames( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
 		virtual IECore::ConstInternedStringVectorDataPtr computeSetNames( const Gaffer::Context *context, const ScenePlug *parent ) const;
 
+		virtual void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
+		virtual GafferScene::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const;
+
 	private :
 
 		static size_t g_firstPlugIndex;

--- a/include/GafferScene/SceneSwitch.h
+++ b/include/GafferScene/SceneSwitch.h
@@ -38,6 +38,7 @@
 #define GAFFER_SCENESWITCH_H
 
 #include "Gaffer/Switch.h"
+#include "Gaffer/Context.h"
 
 #include "GafferScene/SceneProcessor.h"
 

--- a/python/GafferImageTest/ImageSwitchTest.py
+++ b/python/GafferImageTest/ImageSwitchTest.py
@@ -34,6 +34,7 @@
 #
 ##########################################################################
 
+import inspect
 import unittest
 
 import IECore
@@ -131,6 +132,35 @@ class ImageSwitchTest( GafferImageTest.ImageTestCase ) :
 		self.assertTrue( script2["switch"]["in"][0].getInput().isSame( script2["in0"]["out"] ) )
 		self.assertTrue( script2["switch"]["in"][1].getInput().isSame( script2["in1"]["out"] ) )
 		self.assertTrue( script2["switch"]["in"][2].getInput() is None )
+
+	def testTileNotAvailableInContextExpressions( self ) :
+
+		# We don't want expressions on the index to be sensitive
+		# to the image:tileOrigin or image:channelName context entries,
+		# because then an invalid image could result from splicing together
+		# different images, even requesting tiles outside the data window.
+
+		script = Gaffer.ScriptNode()
+
+		script["switch"] = GafferImage.ImageSwitch()
+		script["in0"] = GafferImage.Constant()
+		script["in0"]["color"].setValue( IECore.Color4f( 1, 1, 1, 1 ) )
+		script["in1"] = GafferImage.Constant()
+		script["in0"]["color"].setValue( IECore.Color4f( 0, 0, 0, 0 ) )
+
+		script["switch"]["in"][0].setInput( script["in0"]["out"] )
+		script["switch"]["in"][1].setInput( script["in1"]["out"] )
+
+		script["expression"] = Gaffer.Expression()
+		script["expression"].setExpression( inspect.cleandoc(
+			"""
+			assert( context.get( "image:channelName", None ) is None )
+			assert( context.get( "image:tileOrigin", None ) is None )
+			parent["switch"]["index"] = 1
+			"""
+		) )
+
+		self.assertEqual( script["switch"]["out"].channelData( "R", IECore.V2i( 0 ) )[0], 0 )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/TypedObjectPlugTest.py
+++ b/python/GafferTest/TypedObjectPlugTest.py
@@ -80,6 +80,9 @@ class TypedObjectPlugTest( GafferTest.TestCase ) :
 		p = Gaffer.ObjectPlug( "p", defaultValue = IECore.IntVectorData( [ 1, 2, 3 ] ) )
 		self.assertEqual( p.defaultValue(), IECore.IntVectorData( [ 1, 2, 3 ] ) )
 
+		self.assertFalse( p.defaultValue().isSame( p.defaultValue() ) )
+		self.assertTrue( p.defaultValue( _copy = False ).isSame( p.defaultValue( _copy = False ) ) )
+
 	def testRunTimeTyped( self ) :
 
 		self.assertEqual( IECore.RunTimeTyped.baseTypeId( Gaffer.ObjectPlug.staticTypeId() ), Gaffer.ValuePlug.staticTypeId() )

--- a/src/GafferImage/ImageSwitch.cpp
+++ b/src/GafferImage/ImageSwitch.cpp
@@ -35,13 +35,49 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "Gaffer/Switch.inl"
+#include "Gaffer/Context.h"
 
 #include "GafferImage/ImageSwitch.h"
+
+using namespace GafferImage;
+
+namespace
+{
+
+/// \todo If we introduce a TemporaryContext base class in Context.h
+/// then this should derive from that.
+struct ImageSwitchIndexContext
+{
+
+	ImageSwitchIndexContext( const Gaffer::Context *context )
+		:	m_context( new Gaffer::Context( *context, Gaffer::Context::Borrowed ) ),
+			m_scopedContext( m_context.get() )
+	{
+		m_context->remove( ImagePlug::channelNameContextName );
+		m_context->remove( ImagePlug::tileOriginContextName );
+	}
+
+	private :
+
+		Gaffer::ContextPtr m_context;
+		Gaffer::Context::Scope m_scopedContext;
+
+};
+
+} // namespace
 
 namespace Gaffer
 {
 
 IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( GafferImage::ImageSwitch, GafferImage::ImageSwitchTypeId )
+
+template<>
+struct SwitchTraits<GafferImage::ImageProcessor>
+{
+
+	typedef ImageSwitchIndexContext IndexContext;
+
+};
 
 }
 

--- a/src/GafferScene/DeleteSets.cpp
+++ b/src/GafferScene/DeleteSets.cpp
@@ -61,7 +61,6 @@ DeleteSets::DeleteSets( const std::string &name )
 	outPlug()->objectPlug()->setInput( inPlug()->objectPlug() );
 	outPlug()->childNamesPlug()->setInput( inPlug()->childNamesPlug() );
 	outPlug()->globalsPlug()->setInput( inPlug()->globalsPlug() );
-	outPlug()->setPlug()->setInput( inPlug()->setPlug() );
 }
 
 DeleteSets::~DeleteSets()
@@ -131,4 +130,32 @@ IECore::ConstInternedStringVectorDataPtr DeleteSets::computeSetNames( const Gaff
 	}
 
 	return outputSetNamesData;
+}
+
+void DeleteSets::hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
+{
+	const std::string names = namesPlug()->getValue();
+	const bool invert = invertNamesPlug()->getValue();
+	if( matchMultiple( setName, names ) != (!invert) )
+	{
+		h = inPlug()->setPlug()->getValue()->Object::hash();
+	}
+	else
+	{
+		h = inPlug()->setPlug()->defaultValue()->Object::hash();
+	}
+}
+
+GafferScene::ConstPathMatcherDataPtr DeleteSets::computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const
+{
+	const std::string names = namesPlug()->getValue();
+	const bool invert = invertNamesPlug()->getValue();
+	if( matchMultiple( setName, names ) != (!invert) )
+	{
+		return inPlug()->setPlug()->getValue();
+	}
+	else
+	{
+		return inPlug()->setPlug()->defaultValue();
+	}
 }

--- a/src/GafferScene/PathFilter.cpp
+++ b/src/GafferScene/PathFilter.cpp
@@ -158,7 +158,14 @@ void PathFilter::hashMatch( const ScenePlug *scene, const Gaffer::Context *conte
 		const ScenePlug::ScenePath &path = pathData->readable();
 		h.append( &(path[0]), path.size() );
 	}
-	pathMatcherPlug()->hash( h );
+	if( m_pathMatcher )
+	{
+		m_pathMatcher->hash( h );
+	}
+	else
+	{
+		pathMatcherPlug()->hash( h );
+	}
 }
 
 unsigned PathFilter::computeMatch( const ScenePlug *scene, const Gaffer::Context *context ) const

--- a/src/GafferScene/ScenePlug.cpp
+++ b/src/GafferScene/ScenePlug.cpp
@@ -332,6 +332,14 @@ ConstPathMatcherDataPtr ScenePlug::set( const IECore::InternedString &setName ) 
 {
 	ContextPtr tmpContext = new Context( *Context::current(), Context::Borrowed );
 	tmpContext->set( setNameContextName, setName );
+
+	// Remove unnecessary but frequently changed context entries. This
+	// makes us friendlier to the hash caching mechanism in ValuePlug,
+	// since it'll see fewer unnecessarily different contexts, and will
+	// therefore get more cache hits. We do the same in setHash().
+	tmpContext->remove( Filter::inputSceneContextName );
+	tmpContext->remove( ScenePlug::scenePathContextName );
+
 	Context::Scope scopedContext( tmpContext.get() );
 	return setPlug()->getValue();
 }
@@ -415,6 +423,11 @@ IECore::MurmurHash ScenePlug::setHash( const IECore::InternedString &setName ) c
 {
 	ContextPtr tmpContext = new Context( *Context::current(), Context::Borrowed );
 	tmpContext->set( setNameContextName, setName );
+
+	// See explanatory comments in set().
+	tmpContext->remove( Filter::inputSceneContextName );
+	tmpContext->remove( ScenePlug::scenePathContextName );
+
 	Context::Scope scopedContext( tmpContext.get() );
 	return setPlug()->hash();
 }

--- a/src/GafferScene/SceneSwitch.cpp
+++ b/src/GafferScene/SceneSwitch.cpp
@@ -38,12 +38,50 @@
 
 #include "GafferScene/SceneSwitch.h"
 
+using namespace GafferScene;
+
+namespace
+{
+
+/// \todo If we introduce a TemporaryContext base class in Context.h
+/// then this should derive from that. In fact, we might even define
+/// this publicly as GafferScene::GlobalContext and then we could also
+/// use it in ScenePlug::set() and other places we want to suppress the
+/// scene path.
+struct SceneSwitchIndexContext
+{
+
+	SceneSwitchIndexContext( const Gaffer::Context *context )
+		:	m_context( new Gaffer::Context( *context, Gaffer::Context::Borrowed ) ),
+			m_scopedContext( m_context.get() )
+	{
+		m_context->remove( ScenePlug::scenePathContextName );
+		m_context->remove( Filter::inputSceneContextName );
+	}
+
+	private :
+
+		Gaffer::ContextPtr m_context;
+		Gaffer::Context::Scope m_scopedContext;
+
+};
+
+} // namespace
+
 namespace Gaffer
 {
 
 IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( GafferScene::SceneSwitch, GafferScene::SceneSwitchTypeId )
 
-}
+template<>
+struct SwitchTraits<GafferScene::SceneProcessor>
+{
+
+	typedef SceneSwitchIndexContext IndexContext;
+
+};
+
+} // namespace Gaffer
 
 // explicit instantiation
 template class Gaffer::Switch<GafferScene::SceneProcessor>;

--- a/src/GafferScene/SetFilter.cpp
+++ b/src/GafferScene/SetFilter.cpp
@@ -118,15 +118,6 @@ void SetFilter::hashMatch( const ScenePlug *scene, const Gaffer::Context *contex
 		h.append( &(path[0]), path.size() );
 	}
 
-	// Remove unnecessary but frequently changed context entries. This
-	// makes us friendlier to the hash caching mechanism in ValuePlug,
-	// since it'll see fewer unnecessarily different contexts, and will
-	// therefore get more cache hits. We do the same in computeMatch().
-	ContextPtr tmpContext = new Context( *context, Context::Borrowed );
-	tmpContext->remove( Filter::inputSceneContextName );
-	tmpContext->remove( ScenePlug::scenePathContextName );
-	Context::Scope scopedContext( tmpContext.get() );
-
 	h.append( scene->setHash( setPlug()->getValue() ) );
 }
 
@@ -138,13 +129,6 @@ unsigned SetFilter::computeMatch( const ScenePlug *scene, const Gaffer::Context 
 	}
 
 	const ScenePlug::ScenePath &path = context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
-
-	// See explanatory comments in hashMatch().
-	ContextPtr tmpContext = new Context( *context, Context::Borrowed );
-	tmpContext->remove( Filter::inputSceneContextName );
-	tmpContext->remove( ScenePlug::scenePathContextName );
-	Context::Scope scopedContext( tmpContext.get() );
-
 	ConstPathMatcherDataPtr set = scene->set( setPlug()->getValue() );
 
 	return set->readable().match( path );


### PR DESCRIPTION
These are all motivated by a certain production some of you may be familiar with. The main focus is on reducing the number of entries in the hash cache, which has a very direct effect on speed and memory usage, but there are a few other fixes thrown in. Here are some results in comparison to Gaffer 0.23.0.1 - all numbers are percentages of our previous results :

    | Memory usage   | Scene generation time
---| ----------------------|--------------------------------
Old lookdev |    63%     | 64%
New lookdev |   85%     | 72% 