### PR TITLE
Remove manual ExecutableNode string substitutions

### DIFF
--- a/include/GafferCortex/ExecutableOpHolder.h
+++ b/include/GafferCortex/ExecutableOpHolder.h
@@ -72,10 +72,6 @@ class ExecutableOpHolder : public ParameterisedHolderExecutableNode
 		virtual IECore::MurmurHash hash( const Gaffer::Context *context ) const;
 		virtual void execute() const;
 
-	private :
-
-		void substitute( IECore::Parameter *parameter, const Gaffer::Context *context ) const;
-
 };
 
 IE_CORE_DECLAREPTR( ExecutableOpHolder )

--- a/include/GafferScene/SceneWriter.h
+++ b/include/GafferScene/SceneWriter.h
@@ -81,7 +81,7 @@ class SceneWriter : public GafferDispatch::ExecutableNode
 
 	private :
 
-		void createDirectories( std::string &fileName ) const;
+		void createDirectories( const std::string &fileName ) const;
 		void writeLocation( const GafferScene::ScenePlug *scene, const ScenePlug::ScenePath &scenePath, Gaffer::Context *context, IECore::SceneInterface *output, double time ) const;
 
 		static size_t g_firstPlugIndex;

--- a/python/GafferAppleseed/AppleseedRender.py
+++ b/python/GafferAppleseed/AppleseedRender.py
@@ -82,7 +82,7 @@ class AppleseedRender( GafferScene.ExecutableRender ) :
 
 	def _createRenderer( self ) :
 
-		fileName = self.__fileName()
+		fileName = self["fileName"].getValue()
 		directory = os.path.dirname( fileName )
 		if directory :
 			self._makeDir( directory )
@@ -98,18 +98,8 @@ class AppleseedRender( GafferScene.ExecutableRender ) :
 
 	def _command( self ) :
 		if self["mode"].getValue() == "render" :
-			return "appleseed.cli --message-verbosity %s -c final '%s'" % ( self["verbosity"].getValue(), self.__fileName() )
+			return "appleseed.cli --message-verbosity %s -c final '%s'" % ( self["verbosity"].getValue(), self["fileName"].getValue() )
 
 		return ""
-
-	def __fileName( self ) :
-
-		result = self["fileName"].getValue()
-		# because execute() isn't called inside a compute(), we
-		# don't get string expansions automatically, and have to
-		# do them ourselves.
-		## \todo Can we improve this situation?
-		result = Gaffer.Context.current().substitute( result )
-		return result
 
 IECore.registerRunTimeTyped( AppleseedRender, typeName = "GafferAppleseed::AppleseedRender" )

--- a/python/GafferArnold/ArnoldRender.py
+++ b/python/GafferArnold/ArnoldRender.py
@@ -73,7 +73,7 @@ class ArnoldRender( GafferScene.ExecutableRender ) :
 
 	def _createRenderer( self ) :
 
-		fileName = self.__fileName()
+		fileName = self["fileName"].getValue()
 		directory = os.path.dirname( fileName )
 		if directory :
 			try :
@@ -140,22 +140,14 @@ class ArnoldRender( GafferScene.ExecutableRender ) :
 
 	def _command( self ) :
 
+		fileName = self["fileName"].getValue()
+
 		mode = self["mode"].getValue()
 		if mode == "render" :
-			return "kick -dp -dw -v %d '%s'" % ( self["verbosity"].getValue(), self.__fileName() )
+			return "kick -dp -dw -v %d '%s'" % ( self["verbosity"].getValue(), fileName )
 		elif mode == "expand" :
-			return "kick -v %d -forceexpand -resave '%s' '%s'" % ( self["verbosity"].getValue(), self.__fileName(), self.__fileName() )
+			return "kick -v %d -forceexpand -resave '%s' '%s'" % ( self["verbosity"].getValue(), fileName, fileName )
 
 		return ""
-
-	def __fileName( self ) :
-
-		result = self["fileName"].getValue()
-		# because execute() isn't called inside a compute(), we
-		# don't get string expansions automatically, and have to
-		# do them ourselves.
-		## \todo Can we improve this situation?
-		result = Gaffer.Context.current().substitute( result )
-		return result
 
 IECore.registerRunTimeTyped( ArnoldRender, typeName = "GafferArnold::ArnoldRender" )

