### PR TITLE
ExecutableNode Process support

### DIFF
--- a/apps/execute/execute-1.py
+++ b/apps/execute/execute-1.py
@@ -147,7 +147,7 @@ class execute( Gaffer.Application ) :
 		with context :
 			for node in nodes :
 				try :
-					node.executeSequence( frames )
+					node["task"].executeSequence( frames )
 				except Exception as exception :
 					IECore.msg(
 						IECore.Msg.Level.Debug,

--- a/doc/config/Doxyfile
+++ b/doc/config/Doxyfile
@@ -760,6 +760,7 @@ WARN_LOGFILE           =
 
 INPUT                  = include/Gaffer \
                          include/GafferUI \
+                         include/GafferDispatch \
                          include/GafferScene \
                          include/GafferImage \
                          include/GafferRenderMan \
@@ -769,6 +770,7 @@ INPUT                  = include/Gaffer \
                          include/GafferAppleseed \
                          src/Gaffer \
                          src/GafferUI \
+                         src/GafferDispatch \
                          src/GafferScene \
                          src/GafferImage \
                          src/GafferRenderMan \

--- a/include/GafferDispatch/Dispatcher.h
+++ b/include/GafferDispatch/Dispatcher.h
@@ -204,7 +204,7 @@ class Dispatcher : public Gaffer::Node
 		/// be executed first. This DAG is the primary
 		/// data structure used in the dispatch process.
 		///
-		/// All tasks within a batch are from the same node
+		/// All tasks within a batch are from the same plug
 		/// and have identical contexts except for the frame
 		/// number.
 		class TaskBatch : public IECore::RefCounted
@@ -212,12 +212,16 @@ class Dispatcher : public Gaffer::Node
 			public :
 
 				TaskBatch();
+				TaskBatch( ExecutableNode::ConstTaskPlugPtr plug, Gaffer::ConstContextPtr context );
+				/// \deprecated
 				TaskBatch( ConstExecutableNodePtr node, Gaffer::ConstContextPtr context );
 
 				IE_CORE_DECLAREMEMBERPTR( TaskBatch );
 
 				void execute() const;
 
+				const ExecutableNode::TaskPlug *plug() const;
+				/// \deprecated.
 				const ExecutableNode *node() const;
 				const Gaffer::Context *context() const;
 
@@ -232,7 +236,7 @@ class Dispatcher : public Gaffer::Node
 
 			private :
 
-				ConstExecutableNodePtr m_node;
+				ExecutableNode::ConstTaskPlugPtr m_plug;
 				Gaffer::ConstContextPtr m_context;
 				IECore::CompoundDataPtr m_blindData;
 				std::vector<float> m_frames;

--- a/include/GafferDispatch/Dispatcher.h
+++ b/include/GafferDispatch/Dispatcher.h
@@ -124,6 +124,11 @@ class Dispatcher : public Gaffer::Node
 		/// Calls doDispatch, taking care to trigger the dispatch signals at the appropriate times.
 		/// Note that this will throw unless all of the nodes are either ExecutableNodes or Boxes,
 		/// and it will also throw if cycles are detected in the resulting TaskBatch graph.
+		/// \todo Replace this with a version taking vector<TaskPlugPtr>. This will plug the
+		/// type safety issue whereby currently any old node can be passed to dispatch.
+		/// Alternatively, perhaps the tasks to dispatch should be specified via connections
+		/// into a "tasks" ArrayPlug, so dispatchers can optionally live directly in the node
+		/// graph.
 		void dispatch( const std::vector<Gaffer::NodePtr> &nodes ) const;
 
 		enum FramesMode

--- a/include/GafferDispatch/ExecutableNode.h
+++ b/include/GafferDispatch/ExecutableNode.h
@@ -66,31 +66,44 @@ class ExecutableNode : public Gaffer::Node
 
 	public :
 
-		/// Defines the execution of an ExecutableNode in a specific Context.
+		IE_CORE_FORWARDDECLARE( TaskPlug )
+
+		/// Defines a task for dispatch by storing a TaskPlug and
+		/// the context in which it should be executed. This is
+		/// primarily for the use of Dispatcher classes. See TaskPlug
+		/// for the main public interface for the execution of
+		/// individual tasks.
 		class Task
 		{
 			public :
 
+				/// Constructs a task representing a call to
+				/// `plug->execute()` in the specified context.
+				/// A copy of the context is stored.
+				Task( ConstTaskPlugPtr plug, const Gaffer::Context *context );
 				Task( const Task &t );
-				/// Constructs a task representing the execution of
-				/// node n in context c. A copy of the context is
-				/// taken.
-				Task( ExecutableNodePtr n, const Gaffer::Context *c );
-				/// Returns the node to be executed.
-				const ExecutableNode *node() const;
-				/// Returns the context to execute the node in.
+				/// Returns the TaskPlug component of the task.
+				const TaskPlug *plug() const;
+				/// Returns the Context component of the task.
 				const Gaffer::Context *context() const;
-				/// A hash uniquely representing the side effects
-				/// of the task. This is stored from ExecutableNode::hash()
+				/// Returns a hash uniquely representing the side effects
+				/// of the task. This is stored from `plug->hash()`
 				/// during construction, so editing the node or upstream
 				/// graph will invalidate the hash (and therefore the task).
 				const IECore::MurmurHash hash() const;
+				/// Compares hashes.
 				bool operator == ( const Task &rhs ) const;
+				/// Compares hashes.
 				bool operator < ( const Task &rhs ) const;
+
+				/// \deprecated
+				Task( ExecutableNodePtr n, const Gaffer::Context *c );
+				/// \deprecated
+				const ExecutableNode *node() const;
 
 			private :
 
-				ConstExecutableNodePtr m_node;
+				ConstTaskPlugPtr m_plug;
 				Gaffer::ConstContextPtr m_context;
 				IECore::MurmurHash m_hash;
 
@@ -104,8 +117,9 @@ class ExecutableNode : public Gaffer::Node
 		ExecutableNode( const std::string &name=defaultName<ExecutableNode>() );
 		virtual ~ExecutableNode();
 
-		/// The plug type used to connect ExecutableNodes
-		/// together to define order of execution.
+		/// Plug type used to represent tasks within the
+		/// node graph. This provides the primary public
+		/// interface for querying and executing tasks.
 		class TaskPlug : public Gaffer::Plug
 		{
 
@@ -119,10 +133,37 @@ class ExecutableNode : public Gaffer::Node
 				virtual bool acceptsInput( const Gaffer::Plug *input ) const;
 				virtual Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
 
+				/// Returns a hash representing the side effects of
+				/// calling `execute()` in the current context.
+				IECore::MurmurHash hash() const;
+				/// Executes the task for the current context.
+				void execute() const;
+				/// Executes a sequence of tasks by taking the current context
+				/// and varying it over the sequence of frames. This should be
+				/// preferred over `execute()` if `requiresSequenceExecution()`
+				/// returns true.
+				void executeSequence( const std::vector<float> &frames ) const;
+				/// Returns true if multiple frame execution must be done
+				/// via a single call to `executeSequence()`, and shouldn't
+				/// be split into several distinct calls.
+				bool requiresSequenceExecution() const;
+
+				/// Fills tasks with all Tasks that must be completed before `execute()`
+				/// is called in the current context. Primarily for use by the Dispatcher
+				/// class.
+				void preTasks( Tasks &tasks ) const;
+				/// Fills tasks with Tasks that must be executed following the execution
+				/// of this node in the current context. Primarily for use by the Dispatcher
+				/// class.
+				void postTasks( Tasks &tasks ) const;
+
+			private :
+
+				const ExecutableNode *executableNode() const;
+
 		};
 
 		typedef Gaffer::FilteredChildIterator<Gaffer::PlugPredicate<Gaffer::Plug::Invalid, TaskPlug> > TaskPlugIterator;
-		IE_CORE_DECLAREPTR( TaskPlug )
 
 		/// Input plugs to which upstream tasks may be connected to cause them
 		/// to be executed before this node.
@@ -145,36 +186,41 @@ class ExecutableNode : public Gaffer::Node
 		Gaffer::Plug *dispatcherPlug();
 		const Gaffer::Plug *dispatcherPlug() const;
 
-		/// Fills tasks with all Tasks that must be completed before execute
-		/// can be called with the given context. The default implementation collects
+	/// All methods below here are considered to be protected, and will become
+	/// so in a future release. Use the TaskPlug accessor methods instead of
+	/// calling them directly.
+	/// \todo Add protected access specifier.
+
+		/// Called by `TaskPlug::preTasks()`. The default implementation collects
 		/// the upstream Tasks connected into the preTasksPlug().
-		/// \todo Remove the context argument and use the current context instead.
+		/// \todo Add `const TaskPlug *plug` argument, to allow ExecutableNodes to
+		/// have multiple output tasks should they so desire.
 		virtual void preTasks( const Gaffer::Context *context, Tasks &tasks ) const;
 
-		/// Fills tasks with Tasks that must be executed following the execution
-		/// of this node in the given context. The default implementation collects
+		/// Called by `TaskPlug::postTasks()`. The default implementation collects
 		/// the tasks connected into the postTasksPlug().
-		/// \todo Remove the context argument and use the current context instead.
+		/// \todo Add `const TaskPlug *plug` argument.
 		virtual void postTasks( const Gaffer::Context *context, Tasks &tasks ) const;
 
-		/// Returns a hash that uniquely represents the side effects (e.g. files created)
-		/// of calling execute with the given context. Derived nodes should call the base
+		/// Called by `TaskPlug::hash()`. Derived nodes should first call the base
 		/// implementation and append to the returned hash. Nodes can indicate that they
 		/// don't cause side effects for the given context by returning a default hash.
-		/// \todo Remove the context argument and use the current context instead.
+		/// \todo Add `const TaskPlug *plug` argument.
 		virtual IECore::MurmurHash hash( const Gaffer::Context *context ) const = 0;
 
-		/// Executes this node using the current Context.
+		/// Called by `TaskPlug::execute()`.
+		/// \todo Add `const TaskPlug *plug, const Context *context` arguments,
+		/// to allow ExecutableNodes to have multiple output tasks should
+		/// they so desire.
 		virtual void execute() const = 0;
 
-		/// Executes this node by copying the current Context and varying it over the sequence of frames.
-		/// The default implementation modifies the current Context and calls execute() for each frame.
-		/// Derived classes which need more specialized behaviour should re-implement executeSequence()
-		/// along with requiresSequenceExecution().
+		/// Called by `TaskPlug::executeSequence()`.
+		/// \todo Add `const TaskPlug *plug, const Context *context` arguments.
 		virtual void executeSequence( const std::vector<float> &frames ) const;
 
-		/// Returns true if the node must execute a sequence of frames all at once.
+		/// Called by `TaskPlug::requiresSequenceExecution()`.
 		/// The default implementation returns false.
+		/// \todo Add `const TaskPlug *plug, const Context *context` arguments.
 		virtual bool requiresSequenceExecution() const;
 
 	private :

--- a/include/GafferDispatch/ExecutableNode.h
+++ b/include/GafferDispatch/ExecutableNode.h
@@ -158,10 +158,6 @@ class ExecutableNode : public Gaffer::Node
 				/// class.
 				void postTasks( Tasks &tasks ) const;
 
-			private :
-
-				const ExecutableNode *executableNode() const;
-
 		};
 
 		typedef Gaffer::FilteredChildIterator<Gaffer::PlugPredicate<Gaffer::Plug::Invalid, TaskPlug> > TaskPlugIterator;

--- a/include/GafferDispatch/ExecutableNode.h
+++ b/include/GafferDispatch/ExecutableNode.h
@@ -110,6 +110,7 @@ class ExecutableNode : public Gaffer::Node
 		};
 
 		typedef std::vector<Task> Tasks;
