### PR TITLE
NodeGraph useability improvements

### DIFF
--- a/include/GafferUI/GraphGadget.h
+++ b/include/GafferUI/GraphGadget.h
@@ -209,7 +209,7 @@ class GraphGadget : public ContainerGadget
 		void removeConnectionGadget( const Gaffer::Plug *dstPlug );
 		ConnectionGadget *findConnectionGadget( const Gaffer::Plug *dstPlug ) const;
 		void updateConnectionGadgetMinimisation( ConnectionGadget *gadget );
-		ConnectionGadget *reconnectionGadgetAt( NodeGadget *gadget, const IECore::LineSegment3f &lineInGadgetSpace ) const;
+		ConnectionGadget *reconnectionGadgetAt( const NodeGadget *gadget, const IECore::LineSegment3f &lineInGadgetSpace ) const;
 		void updateDragReconnectCandidate( const DragDropEvent &event );
 
 		void connectedNodeGadgetsWalk( NodeGadget *gadget, std::set<NodeGadget *> &connectedGadgets, Gaffer::Plug::Direction direction, size_t degreesOfSeparation );

--- a/include/GafferUI/StandardConnectionGadget.h
+++ b/include/GafferUI/StandardConnectionGadget.h
@@ -74,8 +74,10 @@ class StandardConnectionGadget : public ConnectionGadget
 		static ConnectionGadgetTypeDescription<StandardConnectionGadget> g_connectionGadgetTypeDescription;
 
 		void setPositionsFromNodules();
+		Gaffer::Plug::Direction endAt( const IECore::LineSegment3f &line );
 
 		void enter( const ButtonEvent &event );
+		bool mouseMove( const ButtonEvent &event );
 		void leave( const ButtonEvent &event );
 		bool buttonPress( const ButtonEvent &event );
 		IECore::RunTimeTypedPtr dragBegin( const DragDropEvent &event );
@@ -96,6 +98,10 @@ class StandardConnectionGadget : public ConnectionGadget
 
 		Gaffer::Plug::Direction m_dragEnd;
 
+		/// \todo Store the end we are hovering over as
+		/// type Plug::Direction, and update the Style
+		/// classes so we can show which end is being
+		/// hovered.
 		bool m_hovering;
 		boost::optional<Imath::Color3f> m_userColor;
 

--- a/include/GafferUI/StandardConnectionGadget.h
+++ b/include/GafferUI/StandardConnectionGadget.h
@@ -75,13 +75,13 @@ class StandardConnectionGadget : public ConnectionGadget
 
 		void setPositionsFromNodules();
 
-		void enter( GadgetPtr gadget, const ButtonEvent &event );
-		void leave( GadgetPtr gadget, const ButtonEvent &event );
-		bool buttonPress( GadgetPtr gadget, const ButtonEvent &event );
-		IECore::RunTimeTypedPtr dragBegin( GadgetPtr gadget, const DragDropEvent &event );
-		bool dragEnter( GadgetPtr gadget, const DragDropEvent &event );
-		bool dragMove( GadgetPtr gadget, const DragDropEvent &event );
-		bool dragEnd( GadgetPtr gadget, const DragDropEvent &event );
+		void enter( const ButtonEvent &event );
+		void leave( const ButtonEvent &event );
+		bool buttonPress( const ButtonEvent &event );
+		IECore::RunTimeTypedPtr dragBegin( const DragDropEvent &event );
+		bool dragEnter( const DragDropEvent &event );
+		bool dragMove( const DragDropEvent &event );
+		bool dragEnd(  const DragDropEvent &event );
 
 		bool nodeSelected( const Nodule *nodule ) const;
 

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -1086,7 +1086,33 @@ void GraphGadget::updateDragReconnectCandidate( const DragDropEvent &event )
 			continue;
 		}
 
