### PR TITLE
Processes and monitors

### DIFF
--- a/apps/stats/stats-1.py
+++ b/apps/stats/stats-1.py
@@ -75,6 +75,27 @@ class stats( Gaffer.Application ) :
 					defaultValue = "",
 				),
 
+				IECore.BoolParameter(
+					name = "performanceMonitor",
+					description = "Turns on a performance monitor to provide additional"
+						"statistics about the operation of the node graph.",
+					defaultValue = False,
+				),
+
+				IECore.IntParameter(
+					name = "mostFrequentlyHashed",
+					description = "The number of most-frequently hashed plugs to print. "
+						"Only used when the performance monitor is on.",
+					defaultValue = 50,
+				),
+
+				IECore.IntParameter(
+					name = "mostFrequentlyComputed",
+					description = "The number of most-frequently hashed plugs to print. "
+						"Only used when the performance monitor is on.",
+					defaultValue = 50,
+				)
+
 			]
 
 		)
@@ -86,6 +107,11 @@ class stats( Gaffer.Application ) :
 		)
 
 	def _run( self, args ) :
+
+		if args["performanceMonitor"].value :
+			self.__performanceMonitor = Gaffer.PerformanceMonitor()
+		else :
+			self.__performanceMonitor = None
 
 		self.__timers = collections.OrderedDict()
 		self.__memory = collections.OrderedDict()
@@ -123,19 +149,15 @@ class stats( Gaffer.Application ) :
 
 				self.__printScene( script, args )
 
-		with _Timer() as shutdownTimer :
-			del script
-			while gc.collect() :
-				IECore.RefCounted.collectGarbage()
-		self.__timers["Shutdown"] = shutdownTimer
-
 		print ""
 
 		self.__printMemory()
 
 		print ""
 
-		self.__printPerformance()
+		self.__printPerformance( script, args )
+
+		print
 
 	def __printVersion( self, script ) :
 
@@ -226,7 +248,8 @@ class stats( Gaffer.Application ) :
 
 		memory = _Memory.maxRSS()
 		with _Timer() as sceneTimer :
-			GafferSceneTest.traverseScene( scene )
+			with self.__performanceMonitor or _NullContextManager() :
+				GafferSceneTest.traverseScene( scene )
 		self.__timers["Scene generation"] = sceneTimer
 		self.__memory["Scene generation"] = _Memory.maxRSS() - memory
 
@@ -254,10 +277,27 @@ class stats( Gaffer.Application ) :
 		print "Memory :\n"
 		self.__printItems( items )
 
-	def __printPerformance( self ) :
+	def __printStatisticsItems( self, script, stats, key, n ) :
+
+		stats.sort( key = key, reverse = True )
+		items = [ ( x[0].relativeName( script ), key( x ) ) for x in stats[:n] ]
+		self.__printItems( items )
+
+	def __printPerformance( self, script, args ) :
 
 			print "Performance :\n"
 			self.__printItems( self.__timers.items() )
+
+			if self.__performanceMonitor is None :
+				return
+
+			stats = self.__performanceMonitor.allStatistics().items()
+
+			print "\nMost frequently hashed :\n"
+			self.__printStatisticsItems( script, stats, lambda x : x[1].hashCount, args["mostFrequentlyHashed"].value )
+
+			print "\nMost frequently computed :\n"
+			self.__printStatisticsItems( script, stats, lambda x : x[1].computeCount, args["mostFrequentlyComputed"].value )
 
 class _Timer( object ) :
 
@@ -298,5 +338,15 @@ class _Memory( object ) :
 	def __sub__( self, other ) :
 
 		return _Memory( self.__bytes - other.__bytes )
+
+class _NullContextManager( object ) :
+
+	def __enter__( self ) :
+
+		pass
+
+	def __exit__( self, type, value, traceBack ) :
+
+		pass
 
 IECore.registerRunTimeTyped( stats )