+		/// \todo This is unused - remove it.
 		typedef std::vector<Gaffer::ConstContextPtr> Contexts;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferDispatch::ExecutableNode, ExecutableNodeTypeId, Gaffer::Node );

--- a/python/GafferAppleseedTest/AppleseedRenderTest.py
+++ b/python/GafferAppleseedTest/AppleseedRenderTest.py
@@ -107,7 +107,7 @@ class AppleseedRenderTest( GafferTest.TestCase ) :
 		s["fileName"].setValue( self.__scriptFileName )
 		s.save()
 
-		s["render"].execute()
+		s["render"]["task"].execute()
 
 		self.failUnless( os.path.exists( self.temporaryDirectory() + "/test.exr" ) )
 
@@ -166,7 +166,7 @@ class AppleseedRenderTest( GafferTest.TestCase ) :
 		for i in range( 1, 4 ) :
 			c.setFrame( i )
 			with c :
-				s["render"].execute()
+				s["render"]["task"].execute()
 
 		for i in range( 1, 4 ) :
 			self.failUnless( os.path.exists( self.temporaryDirectory() + "/test.%04d.exr" % i ) )
@@ -220,7 +220,7 @@ class AppleseedRenderTest( GafferTest.TestCase ) :
 		s.save()
 
 		with s.context() :
