### PR TITLE
Performance monitor enhancements

### DIFF
--- a/apps/stats/stats-1.py
+++ b/apps/stats/stats-1.py
@@ -89,18 +89,11 @@ class stats( Gaffer.Application ) :
 				),
 
 				IECore.IntParameter(
-					name = "mostFrequentlyHashed",
-					description = "The number of most-frequently hashed plugs to print. "
-						"Only used when the performance monitor is on.",
+					name = "maxLinesPerMetric",
+					description = "The maximum number of plugs to list for each metric "
+						"captured by the performance monitor.",
 					defaultValue = 50,
 				),
-
-				IECore.IntParameter(
-					name = "mostFrequentlyComputed",
-					description = "The number of most-frequently hashed plugs to print. "
-						"Only used when the performance monitor is on.",
-					defaultValue = 50,
-				)
 
 			]
 
@@ -330,16 +323,11 @@ class stats( Gaffer.Application ) :
 			print "Performance :\n"
 			self.__printItems( self.__timers.items() )
 
-			if self.__performanceMonitor is None :
-				return
-
-			stats = self.__performanceMonitor.allStatistics().items()
-
-			print "\nMost frequently hashed :\n"
-			self.__printStatisticsItems( script, stats, lambda x : x[1].hashCount, args["mostFrequentlyHashed"].value )
-
-			print "\nMost frequently computed :\n"
-			self.__printStatisticsItems( script, stats, lambda x : x[1].computeCount, args["mostFrequentlyComputed"].value )
+			if self.__performanceMonitor is not None :
+				print "\n" + Gaffer.formatStatistics(
+					self.__performanceMonitor,
+					maxLinesPerMetric = args["maxLinesPerMetric"].value
+				)
 
 class _Timer( object ) :
 

--- a/include/Gaffer/MonitorAlgo.h
+++ b/include/Gaffer/MonitorAlgo.h
@@ -1,0 +1,68 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFER_MONITORALGO_H
+#define GAFFER_MONITORALGO_H
+
+#include <string>
+
+namespace Gaffer
+{
+
+class PerformanceMonitor;
+
+enum PerformanceMetric
+{
+	Invalid,
+	HashCount,
+	ComputeCount,
+	HashDuration,
+	ComputeDuration,
+	TotalDuration,
+	PerHashDuration,
+	PerComputeDuration,
+	HashesPerCompute,
+
+	First = HashCount,
+	Last = HashesPerCompute
+};
+
+std::string formatStatistics( const PerformanceMonitor &monitor, size_t maxLinesPerMetric = 50 );
+std::string formatStatistics( const PerformanceMonitor &monitor, PerformanceMetric metric, size_t maxLines = 50 );
+
+} // namespace Gaffer
+
+#endif // GAFFER_MONITORALGO_H

--- a/include/Gaffer/PerformanceMonitor.h
+++ b/include/Gaffer/PerformanceMonitor.h
@@ -40,6 +40,7 @@
 #include "tbb/enumerable_thread_specific.h"
 
 #include "boost/unordered_map.hpp"
+#include "boost/chrono.hpp"
 
 #include "IECore/RefCounted.h"
 
