### PR TITLE
FormatData : Make hash stable with GCC 4.4.7.

### DIFF
--- a/python/GafferImageTest/FormatPlugTest.py
+++ b/python/GafferImageTest/FormatPlugTest.py
@@ -216,5 +216,15 @@ class FormatPlugTest( GafferImageTest.ImageTestCase ) :
 		self.assertTrue( s["n"]["f"].getInput().node().isSame( s["e"] ) )
 		self.assertEqual( s["n"]["f"].getValue(), f )
 
+	def testDefaultFormatHashRepeatability( self ) :
+
+		allHashes = set()
+		for i in range( 0, 1000 ) :
+			c = Gaffer.Context()
+			GafferImage.FormatPlug.setDefaultFormat( c, GafferImage.Format( 1920, 1080 ) )
+			allHashes.add( str( c.hash() ) )
+
+		self.assertEqual( len( allHashes ), 1 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferImage/FormatData.cpp
+++ b/src/GafferImage/FormatData.cpp
@@ -77,7 +77,7 @@ void FormatData::load( LoadContextPtr context )
 template<>
 void SimpleDataHolder<GafferImage::Format>::hash( MurmurHash &h ) const
 {
-	GafferImage::Format f = readable();
+	const GafferImage::Format &f = readable();
 	h.append( f.getDisplayWindow() );
 	h.append( f.getPixelAspect() );
 }


### PR DESCRIPTION
This one is a bit beyond my understanding. While working with the new PerformanceMonitor I noticed that an expression was being hashed more often than it should have been, and traced it down to the hash for the "image:defaultFormat" context variable changing each time it was computed.

This only occurred with GCC 4.4.7 - the new unit test already passed with GCC 4.8.3 and 4.6.3 and 5, and Clang 3.4. I got as far as verifying that the assembly for `SimpleDataHolder<GafferImage::Format>::hash()` was different in GCC 4.4.7, but at that point things were beyond me. The simple change to referencing rather than copying the Format object fixes things, and at this point I'm afraid to say that's good enough for me.