### PR TITLE
ScenePlug : Add helpers for accessing globals and set names.

### DIFF
--- a/include/GafferScene/ScenePlug.h
+++ b/include/GafferScene/ScenePlug.h
@@ -144,6 +144,16 @@ class ScenePlug : public Gaffer::ValuePlug
 		IECore::CompoundObjectPtr fullAttributes( const ScenePath &scenePath ) const;
 		IECore::ConstObjectPtr object( const ScenePath &scenePath ) const;
 		IECore::ConstInternedStringVectorDataPtr childNames( const ScenePath &scenePath ) const;
+		/// Prefer this to bare `globalsPlug()->getValue()` calls when
+		/// accessing globals from within a per-location computation. It
+		/// removes unnecessary context variables which could otherwise
+		/// lead to poor cache performance.
+		IECore::ConstCompoundObjectPtr globals() const;
+		/// Prefer this to bare `setNamesPlug()->getValue()` calls when
+		/// accessing set names from within a per-location computation. It
+		/// removes unnecessary context variables which could otherwise
+		/// lead to poor cache performance.
+		IECore::ConstInternedStringVectorDataPtr setNames() const;
 		ConstPathMatcherDataPtr set( const IECore::InternedString &setName ) const;
 
 		IECore::MurmurHash boundHash( const ScenePath &scenePath ) const;
@@ -153,6 +163,10 @@ class ScenePlug : public Gaffer::ValuePlug
 		IECore::MurmurHash fullAttributesHash( const ScenePath &scenePath ) const;
 		IECore::MurmurHash objectHash( const ScenePath &scenePath ) const;
 		IECore::MurmurHash childNamesHash( const ScenePath &scenePath ) const;
+		/// See comments for `globals()` method.
+		IECore::MurmurHash globalsHash() const;
+		/// See comments for `setNames()` method.
+		IECore::MurmurHash setNamesHash() const;
 		IECore::MurmurHash setHash( const IECore::InternedString &setName ) const;
 		//@}
 

--- a/python/GafferSceneTest/ScenePlugTest.py
+++ b/python/GafferSceneTest/ScenePlugTest.py
@@ -218,5 +218,20 @@ class ScenePlugTest( GafferSceneTest.SceneTestCase ) :
 		self.assertTrue( isinstance( p["set"], GafferScene.PathMatcherDataPlug ) )
 		self.assertEqual( p["set"].defaultValue(), GafferScene.PathMatcherData() )
 
+	def testGlobalsAccessors( self ) :
+
+		p = GafferScene.ScenePlug()
+
+		self.assertEqual( p.globals(), p["globals"].getValue() )
+		self.assertFalse( p.globals().isSame( p["globals"].getValue() ) )
+		self.assertTrue( p.globals( _copy = False ).isSame( p["globals"].getValue( _copy = False ) ) )
+
+		self.assertEqual( p.setNames(), p["setNames"].getValue() )
+		self.assertFalse( p.setNames().isSame( p["setNames"].getValue() ) )
+		self.assertTrue( p.setNames( _copy = False ).isSame( p["setNames"].getValue( _copy = False ) ) )
+
+		self.assertEqual( p.globalsHash(), p["globals"].hash() )
+		self.assertEqual( p.setNamesHash(), p["setNames"].hash() )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferSceneBindings/ScenePlugBinding.cpp
+++ b/src/GafferSceneBindings/ScenePlugBinding.cpp
@@ -175,6 +175,20 @@ IECore::CompoundObjectPtr fullAttributesWrapper( const ScenePlug &plug, const Sc
 	return plug.fullAttributes( scenePath );
 }
 
