### PR TITLE
ClassVectorParameterValueWidget : Fix for preexisting child parameters.

### DIFF
--- a/python/GafferCortexUI/ClassVectorParameterValueWidget.py
+++ b/python/GafferCortexUI/ClassVectorParameterValueWidget.py
@@ -265,7 +265,8 @@ class _ChildParameterUI( GafferUI.CompoundPlugValueWidget ) :
 
 			layerButton = GafferUI.MenuButton( image="classVectorParameterHandle.png", hasFrame=False )
 
-			parentParameter = self.ancestor( ClassVectorParameterValueWidget ).parameter()
+			compoundPlugValueWidget = self.ancestor( _PlugValueWidget )
+			parentParameter = compoundPlugValueWidget._parameter()
 			cls = parentParameter.getClass( self.__parameterHandler.parameter().name, True )
 
 			layerButtonToolTip = "<h3>%s v%d</h3>" % ( cls[1], cls[2] )
@@ -274,7 +275,6 @@ class _ChildParameterUI( GafferUI.CompoundPlugValueWidget ) :
 			layerButtonToolTip += "<p>Click to reorder or remove.</p>"
 			layerButton.setToolTip( layerButtonToolTip )
 
-			compoundPlugValueWidget = self.ancestor( _PlugValueWidget )
 			layerButton.setMenu( GafferUI.Menu( IECore.curry( Gaffer.WeakMethod( compoundPlugValueWidget._layerMenuDefinition ), self.__parameterHandler.parameter().name ) ) )
 
 			GafferUI.Spacer( IECore.V2i( 2 ) )


### PR DESCRIPTION
The _ChildParameterUI._headerWidget() method relies on being able to find an ancestor widget in order to find some information about the class it is displaying. This is bad design really, but it's what we have, and since the CortexUI is based entirely on deprecated functionality (CompoundPlugValueWidget) it's unlikely to change without a rewrite.

As described in #665, this causes a problem when invoking a GUI for a ClassVectorParameter which already has some children. The assumption is that the building of the contents of _ChildParameterUI will be delayed until such a time as a parent is available (because CompoundParameterValueWidget waits for visibilityChangedSignal() or parentChangedSignal()). However, it seems that we have a problem here :

https://github.com/ImageEngine/gaffer/blob/266737b1d55ab2afd42e90ec93505776bacf5461/python/GafferUI/Widget.py#L147-L149

We're parenting self.__gafferWidget before we register the Qt<->Gaffer relationship on the next line. That means that ClassVectorParameter is failing to find the expected ancestor, even though parentChanged() has been signalled and we'd therefore expect to find one. Reordering to register the relationship has it's own problems though - since this is all happening in the Widget constructor, it means that instead of no ancestor, you'd find a half-constructed one, which is perhaps even worse. Really I think this should be considered to be a bug in Widget, but fixing it seems non-trivial.

The solution in this case is to use an ancestor not quite so high up in the hierarchy, that we're lucky enough to be able to access. None of this is pretty by any means, but it's a minimal change and it seems to work.

Fixes #665.