-			s["render"].execute()
+			s["render"]["task"].execute()
 
 		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/renderTests" ) )
 		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/appleseedTests" ) )
@@ -230,7 +230,7 @@ class AppleseedRenderTest( GafferTest.TestCase ) :
 		# check it can cope with everything already existing
 
 		with s.context() :
-			s["render"].execute()
+			s["render"]["task"].execute()
 
 		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/renderTests" ) )
 		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/appleseedTests" ) )

--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -109,7 +109,7 @@ class ArnoldRenderTest( GafferTest.TestCase ) :
 
 		s["fileName"].setValue( self.__scriptFileName )
 
-		s["render"].execute()
+		s["render"]["task"].execute()
 
 		self.failUnless( os.path.exists( self.temporaryDirectory() + "/test.tif" ) )
 
@@ -168,7 +168,7 @@ class ArnoldRenderTest( GafferTest.TestCase ) :
 		for i in range( 1, 4 ) :
 			c.setFrame( i )
 			with c :
-				s["render"].execute()
+				s["render"]["task"].execute()
 
 		for i in range( 1, 4 ) :
 			self.failUnless( os.path.exists( self.temporaryDirectory() + "/test.%04d.tif" % i ) )
@@ -220,7 +220,7 @@ class ArnoldRenderTest( GafferTest.TestCase ) :
 		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 
 		with s.context() :
-			s["render"].execute()
+			s["render"]["task"].execute()
 
 		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/renderTests" ) )
 		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/assTests" ) )
@@ -229,7 +229,7 @@ class ArnoldRenderTest( GafferTest.TestCase ) :
 		# check it can cope with everything already existing
 
 		with s.context() :
-			s["render"].execute()
+			s["render"]["task"].execute()
 
 		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/renderTests" ) )
 		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/assTests" ) )
@@ -325,7 +325,7 @@ class ArnoldRenderTest( GafferTest.TestCase ) :
 		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s.save()
 
-		s["render"].execute()
+		s["render"]["task"].execute()
 
 		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/test.ass" ) )
 

--- a/python/GafferCortexTest/ObjectWriterTest.py
+++ b/python/GafferCortexTest/ObjectWriterTest.py
@@ -81,7 +81,7 @@ class ObjectWriterTest( GafferTest.TestCase ) :
 
 		self.failIf( os.path.exists( self.__exrFileName ) )
 		with Gaffer.Context() :
-			node.execute()
+			node["task"].execute()
 		self.failUnless( os.path.exists( self.__exrFileName ) )
 
 		checker2 = IECore.Reader.create( self.__exrFileName ).read()
@@ -99,7 +99,7 @@ class ObjectWriterTest( GafferTest.TestCase ) :
 		node["fileName"].setValue( self.__tifFileName )
 
 		with Gaffer.Context() :
-			node.execute()
+			node["task"].execute()
 		self.failUnless( os.path.exists( self.__tifFileName ) )
 
 		self.failUnless( IECore.TIFFImageReader.canRead( self.__tifFileName ) )
@@ -135,7 +135,7 @@ class ObjectWriterTest( GafferTest.TestCase ) :
 			context = Gaffer.Context()
 			context.setFrame( i )
 			with context :
-				node.execute()
+				node["task"].execute()
 
 		for f in self.__exrSequence.fileNames() :
 			self.failUnless( os.path.exists( f ) )