-		// Check that those plugs are represented in the graph.
+		// Check that this pair of plugs doesn't have existing
+		// connections. We do however allow output connections
+		// provided they are not to plugs in this graph - this
+		// allows us to ignore connections the UI components
+		// make, for instance connecting an output plug into
+		// a View outside the script.
+		if( inPlug->getInput<Gaffer::Plug>() )
+		{
+			continue;
+		}
+
+		bool haveOutputs = false;
+		for( Gaffer::Plug::OutputContainer::const_iterator oIt = outPlug->outputs().begin(), oeIt = outPlug->outputs().end(); oIt != oeIt; ++oIt )
+		{
+			if( m_root->isAncestorOf( *oIt ) )
+			{
+				haveOutputs = true;
+				break;
+			}
+		}
+
+		if( haveOutputs )
+		{
+			continue;
+		}
+
+		// Check that our plugs are represented in the graph.
 		// If they are, we've found a valid place to insert the
 		// dragged node.
 

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -1119,29 +1119,12 @@ bool GraphGadget::dragEnd( GadgetPtr gadget, const DragDropEvent &event )
 		return false;
 	}
 
-	if( dragMode == Moving )
+	if( dragMode == Moving && m_dragReconnectCandidate )
 	{
-		if ( m_dragReconnectCandidate )
-		{
-			if ( m_dragReconnectDstNodule || m_dragReconnectSrcNodule )
-			{
-				Gaffer::Plug *srcPlug = m_dragReconnectCandidate->srcNodule()->plug();
-				Gaffer::Plug *dstPlug = m_dragReconnectCandidate->dstNodule()->plug();
+		Gaffer::UndoContext undoContext( m_scriptNode );
 
-				Gaffer::UndoContext undoContext( m_scriptNode );
-
-				if ( m_dragReconnectDstNodule )
-				{
-					m_dragReconnectDstNodule->plug()->setInput( srcPlug );
-					dstPlug->setInput( NULL );
-				}
-
-				if ( m_dragReconnectSrcNodule )
-				{
-					dstPlug->setInput( m_dragReconnectSrcNodule->plug() );
-				}
-			}
-		}
+		m_dragReconnectDstNodule->plug()->setInput( m_dragReconnectCandidate->srcNodule()->plug() );
+		m_dragReconnectCandidate->dstNodule()->plug()->setInput( m_dragReconnectSrcNodule->plug() );
 
 		m_dragReconnectCandidate = NULL;
  		requestRender();

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -78,7 +78,7 @@ static const InternedString g_outputConnectionsMinimisedPlugName( "__uiOutputCon
 IE_CORE_DEFINERUNTIMETYPED( GraphGadget );
 
 GraphGadget::GraphGadget( Gaffer::NodePtr root, Gaffer::SetPtr filter )
-	:	m_dragStartPosition( 0 ), m_lastDragPosition( 0 ), m_dragMode( None ), m_dragReconnectCandidate( 0 ), m_dragReconnectSrcNodule( 0 ), m_dragReconnectDstNodule( 0 )
+	:	m_dragStartPosition( 0 ), m_lastDragPosition( 0 ), m_dragMode( None ), m_dragReconnectCandidate( NULL ), m_dragReconnectSrcNodule( NULL ), m_dragReconnectDstNodule( NULL )
 {
 	keyPressSignal().connect( boost::bind( &GraphGadget::keyPressed, this, ::_1,  ::_2 ) );
 	buttonPressSignal().connect( boost::bind( &GraphGadget::buttonPress, this, ::_1,  ::_2 ) );
@@ -490,7 +490,7 @@ NodeGadget *GraphGadget::nodeGadgetAt( const IECore::LineSegment3f &lineInGadget
 
 	if( !gadgetsUnderMouse.size() )
 	{
-		return 0;
+		return NULL;
 	}
 
 	NodeGadget *nodeGadget = runTimeCast<NodeGadget>( gadgetsUnderMouse[0].get() );
@@ -511,7 +511,7 @@ ConnectionGadget *GraphGadget::connectionGadgetAt( const IECore::LineSegment3f &
 
 	if ( !gadgetsUnderMouse.size() )
 	{
-		return 0;
+		return NULL;
 	}
 
 	ConnectionGadget *connectionGadget = runTimeCast<ConnectionGadget>( gadgetsUnderMouse[0].get() );
@@ -560,7 +560,7 @@ ConnectionGadget *GraphGadget::reconnectionGadgetAt( NodeGadget *gadget, const I
 		}
 	}
 
-	return 0;
+	return NULL;
 }
 
 void GraphGadget::doRender( const Style *style ) const
@@ -886,13 +886,13 @@ IECore::RunTimeTypedPtr GraphGadget::dragBegin( GadgetPtr gadget, const DragDrop
 {
 	if( !m_scriptNode )
 	{
-		return 0;
+		return NULL;
 	}
 
 	V3f i;
 	if( !event.line.intersect( Plane3f( V3f( 0, 0, 1 ), 0 ), i ) )
 	{
-		return 0;
+		return NULL;
 	}
 
 	m_dragMode = None;
@@ -932,7 +932,7 @@ IECore::RunTimeTypedPtr GraphGadget::dragBegin( GadgetPtr gadget, const DragDrop
 		}
 	}
 
-	return 0;
+	return NULL;
 }
 
 bool GraphGadget::dragEnter( GadgetPtr gadget, const DragDropEvent &event )
@@ -1036,9 +1036,9 @@ bool GraphGadget::dragMove( GadgetPtr gadget, const DragDropEvent &event )
 
 void GraphGadget::updateDragReconnectCandidate( const DragDropEvent &event )
 {
-	m_dragReconnectCandidate = 0;
-	m_dragReconnectSrcNodule = 0;
-	m_dragReconnectDstNodule = 0;
+	m_dragReconnectCandidate = NULL;
+	m_dragReconnectSrcNodule = NULL;
+	m_dragReconnectDstNodule = NULL;
 
 	if ( m_scriptNode->selection()->size() != 1 )
 	{
@@ -1064,7 +1064,7 @@ void GraphGadget::updateDragReconnectCandidate( const DragDropEvent &event )
 	Gaffer::Plug *dstPlug = m_dragReconnectCandidate->dstNodule()->plug();
 	if ( srcPlug->node() == node || dstPlug->node() == node )
 	{
-		m_dragReconnectCandidate = 0;
+		m_dragReconnectCandidate = NULL;
 		return;
 	}
 
@@ -1091,7 +1091,7 @@ void GraphGadget::updateDragReconnectCandidate( const DragDropEvent &event )
 			NodeGadget *oNodeGadget = nodeGadget( (*oIt)->node() );
 			if ( oNodeGadget && oNodeGadget->nodule( *oIt ) )
 			{
-				m_dragReconnectSrcNodule = 0;
+				m_dragReconnectSrcNodule = NULL;
 				break;
 			}
 		}
@@ -1112,7 +1112,7 @@ void GraphGadget::updateDragReconnectCandidate( const DragDropEvent &event )
 		{
 			if ( in->getInput<Gaffer::Plug>() )
 			{
-				m_dragReconnectSrcNodule = 0;
+				m_dragReconnectSrcNodule = NULL;
 				continue;
 			}
 
@@ -1143,7 +1143,7 @@ void GraphGadget::updateDragReconnectCandidate( const DragDropEvent &event )
 
 	if ( !m_dragReconnectSrcNodule && !m_dragReconnectDstNodule )
 	{
-		m_dragReconnectCandidate = 0;
+		m_dragReconnectCandidate = NULL;
 	}
 }
 
@@ -1178,7 +1178,7 @@ bool GraphGadget::dragEnd( GadgetPtr gadget, const DragDropEvent &event )
 				if ( m_dragReconnectDstNodule )
 				{
 					m_dragReconnectDstNodule->plug()->setInput( srcPlug );
-					dstPlug->setInput( 0 );
+					dstPlug->setInput( NULL );
 				}
 
 				if ( m_dragReconnectSrcNodule )
@@ -1188,7 +1188,7 @@ bool GraphGadget::dragEnd( GadgetPtr gadget, const DragDropEvent &event )
 			}
 		}
 
-		m_dragReconnectCandidate = 0;
+		m_dragReconnectCandidate = NULL;
  		requestRender();
 	}
 	else if( dragMode == Selecting )
@@ -1273,8 +1273,8 @@ void GraphGadget::calculateDragSnapOffsets( Gaffer::Set *nodes )
 			// compute an offset that will position the node snugly next to its input
 			// in the other axis.
 
-			Box3f srcNodeBound = srcNodeGadget->transformedBound( 0 );
-			Box3f dstNodeBound = dstNodeGadget->transformedBound( 0 );
+			Box3f srcNodeBound = srcNodeGadget->transformedBound( NULL );
+			Box3f dstNodeBound = dstNodeGadget->transformedBound( NULL );
 
 			const int otherAxis = snapAxis == 1 ? 0 : 1;
 			if( otherAxis == 1 )
@@ -1439,7 +1439,7 @@ NodeGadget *GraphGadget::findNodeGadget( const Gaffer::Node *node ) const
 	NodeGadgetMap::const_iterator it = m_nodeGadgets.find( node );
 	if( it==m_nodeGadgets.end() )
 	{
-		return 0;
+		return NULL;
 	}
 	return it->second.gadget;
 }