@@ -63,10 +64,17 @@ class PerformanceMonitor : public Monitor
 		struct Statistics
 		{
 
-			Statistics( size_t hashCount = 0, size_t computeCount = 0 );
+			Statistics(
+				size_t hashCount = 0,
+				size_t computeCount = 0,
+				boost::chrono::nanoseconds hashDuration = boost::chrono::nanoseconds( 0 ),
+				boost::chrono::nanoseconds computeDuration = boost::chrono::nanoseconds( 0 )
+			);
 
 			size_t hashCount;
 			size_t computeCount;
+			boost::chrono::nanoseconds hashDuration;
+			boost::chrono::nanoseconds computeDuration;
 
 			Statistics & operator += ( const Statistics &rhs );
 
@@ -89,7 +97,8 @@ class PerformanceMonitor : public Monitor
 
 		// For performance reasons we accumulate our statistics into
 		// thread local storage while computations are running.
-		tbb::enumerable_thread_specific<StatisticsMap> m_threadStatistics;
+		struct ThreadData;
+		tbb::enumerable_thread_specific<ThreadData, tbb::cache_aligned_allocator<ThreadData>, tbb::ets_key_per_instance> m_threadData;
 
 		// Then when we want to query it, we collate it into m_statistics.
 		void collate() const;

--- a/include/GafferBindings/ComputeNodeBinding.h
+++ b/include/GafferBindings/ComputeNodeBinding.h
@@ -78,6 +78,10 @@ class ComputeNodeWrapper : public DependencyNodeWrapper<WrappedType>
 
 		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 		{
+			/// \todo Stop calling the base class unconditionally - if an override
+			/// exists then the override should call the base class explicitly itself
+			/// if required. Having a disparity between the python bindings and the
+			/// C++ form here does us no favours.
 			WrappedType::hash( output, context, h );
 			if( this->isSubclassed() )
 			{

--- a/python/GafferScene/ScriptProcedural.py
+++ b/python/GafferScene/ScriptProcedural.py
@@ -212,38 +212,11 @@ class ScriptProcedural( IECore.ParameterisedProcedural ) :
 		cls.__performanceMonitor = Gaffer.PerformanceMonitor()
 		cls.__performanceMonitor.setActive( True )
 
-	@staticmethod
-	def __printItems( items ) :
-
-		if not len( items ) :
-			return
-
-		width = max( [ len( x[0] ) for x in items ] ) + 4
-		for name, value in items :
-			sys.stderr.write( "  {name:<{width}}{value}\n".format( name = name, width = width, value = value ) )
-
-	@classmethod
-	def __printStatisticsItems( cls, stats, key, n ) :
-
-		stats.sort( key = key, reverse = True )
-		items = [ ( x[0].relativeName( x[0].ancestor( Gaffer.ScriptNode ) ), key( x ) ) for x in stats[:n] ]
-		cls.__printItems( items )
-
 	@classmethod
 	def __printPerformance( cls ) :
 
-		## \todo This code is essentially just cribbed from the
-		# stats app. Perhaps we should share it via something
-		# like a MonitorAlgo file.
-
-		stats = cls.__performanceMonitor.allStatistics().items()
-
 		sys.stderr.write( "\nPerformance Monitor\n===================\n\n" )
 
-		sys.stderr.write( "Most frequently hashed :\n\n" )
-		cls.__printStatisticsItems( stats, lambda x : x[1].hashCount, 50 )
-
-		sys.stderr.write( "\nMost frequently computed :\n\n" )
-		cls.__printStatisticsItems(stats, lambda x : x[1].computeCount, 50 )
+		sys.stderr.write( Gaffer.formatStatistics( cls.__performanceMonitor ) )
 
 IECore.registerRunTimeTyped( ScriptProcedural, typeName = "GafferScene::ScriptProcedural" )

--- a/src/Gaffer/MonitorAlgo.cpp
+++ b/src/Gaffer/MonitorAlgo.cpp
@@ -1,0 +1,361 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include <iomanip>
+
+#include "Gaffer/PerformanceMonitor.h"
+#include "Gaffer/MonitorAlgo.h"
+#include "Gaffer/Plug.h"
+
+using namespace Gaffer;
+
+//////////////////////////////////////////////////////////////////////////
+// Metrics. These are simple structs whose operator() can
+// retrieve some information from a Statistics object.
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+struct InvalidMetric
+{
+
+	typedef size_t ResultType;
+
+	ResultType operator() ( const PerformanceMonitor::Statistics &s ) const
+	{
+		return 0;
+	}
+
+	const char *description() const
+	{
+		return "invalid";
+	}
+
+};
+
+struct HashCountMetric
+{
+
+	typedef size_t ResultType;
+
+	ResultType operator() ( const PerformanceMonitor::Statistics &s ) const
+	{
+		return s.hashCount;
+	}
+
+	const char *description() const
+	{
+		return "number of hash processes";
+	}
+
+};
+
+struct ComputeCountMetric
+{
+
+	typedef size_t ResultType;
+
+	ResultType operator() ( const PerformanceMonitor::Statistics &s ) const
+	{
+		return s.computeCount;
+	}
+
+	const char *description() const
+	{
+		return "number of compute processes";
+	}
+
+};
+
+struct HashDurationMetric
+{
+
+	typedef boost::chrono::duration<double> ResultType;
+
+	ResultType operator() ( const PerformanceMonitor::Statistics &s ) const
+	{
+		return s.hashDuration;
+	}
+
+	const char *description() const
+	{
+		return "time spent in hash processes";
+	}
+
+};
+
+struct ComputeDurationMetric
+{
+
+	typedef boost::chrono::duration<double> ResultType;
+
+	ResultType operator() ( const PerformanceMonitor::Statistics &s ) const
+	{
+		return s.computeDuration;
+	}
+
+	const char *description() const
+	{
+		return "time spent in compute processes";
+	}
+
+};
+
+struct TotalDurationMetric
+{
+
+	typedef boost::chrono::duration<double> ResultType;
+
+	ResultType operator() ( const PerformanceMonitor::Statistics &s ) const
+	{
+		return s.hashDuration + s.computeDuration;
+	}
+
+	const char *description() const
+	{
+		return "total time spent in hash and compute processes";
+	}
+
+};
+
+struct PerHashDurationMetric
+{
+
+	typedef boost::chrono::duration<double> ResultType;
+
+	ResultType operator() ( const PerformanceMonitor::Statistics &s ) const
+	{
+		return ResultType( s.hashDuration ) / std::max( 1.0, static_cast<double>( s.hashCount ) );
+	}
+
+	const char *description() const
+	{
+		return "time spent per hash process";
+	}
+
+};
+
+struct PerComputeDurationMetric
+{
+
+	typedef boost::chrono::duration<double> ResultType;
+
+	ResultType operator() ( const PerformanceMonitor::Statistics &s ) const
+	{
+		return ResultType( s.computeDuration ) / std::max( 1.0, static_cast<double>( s.computeCount ) );
+	}
+
+	const char *description() const
+	{
+		return "time spent per compute process";
+	}
+
+};
+
+struct HashesPerComputeMetric
+{
+
+	typedef double ResultType;
+
+	ResultType operator() ( const PerformanceMonitor::Statistics &s ) const
+	{
+		return static_cast<double>( s.hashCount ) / std::max( 1.0, static_cast<double>( s.computeCount ) );
+	}
+
+	const char *description() const
+	{
+		return "number of hash processes per compute process";
+	}
+
+};
+
+// Utility for invoking a templated functor with a particular metric.
+template<typename F>
+typename F::ResultType dispatchMetric( const F &f, PerformanceMetric performanceMetric )
+{
+	switch( performanceMetric )
+	{
+		case HashCount :
+			return f( HashCountMetric() );
+		case ComputeCount :
+			return f( ComputeCountMetric() );
+		case HashDuration :
+			return f( HashDurationMetric() );
+		case ComputeDuration :
+			return f( ComputeDurationMetric() );
+		case TotalDuration :
+			return f( TotalDurationMetric() );
+		case PerHashDuration :
+			return f( PerHashDurationMetric() );
+		case PerComputeDuration :
+			return f( PerComputeDurationMetric() );
+		case HashesPerCompute :
+			return f( HashesPerComputeMetric() );
+		default :
+			return f( InvalidMetric() );
+	}
+}
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// Formatting utilities
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+struct PlugAndStatistics
+{
+
+	PlugAndStatistics( const PerformanceMonitor::StatisticsMap::value_type &v )
+		:	plug( v.first.get() ), statistics( v.second )
+	{
+	}
+
+	const Plug *plug;
+	PerformanceMonitor::Statistics statistics;
+
+};
+
+template<typename Metric>
+struct MetricGreater
+{
+
+	bool operator() ( const PlugAndStatistics &lhs, const PlugAndStatistics &rhs ) const
+	{
+		return metric( lhs.statistics ) > metric( rhs.statistics );
+	}
+
+	Metric metric;
+
+};
+
+template<typename Item>
+void outputItems( const std::vector<std::string> &names, const std::vector<Item> &items, std::ostream &os )
+{
+	size_t maxSize = 0;
+	for( std::vector<std::string>::const_iterator it = names.begin(), eIt = names.end(); it != eIt; ++it )
+	{
+		maxSize = std::max( maxSize, it->size() );
+	}
+
+	os << std::fixed;
+	for( size_t i = 0, e = names.size(); i < e; ++i )
+	{
+		os << "  " << std::left << std::setw( maxSize + 4 ) << names[i] << items[i] << "\n";
+	}
+}
+
+struct FormatStatistics
+{
+
+	FormatStatistics( const PerformanceMonitor::StatisticsMap &statistics, size_t maxLines )
+		:	statistics( statistics ), maxLines( maxLines )
+	{
+	}
+
+	typedef std::string ResultType;
+
+	template<typename Metric>
+	std::string operator() ( const Metric &metric ) const
+	{
+		std::vector<PlugAndStatistics> v( statistics.begin(), statistics.end() );
+		std::sort( v.begin(), v.end(), MetricGreater<Metric>() );
+
+		std::vector<std::string> plugNames; plugNames.reserve( maxLines );
+		std::vector<typename Metric::ResultType> metrics; metrics.reserve( maxLines );
+
+		ResultType result;
+		for( size_t i = 0; i < maxLines && i < v.size(); ++i )
+		{
+			typename Metric::ResultType m = metric( v[i].statistics );
+			if( m == typename Metric::ResultType() )
+			{
+				break;
+			}
+			plugNames.push_back( v[i].plug->relativeName( v[i].plug->ancestor( (IECore::TypeId)ScriptNodeTypeId ) ) );
+			metrics.push_back( m );
+		}
+
+		if( plugNames.empty() )
+		{
+			return "";
+		}
+
+		std::stringstream s;
+		s << "Top " << plugNames.size() << " plugs by " << metric.description() << " :\n\n";
+
+		outputItems( plugNames, metrics, s );
+
+		return s.str();
+	}
+
+	const PerformanceMonitor::StatisticsMap &statistics;
+	const size_t maxLines;
+
+};
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// Implementation of public functions
+//////////////////////////////////////////////////////////////////////////
+
+namespace Gaffer
+{
+
+std::string formatStatistics( const PerformanceMonitor &monitor, size_t maxLinesPerMetric )
+{
+	std::string s;
+	for( int m = First; m <= Last; ++m )
+	{
+		s += formatStatistics( monitor, static_cast<PerformanceMetric>( m ), maxLinesPerMetric );
+		if( m != Last )
+		{
+			s += "\n";
+		}
+	}
+	return s;
+}
+
+std::string formatStatistics( const PerformanceMonitor &monitor, PerformanceMetric metric, size_t maxLines )
+{
+	return dispatchMetric<FormatStatistics>( FormatStatistics( monitor.allStatistics(), maxLines ), metric );
+}
+
+} // namespace Gaffer

--- a/src/GafferBindings/MonitorBinding.cpp
+++ b/src/GafferBindings/MonitorBinding.cpp
@@ -39,6 +39,7 @@
 
 #include "Gaffer/Monitor.h"
 #include "Gaffer/PerformanceMonitor.h"
+#include "Gaffer/MonitorAlgo.h"
 #include "Gaffer/Plug.h"
 
 #include "GafferBindings/MonitorBinding.h"
@@ -116,6 +117,37 @@ dict allStatistics( PerformanceMonitor &m )
 
 void GafferBindings::bindMonitor()
 {
+
+	enum_<PerformanceMetric>( "PerformanceMetric" )
+		.value( "Invalid", Invalid )
+		.value( "HashCount", HashCount )
+		.value( "ComputeCount", ComputeCount )
+		.value( "HashDuration", HashDuration )
+		.value( "ComputeDuration", ComputeDuration )
+		.value( "TotalDuration", TotalDuration )
+		.value( "PerHashDuration", PerHashDuration )
+		.value( "PerComputeDuration", PerComputeDuration )
+		.value( "HashesPerCompute", HashesPerCompute )
+	;
+
+	def(
+		"formatStatistics",
+		( std::string (*)( const PerformanceMonitor &, size_t ) )&formatStatistics,
+		(
+			arg( "monitor" ),
+			arg( "maxLinesPerMetric" ) = 50
+		)
+	);
+
+	def(
+		"formatStatistics",
+		( std::string (*)( const PerformanceMonitor &, PerformanceMetric, size_t ) )&formatStatistics,
+		(
+			arg( "monitor" ),
+			arg( "metric" ),
+			arg( "maxLines" ) = 50
+		)
+	);
 
 	class_<Monitor, boost::noncopyable>( "Monitor", no_init )
 		.def( "setActive", &Monitor::setActive )


### PR DESCRIPTION
This adds timing measurements and a host of other metrics derived from the standard measurements. It also consolidates all the printing code into utilities in a new MonitorAlgo.h header.

This breaks binary compatibility because it adds members to the Statistics class, so I've marked it as requiring a major version.