--- a/python/GafferCortex/ObjectWriter.py
+++ b/python/GafferCortex/ObjectWriter.py
@@ -103,8 +103,6 @@ class ObjectWriter( GafferDispatch.ExecutableNode ) :
 	def __ensureWriter( self ) :
 
 		fileName = self["fileName"].getValue()
-		## \todo See equivalent todo in ArnoldRender.__fileName()
-		fileName = Gaffer.Context.current().substitute( fileName )
 		if fileName :
 
 			extension = os.path.splitext( fileName )[-1]

--- a/python/GafferDispatch/PythonCommand.py
+++ b/python/GafferDispatch/PythonCommand.py
@@ -151,9 +151,6 @@ class _VariablesDict( dict ) :
 				continue
 			with IECore.IgnoredExceptions( Exception ) :
 				value = value.value
-			if isinstance( value, str ) :
-				## \todo Remove when #887 is fixed.
-				value = self.__context.substitute( value )
 
 			self[name] = value
 

--- a/python/GafferDispatch/SystemCommand.py
+++ b/python/GafferDispatch/SystemCommand.py
@@ -59,8 +59,6 @@ class SystemCommand( GafferDispatch.ExecutableNode ) :
 		substitutions = { key : str( value ) for ( key, value ) in substitutions.items() }
 
 		command = self["command"].getValue()
-		## \todo We can remove this manual subsitution when we finally sort out #887.
-		command = Gaffer.Context.current().substitute( command )
 		command = command.format( **substitutions )
 
 		env = os.environ.copy()

--- a/python/GafferDispatchTest/TextWriter.py
+++ b/python/GafferDispatchTest/TextWriter.py
@@ -56,7 +56,7 @@ class TextWriter( GafferDispatch.ExecutableNode ) :
 	def execute( self ) :
 
 		context = Gaffer.Context.current()
-		fileName = context.substitute( self["fileName"].getValue() )
+		fileName = self["fileName"].getValue()
 
 		directory = os.path.dirname( fileName )
 		if directory :
@@ -80,7 +80,7 @@ class TextWriter( GafferDispatch.ExecutableNode ) :
 			return
 
 		context = Gaffer.Context( Gaffer.Context.current() )
-		fileName = context.substitute( self["fileName"].getValue() )
+		fileName = self["fileName"].getValue()
 
 		with file( fileName, self["mode"].getValue() ) as f :
 			with context :
@@ -94,9 +94,9 @@ class TextWriter( GafferDispatch.ExecutableNode ) :
 		h = GafferDispatch.ExecutableNode.hash( self, context )
 		h.append( context.getFrame() )
 		h.append( context.get( "textWriter:replace", IECore.StringVectorData() ) )
-		h.append( context.substitute( self["fileName"].getValue() ) )
-		h.append( self["mode"].getValue() )
-		h.append( context.substitute( self["text"].getValue() ) )
+		self["fileName"].hash( h )
+		self["mode"].hash( h )
+		self["text"].hash( h )
 
 		return h
 
@@ -106,8 +106,7 @@ class TextWriter( GafferDispatch.ExecutableNode ) :
 
 	def __processText( self, context ) :
 
-		text = context.substitute( self["text"].getValue() )
-
+		text = self["text"].getValue()
 		replace = context.get( "textWriter:replace", IECore.StringVectorData() )
 		if replace and len(replace) == 2 :
 			text = text.replace( replace[0], replace[1] )

--- a/python/GafferRenderMan/RenderManRender.py
+++ b/python/GafferRenderMan/RenderManRender.py
@@ -71,7 +71,7 @@ class RenderManRender( GafferScene.ExecutableRender ) :
 
 	def _createRenderer( self ) :
 
-		fileName = self.__fileName()
+		fileName = self["ribFileName"].getValue()
 		directory = os.path.dirname( fileName )
 		if directory :
 			try :
@@ -145,23 +145,12 @@ class RenderManRender( GafferScene.ExecutableRender ) :
 			return ""
 
 		result = self["command"].getValue()
-		result = Gaffer.Context.current().substitute( result ) ## \todo See __fileName()
 		result = result.strip()
 		if result == "" :
 			return
 