@@ -1533,7 +1533,7 @@ void GraphGadget::addConnectionGadget( Gaffer::Plug *dstPlug )
 
 	// find the input nodule for the connection if there is one
 	NodeGadget *srcNodeGadget = findNodeGadget( srcNode );
-	Nodule *srcNodule = 0;
+	Nodule *srcNodule = NULL;
 	if( srcNodeGadget )
 	{
 		srcNodule = srcNodeGadget->nodule( srcPlug );
@@ -1588,7 +1588,7 @@ ConnectionGadget *GraphGadget::findConnectionGadget( const Gaffer::Plug *plug ) 
 	ConnectionGadgetMap::const_iterator it = m_connectionGadgets.find( plug );
 	if( it==m_connectionGadgets.end() )
 	{
-		return 0;
+		return NULL;
 	}
 	return it->second;
 }

--- a/src/GafferUI/StandardConnectionGadget.cpp
+++ b/src/GafferUI/StandardConnectionGadget.cpp
@@ -63,13 +63,13 @@ static IECore::InternedString g_colorKey( "connectionGadget:color" );
 StandardConnectionGadget::StandardConnectionGadget( GafferUI::NodulePtr srcNodule, GafferUI::NodulePtr dstNodule )
 	:	ConnectionGadget( srcNodule, dstNodule ), m_dragEnd( Gaffer::Plug::Invalid ), m_hovering( false )
 {
-	enterSignal().connect( boost::bind( &StandardConnectionGadget::enter, this, ::_1, ::_2 ) );
-	leaveSignal().connect( boost::bind( &StandardConnectionGadget::leave, this, ::_1, ::_2 ) );
-	buttonPressSignal().connect( boost::bind( &StandardConnectionGadget::buttonPress, this, ::_1,  ::_2 ) );
-	dragBeginSignal().connect( boost::bind( &StandardConnectionGadget::dragBegin, this, ::_1, ::_2 ) );
-	dragEnterSignal().connect( boost::bind( &StandardConnectionGadget::dragEnter, this, ::_1, ::_2 ) );
-	dragMoveSignal().connect( boost::bind( &StandardConnectionGadget::dragMove, this, ::_1, ::_2 ) );
-	dragEndSignal().connect( boost::bind( &StandardConnectionGadget::dragEnd, this, ::_1, ::_2 ) );
+	enterSignal().connect( boost::bind( &StandardConnectionGadget::enter, this, ::_2 ) );
+	leaveSignal().connect( boost::bind( &StandardConnectionGadget::leave, this, ::_2 ) );
+	buttonPressSignal().connect( boost::bind( &StandardConnectionGadget::buttonPress, this,  ::_2 ) );
+	dragBeginSignal().connect( boost::bind( &StandardConnectionGadget::dragBegin, this, ::_2 ) );
+	dragEnterSignal().connect( boost::bind( &StandardConnectionGadget::dragEnter, this, ::_2 ) );
+	dragMoveSignal().connect( boost::bind( &StandardConnectionGadget::dragMove, this, ::_2 ) );
+	dragEndSignal().connect( boost::bind( &StandardConnectionGadget::dragEnd, this, ::_2 ) );
 
 	Metadata::plugValueChangedSignal().connect( boost::bind( &StandardConnectionGadget::plugMetadataChanged, this, ::_1, ::_2, ::_3, ::_4 ) );
 
@@ -196,7 +196,7 @@ void StandardConnectionGadget::doRender( const Style *style ) const
 }
 
 
