### PR TITLE
Duplicate improvements

### DIFF
--- a/python/GafferSceneTest/DuplicateTest.py
+++ b/python/GafferSceneTest/DuplicateTest.py
@@ -36,6 +36,7 @@
 
 import IECore
 
+import Gaffer
 import GafferTest
 import GafferScene
 import GafferSceneTest
@@ -185,6 +186,23 @@ class DuplicateTest( GafferSceneTest.SceneTestCase ) :
 				[ "/group/sphere%d" % n for n in range( 1, 1501 ) ]
 			)
 		)
+
+	def testSetNames( self ) :
+
+		s = GafferScene.Sphere()
+		s["sets"].setValue( "testSet" )
+		d = GafferScene.Duplicate()
+		d["in"].setInput( s["out"] )
+		d["target"].setValue( "/sphere" )
+		d["transform"]["translate"].setValue( IECore.V3f( 1, 0, 0 ) )
+
+		with Gaffer.PerformanceMonitor() as m :
+			self.assertEqual( s["out"]["setNames"].hash(), d["out"]["setNames"].hash() )
+			self.assertTrue( s["out"]["setNames"].getValue( _copy = False ).isSame( d["out"]["setNames"].getValue( _copy = False ) ) )
+			self.assertEqual( s["out"]["setNames"].getValue(), IECore.InternedStringVectorData( [ "testSet" ] ) )
+
+		self.assertEqual( m.plugStatistics( d["out"]["setNames"] ).hashCount, 0 )
+		self.assertEqual( m.plugStatistics( d["out"]["setNames"] ).computeCount, 0 )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/PerformanceMonitorTest.py
+++ b/python/GafferTest/PerformanceMonitorTest.py
@@ -105,5 +105,13 @@ class PerformanceMonitorTest( GafferTest.TestCase ) :
 			}
 		)
 
+	def testEnterReturnValue( self ) :
+
+		m = Gaffer.PerformanceMonitor()
+		with m as n :
+			pass
+
+		self.assertTrue( m is n )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferBindings/MonitorBinding.cpp
+++ b/src/GafferBindings/MonitorBinding.cpp
@@ -88,7 +88,7 @@ void GafferBindings::bindMonitor()
 	class_<Monitor, boost::noncopyable>( "Monitor", no_init )
 		.def( "setActive", &Monitor::setActive )
 		.def( "getActive", &Monitor::getActive )
-		.def( "__enter__", &enterScope )
+		.def( "__enter__", &enterScope, return_self<>() )
 		.def( "__exit__", &exitScope )
 	;
 

--- a/src/GafferScene/Duplicate.cpp
+++ b/src/GafferScene/Duplicate.cpp
@@ -65,6 +65,10 @@ Duplicate::Duplicate( const std::string &name )
 	parentPlug()->setFlags( Plug::ReadOnly, true );
 	parentPlug()->setFlags( Plug::Serialisable, false );
 
+	// Since we don't introduce any new sets, but just duplicate parts
+	// of existing ones, we can save the BranchCreator base class some
+	// trouble by making the setNamesPlug into a pass-through.
+	outPlug()->setNamesPlug()->setInput( inPlug()->setNamesPlug() );
 }
 
 Duplicate::~Duplicate()


### PR DESCRIPTION
This knocks 35% off the time to compute a set in a custom downstream node with certain suboptimal qualities.