@@ -151,23 +151,36 @@ class ObjectWriterTest( GafferTest.TestCase ) :
 		s["n"] = GafferCortex.ObjectWriter()
 
 		# no file produces no effect
-		self.assertEqual( s["n"].hash( c ), IECore.MurmurHash() )
+		with c :
+			self.assertEqual( s["n"]["task"].hash(), IECore.MurmurHash() )
 
 		# no input object produces no effect
-		s["n"]["fileName"].setValue( self.__exrFileName )
-		self.assertEqual( s["n"].hash( c ), IECore.MurmurHash() )
+		with c :
+			s["n"]["fileName"].setValue( self.__exrFileName )
+			self.assertEqual( s["n"]["task"].hash(), IECore.MurmurHash() )
 
 		# now theres a file and object, we get some output
-		s["sphere"] = GafferTest.SphereNode()
-		s["n"]["in"].setInput( s["sphere"]["out"] )
-		self.assertNotEqual( s["n"].hash( c ), IECore.MurmurHash() )
+		with c :
+			s["sphere"] = GafferTest.SphereNode()
+			s["n"]["in"].setInput( s["sphere"]["out"] )
+			self.assertNotEqual( s["n"]["task"].hash(), IECore.MurmurHash() )
 
 		# output doesn't vary by time
-		self.assertEqual( s["n"].hash( c ), s["n"].hash( c2 ) )
+		with c :
+			h1 = s["n"]["task"].hash()
+		with c2 :
+			h2 = s["n"]["task"].hash()
+
+		self.assertEqual( h1, h2 )
 
 		# output varies by time since the file name does
 		s["n"]["fileName"].setValue( self.__exrSequence.fileName )
-		self.assertNotEqual( s["n"].hash( c ), s["n"].hash( c2 ) )
+		with c :
+			h1 = s["n"]["task"].hash()
+		with c2 :
+			h2 = s["n"]["task"].hash()
+
+		self.assertNotEqual( h1, h2 )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferDispatch/LocalDispatcher.py
+++ b/python/GafferDispatch/LocalDispatcher.py
@@ -77,7 +77,7 @@ class LocalDispatcher( GafferDispatch.Dispatcher ) :
 			# use signals to report changes in status, and the JobPool should connect to those
 			# signals. Jobs should be blissfully ignorant of JobPools.
 			self.__dispatcher = dispatcher
-			script = batch.preTasks()[0].node().scriptNode()
+			script = batch.preTasks()[0].plug().ancestor( Gaffer.ScriptNode )
 			self.__context = Gaffer.Context( script.context() )
 
 			self.__name = name
@@ -111,7 +111,7 @@ class LocalDispatcher( GafferDispatch.Dispatcher ) :
 		def description( self ) :
 
 			batch = self.__currentBatch( self.__batch )
-			if batch is None or batch.node() is None :
+			if batch is None or batch.plug() is None :
 				return "N/A"
 
 			frames = str( IECore.frameListFromList( [ int(x) for x in batch.frames() ] ) )
@@ -191,7 +191,7 @@ class LocalDispatcher( GafferDispatch.Dispatcher ) :
 				self.__reportKilled( batch )
 				return False
 
-			if not batch.node() or self.__getStatus( batch ) == LocalDispatcher.Job.Status.Complete :
+			if not batch.plug() or self.__getStatus( batch ) == LocalDispatcher.Job.Status.Complete :
 				self.__setStatus( batch, LocalDispatcher.Job.Status.Complete )
 				return True
 
@@ -228,7 +228,7 @@ class LocalDispatcher( GafferDispatch.Dispatcher ) :
 				self.__reportKilled( batch )
 				return False
 
-			if not batch.node() :
+			if not batch.plug() :
 				self.__reportCompleted( batch )
 				return True
 
@@ -331,8 +331,8 @@ class LocalDispatcher( GafferDispatch.Dispatcher ) :
 
 		def __storeNodeNames( self, script, batch ) :
 
-			if batch.node() :
-				batch.blindData()["nodeName"] = batch.node().relativeName( script )
+			if batch.plug() :
+				batch.blindData()["nodeName"] = batch.plug().node().relativeName( script )
 
 			for upstreamBatch in batch.preTasks() :
 				self.__storeNodeNames( script, upstreamBatch )

--- a/python/GafferDispatchTest/PythonCommandTest.py
+++ b/python/GafferDispatchTest/PythonCommandTest.py
@@ -68,10 +68,10 @@ class PythonCommandTest( GafferTest.TestCase ) :
 
 		n.executionCount = 0
 
-		n.execute()
+		n["task"].execute()
 		self.assertEqual( n.executionCount, 1 )
 
-		n.execute()
+		n["task"].execute()
 		self.assertEqual( n.executionCount, 2 )
 
 	def testVariables( self ) :