-bool StandardConnectionGadget::buttonPress( GadgetPtr gadget, const ButtonEvent &event )
+bool StandardConnectionGadget::buttonPress( const ButtonEvent &event )
 {
 	if( event.buttons==ButtonEvent::Left )
 	{
@@ -206,7 +206,7 @@ bool StandardConnectionGadget::buttonPress( GadgetPtr gadget, const ButtonEvent 
 	return false;
 }
 
-IECore::RunTimeTypedPtr StandardConnectionGadget::dragBegin( GadgetPtr gadget, const DragDropEvent &event )
+IECore::RunTimeTypedPtr StandardConnectionGadget::dragBegin( const DragDropEvent &event )
 {
 	setPositionsFromNodules();
 	float length = ( m_srcPos - m_dstPos ).length();
@@ -230,10 +230,10 @@ IECore::RunTimeTypedPtr StandardConnectionGadget::dragBegin( GadgetPtr gadget, c
 		}
 	}
 
-	return 0;
+	return NULL;
 }
 
-bool StandardConnectionGadget::dragEnter( GadgetPtr gadget, const DragDropEvent &event )
+bool StandardConnectionGadget::dragEnter( const DragDropEvent &event )
 {
 	if( event.sourceGadget == this )
 	{
@@ -242,13 +242,13 @@ bool StandardConnectionGadget::dragEnter( GadgetPtr gadget, const DragDropEvent 
 	return false;
 }
 
-bool StandardConnectionGadget::dragMove( GadgetPtr gadget, const DragDropEvent &event )
+bool StandardConnectionGadget::dragMove( const DragDropEvent &event )
 {
 	updateDragEndPoint( event.line.p0, V3f( 0 ) );
 	return true;
 }
 
-bool StandardConnectionGadget::dragEnd( GadgetPtr gadget, const DragDropEvent &event )
+bool StandardConnectionGadget::dragEnd( const DragDropEvent &event )
 {
 	if( !event.destinationGadget || event.destinationGadget == this )
 	{
@@ -326,13 +326,13 @@ std::string StandardConnectionGadget::getToolTip( const IECore::LineSegment3f &l
 	return result;
 }
 
-void StandardConnectionGadget::enter( GadgetPtr gadget, const ButtonEvent &event )
+void StandardConnectionGadget::enter( const ButtonEvent &event )
 {
 	m_hovering = true;
  	requestRender();
 }
 
-void StandardConnectionGadget::leave( GadgetPtr gadget, const ButtonEvent &event )
+void StandardConnectionGadget::leave( const ButtonEvent &event )
 {
 	m_hovering = false;
  	requestRender();

--- a/src/GafferUI/StandardConnectionGadget.cpp
+++ b/src/GafferUI/StandardConnectionGadget.cpp
@@ -38,6 +38,8 @@
 #include "boost/bind.hpp"
 #include "boost/bind/placeholders.hpp"
 
+#include "OpenEXR/ImathFun.h"
+
 #include "Gaffer/UndoContext.h"
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/StandardSet.h"
@@ -176,7 +178,7 @@ void StandardConnectionGadget::doRender( const Style *style ) const
 {
 	const_cast<StandardConnectionGadget *>( this )->setPositionsFromNodules();
 
-	Style::State state = m_hovering ? Style::HighlightedState : Style::NormalState;
+	Style::State state = ( m_hovering || m_dragEnd ) ? Style::HighlightedState : Style::NormalState;
 	if( state != Style::HighlightedState )
 	{
 		if( nodeSelected( srcNodule() ) || nodeSelected( dstNodule() ) )
@@ -199,11 +201,12 @@ void StandardConnectionGadget::doRender( const Style *style ) const
 Gaffer::Plug::Direction StandardConnectionGadget::endAt( const IECore::LineSegment3f &line )
 {
 	const float length = ( m_srcPos - m_dstPos ).length();
+	const float threshold = clamp( length / 4.0f, 2.5f, 25.0f );
 
 	const float dSrc = line.distanceTo( m_srcPos );
 	const float dDst = line.distanceTo( m_dstPos );
 
-	if( min( dSrc, dDst ) < length / 3.0f )
+	if( min( dSrc, dDst ) < threshold )
 	{
 		// close enough to the ends to consider
 		if( dSrc < dDst )


### PR DESCRIPTION
- Tighten up "drag node onto nodule" semantics to only allow sensible insertions.
- Improve feedback when hovering over a connection - only highlight it in a draggable region.
- Adjust draggable region of connections to make dragging easier for short connections and inadvertent dragging harder for long connections.