### PR TITLE
FileSystemPathTest : Prefer assertLess( a, b ) to assertTrue( a < b ).

### DIFF
--- a/python/GafferTest/FileSystemPathTest.py
+++ b/python/GafferTest/FileSystemPathTest.py
@@ -180,7 +180,7 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 
 		mt = p.property( "fileSystem:modificationTime" )
 		self.assertTrue( isinstance( mt, datetime.datetime ) )
-		self.assertTrue( (datetime.datetime.utcnow() - mt).total_seconds() < 1 )
+		self.assertLess( (datetime.datetime.utcnow() - mt).total_seconds(), 1 )
 
 		time.sleep( 1 )
 
@@ -189,7 +189,7 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 
 		mt = p.property( "fileSystem:modificationTime" )
 		self.assertTrue( isinstance( mt, datetime.datetime ) )
-		self.assertTrue( (datetime.datetime.utcnow() - mt).total_seconds() < 1 )
+		self.assertLess( (datetime.datetime.utcnow() - mt).total_seconds(), 1 )
 
 	def testOwner( self ) :
 
@@ -262,7 +262,7 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 
 			self.assertEqual( x.property( "fileSystem:owner" ), pwd.getpwuid( os.stat( str( p ) ).st_uid ).pw_name )
 			self.assertEqual( x.property( "fileSystem:group" ), grp.getgrgid( os.stat( str( p ) ).st_gid ).gr_name )
-			self.assertTrue( (datetime.datetime.utcnow() - x.property( "fileSystem:modificationTime" )).total_seconds() < 1 )
+			self.assertLess( (datetime.datetime.utcnow() - x.property( "fileSystem:modificationTime" )).total_seconds(), 1 )
 			if "###" not in str(x) :
 				self.assertFalse( x.isFileSequence() )
 				self.assertEqual( x.fileSequence(), None )


### PR DESCRIPTION
These tests fail occasionally on Travis for unknown reasons, and this change should mean we get valuable information on the magnitude of the error. If it's small, we likely just have some latency on Travis and can up the threshold. If it's large, it's more likely that we have a timezone bug of some sort that needs fixing.