--- a/include/Gaffer/Monitor.h
+++ b/include/Gaffer/Monitor.h
@@ -1,0 +1,88 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFER_MONITOR_H
+#define GAFFER_MONITOR_H
+
+#include "boost/noncopyable.hpp"
+
+namespace Gaffer
+{
+
+class Process;
+
+/// Base class for monitoring node graph processes.
+class Monitor : boost::noncopyable
+{
+
+	public :
+
+		Monitor();
+		virtual ~Monitor();
+
+		void setActive( bool active );
+		bool getActive() const;
+
+		class Scope : boost::noncopyable
+		{
+
+			public :
+
+				/// Constructing the Scope makes the monitor active.
+				Scope( Monitor *monitor );
+				/// Destruction of the Scope makes the monitor inactive.
+				~Scope();
+
+			private :
+
+				Monitor *m_monitor;
+
+		};
+
+	protected :
+
+		friend class Process;
+
+		/// Implementations must be safe to call concurrently.
+		virtual void processStarted( const Process *process ) = 0;
+		/// Implementations must be safe to call concurrently.
+		virtual void processFinished( const Process *process ) = 0;
+
+};
+
+} // namespace Gaffer
+
+#endif // GAFFER_MONITOR_H

--- a/include/Gaffer/PerformanceMonitor.h
+++ b/include/Gaffer/PerformanceMonitor.h
@@ -1,0 +1,102 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFER_PERFORMANCEMONITOR_H
+#define GAFFER_PERFORMANCEMONITOR_H
+
+#include "tbb/enumerable_thread_specific.h"
+
+#include "boost/unordered_map.hpp"
+
+#include "IECore/RefCounted.h"
+
+#include "Gaffer/Monitor.h"
+
+namespace Gaffer
+{
+
+IE_CORE_FORWARDDECLARE( Plug )
+
+/// A monitor which collects statistics about the frequency
+/// of hash and compute processes per plug.
+class PerformanceMonitor : public Monitor
+{
+
+	public :
+
+		PerformanceMonitor();
+		virtual ~PerformanceMonitor();
+
+		struct Statistics
+		{
+
+			Statistics( size_t hashCount = 0, size_t computeCount = 0 );
+
+			size_t hashCount;
+			size_t computeCount;
+
+			Statistics & operator += ( const Statistics &rhs );
+
+			bool operator == ( const Statistics &rhs );
+			bool operator != ( const Statistics &rhs );
+
+		};
+
+		typedef boost::unordered_map<ConstPlugPtr, Statistics> StatisticsMap;
+
+		const StatisticsMap &allStatistics() const;
+		const Statistics &plugStatistics( const Plug *plug ) const;
+
+	protected :
+
+		virtual void processStarted( const Process *process );
+		virtual void processFinished( const Process *process );
+
+	private :
+
+		// For performance reasons we accumulate our statistics into
+		// thread local storage while computations are running.
+		tbb::enumerable_thread_specific<StatisticsMap> m_threadStatistics;
+
+		// Then when we want to query it, we collate it into m_statistics.
+		void collate() const;
+		mutable StatisticsMap m_statistics;
+
+};
+
+} // namespace Gaffer
+
+#endif // GAFFER_PERFORMANCEMONITOR_H