+IECore::CompoundObjectPtr globalsWrapper( const ScenePlug &plug, bool copy )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	IECore::ConstCompoundObjectPtr g = plug.globals();
+	return copy ? g->copy() : boost::const_pointer_cast<IECore::CompoundObject>( g );
+}
+
+IECore::InternedStringVectorDataPtr setNamesWrapper( const ScenePlug &plug, bool copy )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	IECore::ConstInternedStringVectorDataPtr s = plug.setNames();
+	return copy ? s->copy() : boost::const_pointer_cast<IECore::InternedStringVectorData>( s );
+}
+
 PathMatcherDataPtr setWrapper( const ScenePlug &plug, const IECore::InternedString &setName, bool copy=true )
 {
 	IECorePython::ScopedGILRelease gilRelease;
@@ -224,6 +238,18 @@ IECore::MurmurHash fullAttributesHashWrapper( const ScenePlug &plug, const Scene
 	return plug.fullAttributesHash( scenePath );
 }
 
+IECore::MurmurHash globalsHashWrapper( const ScenePlug &plug )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return plug.globalsHash();
+}
+
+IECore::MurmurHash setNamesHashWrapper( const ScenePlug &plug )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return plug.setNamesHash();
+}
+
 IECore::MurmurHash setHashWrapper( const ScenePlug &plug, const IECore::InternedString &setName )
 {
 	IECorePython::ScopedGILRelease gilRelease;
@@ -266,6 +292,8 @@ void GafferSceneBindings::bindScenePlug()
 		.def( "childNames", &childNamesWrapper, ( boost::python::arg_( "_copy" ) = true ) )
 		.def( "attributes", &attributesWrapper, ( boost::python::arg_( "_copy" ) = true ) )
 		.def( "fullAttributes", &fullAttributesWrapper )
+		.def( "globals", &globalsWrapper, ( boost::python::arg_( "_copy" ) = true ) )
+		.def( "setNames", &setNamesWrapper, ( boost::python::arg_( "_copy" ) = true ) )
 		.def( "set", &setWrapper, ( boost::python::arg_( "_copy" ) = true ) )
 		// hash accessors
 		.def( "boundHash", &boundHashWrapper )
@@ -275,6 +303,8 @@ void GafferSceneBindings::bindScenePlug()
 		.def( "childNamesHash", &childNamesHashWrapper )
 		.def( "attributesHash", &attributesHashWrapper )
 		.def( "fullAttributesHash", &fullAttributesHashWrapper )
+		.def( "globalsHash", &globalsHashWrapper )
+		.def( "setNamesHash", &setNamesHashWrapper )
 		.def( "setHash", &setHashWrapper )
 		// string utilities
 		.def( "stringToPath", &stringToPathWrapper )

--- a/src/GafferSceneBindings/ScenePlugBinding.cpp
+++ b/src/GafferSceneBindings/ScenePlugBinding.cpp
@@ -148,21 +148,21 @@ Imath::M44f fullTransformWrapper( const ScenePlug &plug, const ScenePlug::SceneP
 	return plug.fullTransform( scenePath );
 }
 
-IECore::ObjectPtr objectWrapper( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath, bool copy=true )
+IECore::ObjectPtr objectWrapper( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath, bool copy )
 {
 	IECorePython::ScopedGILRelease gilRelease;
 	IECore::ConstObjectPtr o = plug.object( scenePath );
 	return copy ? o->copy() : boost::const_pointer_cast<IECore::Object>( o );
 }
 
-IECore::InternedStringVectorDataPtr childNamesWrapper( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath, bool copy=true )
+IECore::InternedStringVectorDataPtr childNamesWrapper( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath, bool copy )
 {
 	IECorePython::ScopedGILRelease gilRelease;
 	IECore::ConstInternedStringVectorDataPtr n = plug.childNames( scenePath );
 	return copy ? n->copy() : boost::const_pointer_cast<IECore::InternedStringVectorData>( n );
 }
 
-IECore::CompoundObjectPtr attributesWrapper( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath, bool copy=true )
+IECore::CompoundObjectPtr attributesWrapper( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath, bool copy )
 {
 	IECorePython::ScopedGILRelease gilRelease;
 	IECore::ConstCompoundObjectPtr a = plug.attributes( scenePath );
@@ -189,7 +189,7 @@ IECore::InternedStringVectorDataPtr setNamesWrapper( const ScenePlug &plug, bool
 	return copy ? s->copy() : boost::const_pointer_cast<IECore::InternedStringVectorData>( s );
 }
 
-PathMatcherDataPtr setWrapper( const ScenePlug &plug, const IECore::InternedString &setName, bool copy=true )
+PathMatcherDataPtr setWrapper( const ScenePlug &plug, const IECore::InternedString &setName, bool copy )
 {
 	IECorePython::ScopedGILRelease gilRelease;
 	ConstPathMatcherDataPtr s = plug.set( setName );


### PR DESCRIPTION
These manage the context such that it is friendlier to the hash cache, by removing variables we know to change frequently but which cannot affect the result. Although Gaffer itself doesn't have nodes which can benefit from these methods, a certain proprietary node somewhere else definitely can - using `setNames()` vs `setNamesPlug->getValue()` more than halves the computation time for a complex set operation.