-		result += " '" + self.__fileName() + "'"
+		result += " '" + self["ribFileName"].getValue() + "'"
 
-		return result
-
-	def __fileName( self ) :
-
-		result = self["ribFileName"].getValue()
-		# because execute() isn't called inside a compute(), we
-		# don't get string expansions automatically, and have to
-		# do them ourselves.
-		## \todo Can we improve this situation?
-		result = Gaffer.Context.current().substitute( result )
 		return result
 
 IECore.registerRunTimeTyped( RenderManRender, typeName = "GafferRenderMan::RenderManRender" )

--- a/src/GafferCortex/ExecutableOpHolder.cpp
+++ b/src/GafferCortex/ExecutableOpHolder.cpp
@@ -108,24 +108,5 @@ void ExecutableOpHolder::execute() const
 	// and passing it explicitly in the operate call, so clients can safely call execute() from multiple threads.
 	const_cast<CompoundParameterHandler *>( parameterHandler() )->setParameterValue();
 	Op *op = const_cast<Op *>( getOp() );
-	/// \todo: Remove this once scoping the context takes care of it for us
-	substitute( op->parameters(), Gaffer::Context::current() );
 	op->operate();
-}
-
-void ExecutableOpHolder::substitute( Parameter *parameter, const Gaffer::Context *context ) const
-{
-	if ( const CompoundParameter *compound = runTimeCast<const CompoundParameter>( parameter ) )
-	{
-		const CompoundParameter::ParameterVector &children = compound->orderedParameters();
-		for ( CompoundParameter::ParameterVector::const_iterator it = children.begin(); it != children.end(); ++it )
-		{
-			substitute( const_cast<Parameter*>( it->get() ), context );
-		}
-	}
-
-	if ( StringParameter *stringParm = runTimeCast<StringParameter>( parameter ) )
-	{
-		stringParm->setTypedValue( context->substitute( stringParm->getTypedValue() ) );
-	}
 }

--- a/src/GafferImage/ImageWriter.cpp
+++ b/src/GafferImage/ImageWriter.cpp
@@ -973,7 +973,7 @@ const Gaffer::ValuePlug *ImageWriter::fileFormatSettingsPlug( const std::string 
 
 const std::string ImageWriter::currentFileFormat() const
 {
-	const std::string fileName = Context::current()->substitute( fileNamePlug()->getValue() );
+	const std::string fileName = fileNamePlug()->getValue();
 	ImageOutputPtr out( ImageOutput::create( fileName.c_str() ) );
 	if( out != NULL )
 	{
@@ -1019,7 +1019,7 @@ void ImageWriter::execute() const
 		throw IECore::Exception( "No input image." );
 	}
 
-	std::string fileName = Context::current()->substitute( fileNamePlug()->getValue() );
+	const std::string fileName = fileNamePlug()->getValue();
 
 	ImageOutputPtr out( ImageOutput::create( fileName.c_str() ) );
 	if( !out )

--- a/src/GafferScene/SceneWriter.cpp
+++ b/src/GafferScene/SceneWriter.cpp
@@ -133,7 +133,7 @@ void SceneWriter::executeSequence( const std::vector<float> &frames ) const
 	ContextPtr context = new Context( *Context::current(), Context::Borrowed );
 	Context::Scope scopedContext( context.get() );
 
-	std::string fileName = context->substitute( fileNamePlug()->getValue() );
+	const std::string fileName = fileNamePlug()->getValue();
 	createDirectories( fileName );
 	SceneInterfacePtr output = SceneInterface::create( fileName, IndexedIO::Write );
 
@@ -203,7 +203,7 @@ void SceneWriter::writeLocation( const GafferScene::ScenePlug *scene, const Scen
 	}
 }
 
-void SceneWriter::createDirectories( std::string &fileName ) const
+void SceneWriter::createDirectories( const std::string &fileName ) const
 {
 	boost::filesystem::path filePath( fileName );
 	boost::filesystem::path directory = filePath.parent_path();


### PR DESCRIPTION
Since #1671 now makes string substitutions happen automatically for all ExecutableNodes, we can remove all the manual substitutions we were doing to date. I've split this into a separate PR and applied the majorVersion label, since the substitutions only occur automatically when using the new TaskPlug API and not using the old deprecated API.