--- a/include/Gaffer/Process.h
+++ b/include/Gaffer/Process.h
@@ -1,0 +1,114 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFER_PROCESS_H
+#define GAFFER_PROCESS_H
+
+#include "tbb/enumerable_thread_specific.h"
+
+#include "boost/noncopyable.hpp"
+
+#include "IECore/InternedString.h"
+
+namespace Gaffer
+{
+
+class Plug;
+
+/// Base class representing a node graph process being
+/// performed on behalf of a plug. Processes are never
+/// created directly by client code, but are generated
+/// internally in response to calls such as
+/// ValuePlug::getValue(). Typically processes can be
+/// considered to be entirely an internal implementation
+/// detail - they are exposed publicly only so they can
+/// be used by the Monitor classes.
+class Process : public boost::noncopyable
+{
+
+	public :
+
+		/// The type of process being performed.
+		const IECore::InternedString type() const { return m_type; }
+		/// The plug for which the process is being
+		/// performed.
+		const Plug *plug() const { return m_plug; }
+
+		/// Returns the parent process for this process - that
+		/// is, the process that invoked this one.
+		/// \todo Currently this does not track parent/child
+		/// relationships correctly when a parent process spawns
+		/// child processes on separate threads.
+		const Process *parent() const { return m_parent; }
+
+		/// Returns the Process currently being performed on
+		/// this thread, or NULL if there is no such process.
+		static const Process *current();
+
+	protected :
+
+		/// Protected constructor for use by derived classes only.
+		Process( const IECore::InternedString &type, const Plug *plug, const Plug *downstream = NULL );
+		~Process();
+
+		/// Derived classes should catch exceptions thrown
+		/// during processing, and call this method. It will
+		/// report the error appropriately via Node::errorSignal()
+		/// and rethrow the exception for propagation back to
+		/// the original caller.
+		/// \todo Consider ways of dealing with this automatically - could
+		/// we use C++11's current_exception() in our destructor perhaps?
+		void handleException();
+
+	private :
+
+		void emitError( const std::string &error ) const;
+
+		struct ThreadData;
+
+		IECore::InternedString m_type;
+		const Plug *m_plug;
+		const Plug *m_downstream;
+		const Process *m_parent;
+		ThreadData *m_threadData;
+
+		static tbb::enumerable_thread_specific<ThreadData, tbb::cache_aligned_allocator<Process::ThreadData>, tbb::ets_key_per_instance> g_threadData;
+
+};
+
+} // namespace Gaffer
+
+#endif // GAFFER_PROCESS_H