@@ -88,7 +88,7 @@ class PythonCommandTest( GafferTest.TestCase ) :
 			"""
 		) )
 
-		n.execute()
+		n["task"].execute()
 
 		self.assertEqual( n.testInt, 1 )
 		self.assertEqual( n.testFloat, 2.5 )
@@ -107,7 +107,7 @@ class PythonCommandTest( GafferTest.TestCase ) :
 		with Gaffer.Context() as c :
 			c.setFrame( 10 )
 			c["testInt"] = 2
-			n.execute()
+			n["task"].execute()
 
 		self.assertEqual( n.frame, 10 )
 		self.assertEqual( n.testInt, 2 )
@@ -121,17 +121,17 @@ class PythonCommandTest( GafferTest.TestCase ) :
 
 		with Gaffer.Context() as c :
 
-			h = n.hash( c )
+			h = n["task"].hash()
 
 			c.setTime( 2 )
-			self.assertEqual( n.hash( c ), h )
+			self.assertEqual( n["task"].hash(), h )
 			c.setTime( 3 )
-			self.assertEqual( n.hash( c ), h )
+			self.assertEqual( n["task"].hash(), h )
 
 			c["testInt"] = 10
-			self.assertEqual( n.hash( c ), h )
+			self.assertEqual( n["task"].hash(), h )
 			c["testInt"] = 20
-			self.assertEqual( n.hash( c ), h )
+			self.assertEqual( n["task"].hash(), h )
 
 		# If we access the frame, then we should
 		# be sensitive to the time, but not anything else
@@ -141,13 +141,13 @@ class PythonCommandTest( GafferTest.TestCase ) :
 		with Gaffer.Context() as c :
 
 			c.setTime( 1 )
-			h1 = n.hash( c )
+			h1 = n["task"].hash()
 
 			c.setTime( 2 )
-			h2 = n.hash( c )
+			h2 = n["task"].hash()
 
 			c.setTime( 3 )
-			h3 = n.hash( c )
+			h3 = n["task"].hash()
 
 			self.assertNotEqual( h1, h )
 			self.assertNotEqual( h2, h1 )
@@ -155,9 +155,9 @@ class PythonCommandTest( GafferTest.TestCase ) :
 			self.assertNotEqual( h3, h1 )
 
 			c["testInt"] = 10
-			self.assertEqual( n.hash( c ), h3 )
+			self.assertEqual( n["task"].hash(), h3 )
 			c["testInt"] = 20
-			self.assertEqual( n.hash( c ), h3 )
+			self.assertEqual( n["task"].hash(), h3 )
 
 		# The same should apply if we access the frame
 		# via subscripting rather than the method.
@@ -167,13 +167,13 @@ class PythonCommandTest( GafferTest.TestCase ) :
 		with Gaffer.Context() as c :
 
 			c.setTime( 1 )
-			h1 = n.hash( c )
+			h1 = n["task"].hash()
 
 			c.setTime( 2 )
-			h2 = n.hash( c )
+			h2 = n["task"].hash()
 
 			c.setTime( 3 )
-			h3 = n.hash( c )
+			h3 = n["task"].hash()
 
 			self.assertNotEqual( h1, h )
 			self.assertNotEqual( h2, h1 )
@@ -181,9 +181,9 @@ class PythonCommandTest( GafferTest.TestCase ) :
 			self.assertNotEqual( h3, h1 )
 
 			c["testInt"] = 10
-			self.assertEqual( n.hash( c ), h3 )
+			self.assertEqual( n["task"].hash(), h3 )
 			c["testInt"] = 20
-			self.assertEqual( n.hash( c ), h3 )
+			self.assertEqual( n["task"].hash(), h3 )
 
 		# Likewise, accessing other variables should
 		# affect the hash.
@@ -193,22 +193,22 @@ class PythonCommandTest( GafferTest.TestCase ) :
 		with Gaffer.Context() as c :
 
 			c["testInt"] = 1
-			h1 = n.hash( c )
+			h1 = n["task"].hash()
 
 			c["testInt"] = 2
-			h2 = n.hash( c )
+			h2 = n["task"].hash()
 
 			c["testInt"] = 3
-			h3 = n.hash( c )
+			h3 = n["task"].hash()
 
 			self.assertNotEqual( h2, h1 )
 			self.assertNotEqual( h3, h2 )
 			self.assertNotEqual( h3, h1 )
 
 			c.setFrame( 2 )
-			self.assertEqual( n.hash( c ), h3 )
+			self.assertEqual( n["task"].hash(), h3 )
 			c.setFrame( 3 )
-			self.assertEqual( n.hash( c ), h3 )
+			self.assertEqual( n["task"].hash(), h3 )
 
 	def testRequiresSequenceExecution( self ) :
 
@@ -295,7 +295,7 @@ class PythonCommandTest( GafferTest.TestCase ) :
 
 		with Gaffer.Context() as c :
 			c.setFrame( 10 )
-			s["n"].execute()
+			s["n"]["task"].execute()
 
 		self.assertEqual( s["n"].frameString, "010" )
 

--- a/python/GafferDispatchTest/SystemCommandTest.py
+++ b/python/GafferDispatchTest/SystemCommandTest.py
@@ -50,7 +50,7 @@ class SystemCommandTest( GafferTest.TestCase ) :
 		n = GafferDispatch.SystemCommand()
 		n["command"].setValue( "touch " + self.temporaryDirectory() + "/systemCommandTest.txt" )
 
-		n.execute()
+		n["task"].execute()
 
 		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/systemCommandTest.txt" ) )
 
@@ -60,7 +60,7 @@ class SystemCommandTest( GafferTest.TestCase ) :
 		n["command"].setValue( "env > " + self.temporaryDirectory() + "/systemCommandTest.txt" )
 		n["environmentVariables"].addMember( "GAFFER_SYSTEMCOMMAND_TEST", IECore.StringData( "test" ) )
 
-		n.execute()
+		n["task"].execute()
 
 		env = "".join( open( self.temporaryDirectory() + "/systemCommandTest.txt" ).readlines() )
 		self.assertTrue( "GAFFER_SYSTEMCOMMAND_TEST=test" in env )
@@ -72,7 +72,7 @@ class SystemCommandTest( GafferTest.TestCase ) :
 		n["substitutions"].addMember( "adjective", IECore.StringData( "red" ) )
 		n["substitutions"].addMember( "noun", IECore.StringData( "truck" ) )
 
-		n.execute()
+		n["task"].execute()
 		self.assertEqual( "red truck\n", open( self.temporaryDirectory() + "/systemCommandTest.txt" ).readlines()[0] )
 
 	def testHash( self ) :
@@ -80,19 +80,19 @@ class SystemCommandTest( GafferTest.TestCase ) :
 		hashes = []
 
 		n = GafferDispatch.SystemCommand()
-		hashes.append( n.hash( Gaffer.Context.current() ) )
+		hashes.append( n["task"].hash() )
 
 		n["command"].setValue( "env" )
-		hashes.append( n.hash( Gaffer.Context.current() ) )
+		hashes.append( n["task"].hash() )
 
 		n["command"].setValue( "echo abc" )
-		hashes.append( n.hash( Gaffer.Context.current() ) )
+		hashes.append( n["task"].hash() )
 
 		n["substitutions"].addMember( "test", IECore.StringData( "value" ) )
-		hashes.append( n.hash( Gaffer.Context.current() ) )
+		hashes.append( n["task"].hash() )
 
 		n["environmentVariables"].addMember( "test", IECore.StringData( "value" ) )
-		hashes.append( n.hash( Gaffer.Context.current() ) )
+		hashes.append( n["task"].hash() )
 
 		# check that all hashes are unique
 		self.assertEqual( len( hashes ), len( set( hashes ) ) )

--- a/python/GafferDispatchTest/TaskContextVariablesTest.py
+++ b/python/GafferDispatchTest/TaskContextVariablesTest.py
@@ -128,5 +128,19 @@ class TaskContextVariablesTest( GafferTest.TestCase ) :
 		d = self.__dispatcher()
 		self.assertRaisesRegexp( RuntimeError, "cannot have cyclic dependencies", d.dispatch, [ s["variables"] ] )
 
+	def testStringSubstitutions( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["l"] = GafferDispatchTest.LoggingExecutableNode()
+		s["v"] = GafferDispatch.TaskContextVariables()
+		s["v"]["preTasks"][0].setInput( s["l"]["task"] )
+		s["v"]["variables"].addMember( "test", "test.####.cob" )
+
+		with Gaffer.Context() as c :
+			c.setFrame( 100 )
+			self.__dispatcher().dispatch( [ s["v"] ] )
+
+		self.assertEqual( s["l"].log[0].context["test"], "test.0100.cob" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferDispatchTest/TaskListTest.py
+++ b/python/GafferDispatchTest/TaskListTest.py
@@ -47,14 +47,20 @@ class TaskListTest( GafferTest.TestCase ) :
 	def test( self ) :
 
 		n = GafferDispatch.TaskList()
-		c = Gaffer.Context()
-		c2 = Gaffer.Context()
-		c2["frame"] = 10.0
-		self.assertEqual( n.hash( c ), n.hash( c2 ) )
+		with Gaffer.Context() as c :
+
+			h1 = n["task"].hash()
+			c["frame"] = 10.0
+			h2 = n["task"].hash()
+
+			self.assertEqual( h1, h2 )
 
 		n2 = GafferDispatch.TaskList( "TaskList2" )
-		self.assertEqual( n.hash( c ), n2.hash( c ) )
-		self.assertEqual( n.hash( c2 ), n2.hash( c2 ) )
+		with Gaffer.Context() as c :
+
+			self.assertEqual( n2["task"].hash(), h1 )
+			c["frame"] = 10.0
+			self.assertEqual( n2["task"].hash(), h2 )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageTest/ImageWriterTest.py
+++ b/python/GafferImageTest/ImageWriterTest.py
@@ -69,7 +69,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		w["fileName"].setValue( testFile )
 		w["channels"].setValue( IECore.StringVectorData( ["R","B"] ) )
 		with Gaffer.Context() :
-			w.execute()
+			w["task"].execute()
 
 		writerOutput = GafferImage.ImageReader()
 		writerOutput["fileName"].setValue( testFile )
@@ -264,8 +264,8 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 
 		# Try to execute. In older versions of the ImageWriter this would throw an exception.
 		with s.context() :
-			w1.execute()
-			w2.execute()
+			w1["task"].execute()
+			w2["task"].execute()
 		self.failUnless( os.path.exists( testScanlineFile ) )
 		self.failUnless( os.path.exists( testTileFile ) )
 
@@ -333,7 +333,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 			w["fileName"].setValue( testFile )
 
 			with Gaffer.Context() :
-				w.execute()
+				w["task"].execute()
 
 	# Write an RGBA image that has a data window to various supported formats and in both scanline and tile modes.
 	def __testExtension( self, ext, formatName, options = {}, metadataToIgnore = [] ) :
@@ -379,7 +379,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 
 			# Execute
 			with Gaffer.Context() :
-				w.execute()
+				w["task"].execute()
 			self.failUnless( os.path.exists( testFile ), "Failed to create file : {} ({}) : {}".format( ext, name, testFile ) )
 
 			# Check the output.
@@ -483,7 +483,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 
 		# Execute
 		with Gaffer.Context() :
-			w.execute()
+			w["task"].execute()
 		self.failUnless( os.path.exists( testFile ), "Failed to create file : {} : {}".format( ext, testFile ) )
 
 		# Check the output.
@@ -512,7 +512,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		w["in"].setInput( c["out"] )
 		w["fileName"].setValue( testFile )
 
-		w.execute()
+		w["task"].execute()
 
 		self.failUnless( os.path.exists( testFile ) )
 		i = IECore.Reader.create( testFile ).read()
@@ -598,7 +598,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		w["fileName"].setValue( testFile )
 
 		with Gaffer.Context() :
-			w.execute()
+			w["task"].execute()
 		self.failUnless( os.path.exists( testFile ) )
 
 		result = GafferImage.ImageReader()
@@ -612,7 +612,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		s.addChild( w )
 
 		with Gaffer.Context() :
-			w.execute()
+			w["task"].execute()
 
 		result["refreshCount"].setValue( result["refreshCount"].getValue() + 1 )
 		self.assertEqual( result["out"]["metadata"].getValue()["DocumentName"].value, "untitled" )
@@ -621,7 +621,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		s["fileName"].setValue( "/my/gaffer/script.gfr" )
 
 		with Gaffer.Context() :
-			w.execute()
+			w["task"].execute()
 
 		result["refreshCount"].setValue( result["refreshCount"].getValue() + 1 )
 		self.assertEqual( result["out"]["metadata"].getValue()["DocumentName"].value, "/my/gaffer/script.gfr" )
@@ -669,8 +669,8 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( inMetadata["oiio:Gamma"], IECore.FloatData( 0.25 ) )
 
 		with Gaffer.Context() :
-			w.execute()
-			w2.execute()
+			w["task"].execute()
+			w2["task"].execute()
 		self.failUnless( os.path.exists( testFile ) )
 		self.failUnless( os.path.exists( testFile2 ) )
 
@@ -775,7 +775,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		w["fileName"].setValue( testFile )
 
 		with Gaffer.Context():
-			w.execute()
+			w["task"].execute()
 		self.failUnless( os.path.exists( testFile ) )
 
 		after = GafferImage.ImageReader()
@@ -808,7 +808,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		w["channels"].setValue( IECore.StringVectorData( f["out"]["channelNames"].getValue() ) )
 
 		with Gaffer.Context() :
-			w.execute()
+			w["task"].execute()
 		self.failUnless( os.path.exists( testFile ) )
 
 		after = GafferImage.ImageReader()
@@ -869,7 +869,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		context = Gaffer.Context( s.context() )
 		context["ext"] = "tif"
 		with context :
-			s["w"].execute()
+			s["w"]["task"].execute()
 
 		self.assertTrue( os.path.isfile( self.temporaryDirectory() + "/test.tif" ) )
 
@@ -887,10 +887,10 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 			self.assertRaisesRegexp( RuntimeError, "could not find a format writer for", s["w"].execute )
 
 			s["w"]["fileName"].setValue( self.temporaryDirectory() + "/test.tif" )
-			s["w"].execute()
+			s["w"]["task"].execute()
 
 			os.chmod( self.temporaryDirectory() + "/test.tif", 0o444 )
-			self.assertRaisesRegexp( RuntimeError, "Could not open", s["w"].execute )
+			self.assertRaisesRegexp( RuntimeError, "Could not open", s["w"]["task"].execute )
 
 	def testWriteIntermediateFile( self ) :
 

--- a/python/GafferImageTest/ResampleTest.py
+++ b/python/GafferImageTest/ResampleTest.py
@@ -93,7 +93,7 @@ class ResampleTest( GafferImageTest.ImageTestCase ) :
 			writer = GafferImage.ImageWriter()
 			writer["in"].setInput( crop["out"] )
 			writer["fileName"].setValue( outputFileName )
-			writer.execute()
+			writer["task"].execute()
 
 			result = GafferImage.ImageReader()
 			result["fileName"].setValue( writer["fileName"].getValue() )

--- a/python/GafferSceneTest/OpenGLRenderTest.py
+++ b/python/GafferSceneTest/OpenGLRenderTest.py
@@ -87,7 +87,7 @@ class OpenGLRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s.save()
 
-		s["render"].execute()
+		s["render"]["task"].execute()
 
 		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/test.exr" ) )
 
@@ -127,7 +127,7 @@ class OpenGLRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["fileName"].setValue( "/tmp/test.gfr" )
 
 		with s.context() :
-			s["render"].execute()
+			s["render"]["task"].execute()
 
 		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/openGLRenderTest" ) )
 		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/openGLRenderTest/test.0001.exr" ) )

--- a/python/GafferSceneTest/RenderTest.py
+++ b/python/GafferSceneTest/RenderTest.py
@@ -73,7 +73,7 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 		# CapturingRenderer outputs some spurious errors which
 		# we suppress by capturing them.
 		with IECore.CapturingMessageHandler() :
-			s["r"].execute()
+			s["r"]["task"].execute()
 
 		w = s["r"].world()
 		lights = self.__allState( s["r"].world(), IECore.Light )
@@ -103,7 +103,7 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 		# CapturingRenderer outputs some spurious errors which
 		# we suppress by capturing them.
 		with IECore.CapturingMessageHandler() :
-			s["r"].execute()
+			s["r"]["task"].execute()
 
 		w = s["r"].world()
 		lights = self.__allState( s["r"].world(), IECore.Light )
@@ -113,7 +113,7 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["v"]["attributes"]["visibility"]["value"].setValue( False )
 		with IECore.CapturingMessageHandler() :
-			s["r"].execute()
+			s["r"]["task"].execute()
 
 		w = s["r"].world()
 		lights = self.__allState( s["r"].world(), IECore.Light )
@@ -136,7 +136,7 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 		# CapturingRenderer outputs some spurious errors which
 		# we suppress by capturing them.
 		with IECore.CapturingMessageHandler() :
-			s["r"].execute()
+			s["r"]["task"].execute()
 
 		w = s["r"].world()
 		l = w.children()[0].state()
@@ -162,7 +162,7 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 		# CapturingRenderer outputs some spurious errors which
 		# we suppress by capturing them.
 		with IECore.CapturingMessageHandler() :
-			s["r"].execute()
+			s["r"]["task"].execute()
 
 		w = s["r"].world()
 		self.assertEqual( w.children()[0].state()[0].attributes["name"].value, "/group/light" )
@@ -187,7 +187,7 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 		# CapturingRenderer outputs some spurious errors which
 		# we suppress by capturing them.
 		with IECore.CapturingMessageHandler() :
-			s["r"].execute()
+			s["r"]["task"].execute()
 
 		w = s["r"].world()
 
@@ -218,7 +218,7 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 			# we suppress by capturing them.
 			with IECore.CapturingMessageHandler() :
 				with s.context() :
-					s["r"].execute()
+					s["r"]["task"].execute()
 
 		self.assertTrue( "/group/invalid" in str( a.exception ) )
 
@@ -228,7 +228,7 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 			# we suppress by capturing them.
 			with IECore.CapturingMessageHandler() :
 				with s.context() :
-					s["r"].execute()
+					s["r"]["task"].execute()
 
 		self.assertTrue( "/group/invalid" in str( a.exception ) )
 		self.assertTrue( "does not exist" in str( a.exception ) )
@@ -237,7 +237,7 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 		with self.assertRaises( RuntimeError ) as a :
 			with IECore.CapturingMessageHandler() :
 				with s.context() :
-					s["r"].execute()
+					s["r"]["task"].execute()
 
 		self.assertTrue( "/group/sphere" in str( a.exception ) )
 		self.assertTrue( "is not a camera" in str( a.exception ) )
@@ -257,7 +257,7 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 		# CapturingRenderer outputs some spurious errors which
 		# we suppress by capturing them.
 		with IECore.CapturingMessageHandler() :
-			s["r"].execute()
+			s["r"]["task"].execute()
 
 		self.assertEqual( s["r"].renderer().getOption( "user:test" ), IECore.IntData( 10 ) )
 
@@ -278,7 +278,7 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 		# CapturingRenderer outputs some spurious errors which
 		# we suppress by capturing them.
 		with IECore.CapturingMessageHandler() :
-			s["r"].execute()
+			s["r"]["task"].execute()
 
 		self.assertEqual( s["r"].world().state()[0].attributes["doubleSided"], IECore.BoolData( False ) )
 

--- a/src/GafferDispatchBindings/DispatcherBinding.cpp
+++ b/src/GafferDispatchBindings/DispatcherBinding.cpp
@@ -136,8 +136,16 @@ class DispatcherWrapper : public NodeWrapper<Dispatcher>
 			{
 				return boost::const_pointer_cast<ExecutableNode>( node );
 			}
-
 			return 0;
+		}
+
+		static ExecutableNode::TaskPlugPtr taskBatchPlug( const Dispatcher::TaskBatchPtr &batch )
+		{
+			if( const ExecutableNode::TaskPlug *p = batch->plug() )
+			{
+				return const_cast<ExecutableNode::TaskPlug *>( p );
+			}
+			return NULL;
 		}
 
 		static ContextPtr taskBatchGetContext( const Dispatcher::TaskBatchPtr &batch, bool copy = true )
@@ -329,6 +337,7 @@ void GafferDispatchBindings::bindDispatcher()
 	RefCountedClass<Dispatcher::TaskBatch, RefCounted>( "_TaskBatch" )
 		.def( "execute", &DispatcherWrapper::taskBatchExecute )
 		.def( "node", &DispatcherWrapper::taskBatchGetNode )
+		.def( "plug", &DispatcherWrapper::taskBatchPlug )
 		.def( "context", &DispatcherWrapper::taskBatchGetContext, ( boost::python::arg_( "_copy" ) = true ) )
 		.def( "frames", &DispatcherWrapper::taskBatchGetFrames )
 		.def( "preTasks", &DispatcherWrapper::taskBatchGetPreTasks )


### PR DESCRIPTION
This does the following :

- Adds an API to TaskPlug to provide saner public access to the ExecutableNode methods, which are now "protected" (documented as protected but not actually protected yet for backwards compatibility reasons).
- Exposes the processing performed by ExecutableNodes via the Process class. This makes it possible to monitor them.
- Makes automatic string substitution work for ExecutableNodes (#887).
- Removes the manual string substitutions from the various nodes which had bothered to implement them.

I think it's important that we do this, as it puts the ExecutableNode on a much better footing alongside the rest of our APIs, and #887 is the cause of numerous bugs (some of them yet to be discovered). It'd be great if we could go a bit further and actually break compatibility to get things really tidy, but I haven't done that here since we were hoping for 0.23 to remain the major version for a while.

It's important to note that although substitutions are now automagic, that is only the case if you use the TaskPlug API instead of the deprecated "protected" API to execute nodes (since I removed the manual substitutions). I've updated all Gaffer's code so this is the case, but there may be other code calling `ExecutableNode::execute()` directly rather than via a dispatcher (in Caribou perhaps?). If we're concerned about that, then I can split the removal of manual substitutions out of this PR, and put it into one we merge at a later date.