--- a/include/Gaffer/Process.h
+++ b/include/Gaffer/Process.h
@@ -47,6 +47,7 @@ namespace Gaffer
 {
 
 class Plug;
+class Monitor;
 
 /// Base class representing a node graph process being
 /// performed on behalf of a plug. Processes are never
@@ -94,6 +95,13 @@ class Process : public boost::noncopyable
 		void handleException();
 
 	private :
+
+		// Friendship allows monitors to register and deregister
+		// themselves.
+		friend class Monitor;
+		static void registerMonitor( Monitor *monitor );
+		static void deregisterMonitor( Monitor *monitor );
+		static bool monitorRegistered( const Monitor *monitor );
 
 		void emitError( const std::string &error ) const;
 

--- a/include/Gaffer/ValuePlug.h
+++ b/include/Gaffer/ValuePlug.h
@@ -154,8 +154,7 @@ class ValuePlug : public Plug
 		/// not be changed following the call.
 		void setObjectValue( IECore::ConstObjectPtr value );
 
-		/// Returns true if a computation is currently being performed on this thread -
-		/// if we are inside Node::compute().
+		/// \deprecated. Use Process::current() instead.
 		bool inCompute() const;
 
 		/// Reimplemented for cache management.
@@ -163,7 +162,8 @@ class ValuePlug : public Plug
 
 	private :
 
-		class Computation;
+		class HashProcess;
+		class ComputeProcess;
 		class SetValueAction;
 
 		void setValueInternal( IECore::ConstObjectPtr value, bool propagateDirtiness );

--- a/include/GafferBindings/MonitorBinding.h
+++ b/include/GafferBindings/MonitorBinding.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERBINDINGS_MONITORBINDING_H
+#define GAFFERBINDINGS_MONITORBINDING_H
+
+namespace GafferBindings
+{
+
+void bindMonitor();
+
+} // namespace GafferBindings
+
+#endif // GAFFERBINDINGS_MONITORBINDING_H

--- a/python/GafferImageTest/AtomicFormatPlugTest.py
+++ b/python/GafferImageTest/AtomicFormatPlugTest.py
@@ -129,5 +129,16 @@ class AtomicFormatPlugTest( GafferImageTest.ImageTestCase ) :
 		p.setValue( GafferImage.Format() )
 		self.assertEqual( p.getValue(), GafferImage.Format() )
 
+	def testHashRepeatability( self ) :
+
+		p = GafferImage.AtomicFormatPlug()
+		p.setValue( GafferImage.Format( 1920, 1080 ) )
+
+		allHashes = set()
+		for i in range( 0, 1000 ) :
+			allHashes.add( p.hash().toString() )
+
+		self.assertEqual( len( allHashes ), 1 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/PerformanceMonitorTest.py
+++ b/python/GafferTest/PerformanceMonitorTest.py
@@ -1,0 +1,109 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import Gaffer
+import GafferTest
+
+class PerformanceMonitorTest( GafferTest.TestCase ) :
+
+	def testActiveStatus( self ) :
+
+		m = Gaffer.PerformanceMonitor()
+
+		self.assertEqual( m.getActive(), False )
+		m.setActive( True )
+		self.assertEqual( m.getActive(), True )
+		m.setActive( False )
+		self.assertEqual( m.getActive(), False )
+
+		with m :
+			self.assertEqual( m.getActive(), True )
+
+		self.assertEqual( m.getActive(), False )
+
+	def testStatistics( self ) :
+
+		m = Gaffer.PerformanceMonitor()
+
+		a = GafferTest.AddNode()
+		a["op1"].setValue( -1001 )
+		a["op2"].setValue( -1002 )
+
+		# Do a computation, and check we have one hash
+		# and one compute.
+		with m :
+			self.assertEqual( a["sum"].getValue(), -2003 )
+
+		self.assertEqual(
+			m.plugStatistics( a["sum"] ),
+			m.Statistics( hashCount = 1, computeCount = 1 )
+		)
+
+		# Redo the computation - the caches should ensure
+		# that we don't do anything at all.
+		with m :
+			self.assertEqual( a["sum"].getValue(), -2003 )
+
+		self.assertEqual(
+			m.plugStatistics( a["sum"] ),
+			m.Statistics( hashCount = 1, computeCount = 1 )
+		)
+
+		# Force a rehash by making a new context. We should
+		# still be using the cache for the value though.
+		with m :
+			with Gaffer.Context() as c :
+				c["myVariable"] = 1 # Force a rehash
+				self.assertEqual( a["sum"].getValue(), -2003 )
+
+
+		self.assertEqual(
+			m.plugStatistics( a["sum"] ),
+			m.Statistics( hashCount = 2, computeCount = 1 )
+		)
+
+		# Check the dictionary of all statistics.
+		self.assertEqual(
+			m.allStatistics(),
+			{
+				a["sum"] : m.Statistics( hashCount = 2, computeCount = 1 )
+			}
+		)
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferTest/__init__.py
+++ b/python/GafferTest/__init__.py
@@ -128,6 +128,7 @@ from FileSequencePathFilterTest import FileSequencePathFilterTest
 from AnimationTest import AnimationTest
 from StatsApplicationTest import StatsApplicationTest
 from DownstreamIteratorTest import DownstreamIteratorTest
+from PerformanceMonitorTest import PerformanceMonitorTest
 
 if __name__ == "__main__":
 	import unittest

--- a/src/Gaffer/Monitor.cpp
+++ b/src/Gaffer/Monitor.cpp
@@ -1,0 +1,78 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Gaffer/Monitor.h"
+#include "Gaffer/Process.h"
+
+using namespace Gaffer;
+
+Monitor::Monitor()
+{
+}
+
+Monitor::~Monitor()
+{
+	Process::deregisterMonitor( this );
+}
+
+void Monitor::setActive( bool active )
+{
+	if( active )
+	{
+		Process::registerMonitor( this );
+	}
+	else
+	{
+		Process::deregisterMonitor( this );
+	}
+}
+
+bool Monitor::getActive() const
+{
+	return Process::monitorRegistered( this );
+}
+
+Monitor::Scope::Scope( Monitor *monitor )
+	:	m_monitor( monitor )
+{
+	m_monitor->setActive( true );
+}
+
+Monitor::Scope::~Scope()
+{
+	m_monitor->setActive( false );
+}
+

--- a/src/Gaffer/PerformanceMonitor.cpp
+++ b/src/Gaffer/PerformanceMonitor.cpp
@@ -1,0 +1,139 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Gaffer/PerformanceMonitor.h"
+#include "Gaffer/Process.h"
+#include "Gaffer/Plug.h"
+
+using namespace Gaffer;
+
+/// \todo If we expose ValuePlug::HashProcess and ValuePlug::ComputeProcess
+/// then we can use the types defined there directly.
+static IECore::InternedString g_hashType( "computeNode:hash" );
+static IECore::InternedString g_computeType( "computeNode:compute" );
+static PerformanceMonitor::Statistics g_emptyStatistics;
+
+//////////////////////////////////////////////////////////////////////////
+// PerformanceMonitor::Statistics
+//////////////////////////////////////////////////////////////////////////
+
+PerformanceMonitor::Statistics::Statistics( size_t hashCount, size_t computeCount )
+	:	hashCount( hashCount ), computeCount( computeCount )
+{
+}
+
+PerformanceMonitor::Statistics & PerformanceMonitor::Statistics::operator += ( const Statistics &rhs )
+{
+	hashCount += rhs.hashCount;
+	computeCount += rhs.computeCount;
+	return *this;
+}
+
+bool PerformanceMonitor::Statistics::operator == ( const Statistics &rhs )
+{
+	return hashCount == rhs.hashCount && computeCount == rhs.computeCount;
+}
+
+bool PerformanceMonitor::Statistics::operator != ( const Statistics &rhs )
+{
+	return !( *this == rhs );
+}
+
+//////////////////////////////////////////////////////////////////////////
+// PerformanceMonitor
+//////////////////////////////////////////////////////////////////////////
+
+PerformanceMonitor::PerformanceMonitor()
+{
+}
+
+PerformanceMonitor::~PerformanceMonitor()
+{
+}
+
+const PerformanceMonitor::StatisticsMap &PerformanceMonitor::allStatistics() const
+{
+	collate();
+	return m_statistics;
+}
+
+const PerformanceMonitor::Statistics &PerformanceMonitor::plugStatistics( const Plug *plug ) const
+{
+	collate();
+	StatisticsMap::const_iterator it = m_statistics.find( plug );
+	if( it == m_statistics.end() )
+	{
+		return g_emptyStatistics;
+	}
+	return it->second;
+}
+
+void PerformanceMonitor::processStarted( const Process *process )
+{
+	const IECore::InternedString type = process->type();
+	if( type != g_hashType && type != g_computeType )
+	{
+		return;
+	}
+
+	Statistics &s = m_threadStatistics.local()[process->plug()];
+	if( type == g_hashType )
+	{
+		s.hashCount++;
+	}
+	else
+	{
+		s.computeCount++;
+	}
+}
+
+void PerformanceMonitor::processFinished( const Process *process )
+{
+}
+
+void PerformanceMonitor::collate() const
+{
+	tbb::enumerable_thread_specific<StatisticsMap>::iterator it, eIt;
+	for( it = m_threadStatistics.begin(), eIt = m_threadStatistics.end(); it != eIt; ++it )
+	{
+		StatisticsMap &m = *it;
+		for( StatisticsMap::const_iterator mIt = m.begin(), meIt = m.end(); mIt != meIt; ++mIt )
+		{
+			m_statistics[mIt->first] += mIt->second;
+		}
+		m.clear();
+	}
+}

--- a/src/Gaffer/Process.cpp
+++ b/src/Gaffer/Process.cpp
@@ -1,0 +1,122 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include <stack>
+
+#include "Gaffer/Process.h"
+#include "Gaffer/Plug.h"
+#include "Gaffer/Node.h"
+
+using namespace Gaffer;
+
+struct Process::ThreadData
+{
+
+	typedef std::stack<const Process *> Stack;
+	Stack stack;
+
+	const Plug *errorSource;
+
+};
+
+tbb::enumerable_thread_specific<Process::ThreadData, tbb::cache_aligned_allocator<Process::ThreadData>, tbb::ets_key_per_instance> Process::g_threadData;
+
+Process::Process( const IECore::InternedString &type, const Plug *plug, const Plug *downstream )
+	:	m_type( type ), m_plug( plug ), m_downstream( downstream ? downstream : plug ), m_threadData( &g_threadData.local() )
+{
+	ThreadData::Stack &stack = m_threadData->stack;
+	m_parent = stack.size() ? stack.top() : NULL;
+	m_threadData->stack.push( this );
+}
+
+Process::~Process()
+{
+	m_threadData->stack.pop();
+	if( m_threadData->stack.empty() )
+	{
+		m_threadData->errorSource = NULL;
+	}
+}
+
+const Process *Process::current()
+{
+	const ThreadData::Stack &stack = g_threadData.local().stack;
+	return stack.size() ? stack.top() : NULL;
+}
+
+void Process::handleException()
+{
+	try
+	{
+		// Rethrow the current exception
+		// so we can examine it.
+		throw;
+	}
+	catch( const std::exception &e )
+	{
+		if( !m_threadData->errorSource )
+		{
+			m_threadData->errorSource = plug();
+		}
+		emitError( e.what() );
+		throw;
+	}
+	catch( ... )
+	{
+		if( !m_threadData->errorSource )
+		{
+			m_threadData->errorSource = plug();
+		}
+		emitError( "Unknown error" );
+		throw;
+	}
+}
+
+void Process::emitError( const std::string &error ) const
+{
+	const Plug *plug = m_downstream;
+	while( plug )
+	{
+		if( plug->direction() == Plug::Out )
+		{
+			if( const Node *node = plug->node() )
+			{
+				node->errorSignal()( plug, m_threadData->errorSource, error );
+			}
+		}
+		plug = plug != m_plug ? plug->getInput<Plug>() : NULL;
+	}
+}

--- a/src/Gaffer/StringPlug.cpp
+++ b/src/Gaffer/StringPlug.cpp
@@ -37,6 +37,7 @@
 
 #include "Gaffer/Context.h"
 #include "Gaffer/StringPlug.h"
+#include "Gaffer/Process.h"
 
 using namespace IECore;
 using namespace Gaffer;
@@ -103,7 +104,7 @@ std::string StringPlug::getValue( const IECore::MurmurHash *precomputedHash ) co
 	bool performSubstitution =
 		m_substitutions &&
 		direction()==Plug::In &&
-		inCompute() &&
+		Process::current() &&
 		Plug::getFlags( Plug::PerformsSubstitutions ) &&
 		Context::hasSubstitutions( s->readable() );
 

--- a/src/GafferBindings/MonitorBinding.cpp
+++ b/src/GafferBindings/MonitorBinding.cpp
@@ -1,0 +1,109 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+#include "boost/format.hpp"
+
+#include "Gaffer/Monitor.h"
+#include "Gaffer/PerformanceMonitor.h"
+#include "Gaffer/Plug.h"
+
+#include "GafferBindings/MonitorBinding.h"
+
+using namespace boost::python;
+using namespace Gaffer;
+using namespace GafferBindings;
+
+namespace
+{
+
+void enterScope( Monitor &m )
+{
+	m.setActive( true );
+}
+
+void exitScope( Monitor &m, object type, object value, object traceBack )
+{
+	m.setActive( false );
+}
+
+std::string repr( PerformanceMonitor::Statistics &s )
+{
+	return boost::str(
+		boost::format( "Gaffer.PerformanceMonitor.Statistics( hashCount = %d, computeCount = %d )" )
+			% s.hashCount
+			% s.computeCount
+	);
+}
+
+dict allStatistics( PerformanceMonitor &m )
+{
+	dict result;
+	const PerformanceMonitor::StatisticsMap &s = m.allStatistics();
+	for( PerformanceMonitor::StatisticsMap::const_iterator it = s.begin(), eIt = s.end(); it != eIt; ++it )
+	{
+		result[boost::const_pointer_cast<Plug>( it->first)] = it->second;
+	}
+	return result;
+}
+
+} // namespace
+
+void GafferBindings::bindMonitor()
+{
+
+	class_<Monitor, boost::noncopyable>( "Monitor", no_init )
+		.def( "setActive", &Monitor::setActive )
+		.def( "getActive", &Monitor::getActive )
+		.def( "__enter__", &enterScope )
+		.def( "__exit__", &exitScope )
+	;
+
+	scope s = class_<PerformanceMonitor, bases<Monitor>, boost::noncopyable >( "PerformanceMonitor" )
+		.def( "allStatistics", &allStatistics )
+		.def( "plugStatistics", &PerformanceMonitor::plugStatistics, return_value_policy<copy_const_reference>() )
+	;
+
+	class_<PerformanceMonitor::Statistics>( "Statistics" )
+		.def( init<size_t, size_t>( ( arg( "hashCount" ) = 0, arg( "computeCount" ) = 0 ) ) )
+		.def_readwrite( "hashCount", &PerformanceMonitor::Statistics::hashCount )
+		.def_readwrite( "computeCount", &PerformanceMonitor::Statistics::computeCount )
+		.def( self == self )
+		.def( self != self )
+		.def( "__repr__", &repr )
+	;
+
+}

--- a/src/GafferImage/FormatPlug.cpp
+++ b/src/GafferImage/FormatPlug.cpp
@@ -38,6 +38,7 @@
 
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/Context.h"
+#include "Gaffer/Process.h"
 
 #include "GafferImage/FormatPlug.h"
 #include "GafferImage/FormatData.h"
@@ -107,7 +108,7 @@ void FormatPlug::setValue( const Format &value )
 Format FormatPlug::getValue() const
 {
 	Format result( displayWindowPlug()->getValue(), pixelAspectPlug()->getValue() );
-	if( direction() == Plug::In && result.getDisplayWindow().isEmpty() && inCompute() )
+	if( direction() == Plug::In && result.getDisplayWindow().isEmpty() && Process::current() )
 	{
 		return getDefaultFormat( Context::current() );
 	}

--- a/src/GafferModule/GafferModule.cpp
+++ b/src/GafferModule/GafferModule.cpp
@@ -90,6 +90,7 @@
 #include "GafferBindings/FileSystemPathBinding.h"
 #include "GafferBindings/FileSequencePathFilterBinding.h"
 #include "GafferBindings/AnimationBinding.h"
+#include "GafferBindings/MonitorBinding.h"
 
 using namespace boost::python;
 using namespace Gaffer;
@@ -183,6 +184,7 @@ BOOST_PYTHON_MODULE( _Gaffer )
 	bindFileSystemPath();
 	bindFileSequencePathFilter();
 	bindAnimation();
+	bindMonitor();
 
 	NodeClass<Backdrop>();
 


### PR DESCRIPTION
This provides us with a basic framework for writing performance monitors and profilers for analysing Gaffer's graph execution, as requested in #1147. It's in a fairly basic form at present, with the only visibility in our apps via the stats app, but it's already providing valuable insights. I've no doubt we'll add new features to PerformanceMonitor in the future, as well as adding domain-specific monitors, and it'd be great to make the whole thing more user-visible, but it's at a valuable enough point that I'd like to get it merged.