### PR TITLE
Travis config : Update to use gafferDependencies 0.23.2.0.

### DIFF
--- a/Changes
+++ b/Changes
@@ -67,6 +67,16 @@ Arnold
   should use the equivalent "plugValueWidget:type" metadata instead
   (#1673).
 
+RenderMan
+-----------------------------------------------------------------------
+
+- Added initial support for using OSL shaders in 3delight.
+
+Appleseed
+-----------------------------------------------------------------------
+
+- Updated to [Appleseed 1.4.0-beta](https://github.com/appleseedhq/appleseed/releases/tag/1.4.0-beta).
+
 Cortex
 -----------------------------------------------------------------------
 
@@ -107,6 +117,12 @@ API
     the context such that it is friendlier to the hash cache, by
     removing variables we know to change frequently but which cannot
     affect the result #(1683).
+
+Build
+-----------------------------------------------------------------------
+
+- Updated Cortex to version 9.8.0.
+- Updated Appleseed version to 1.4.0-beta.
 
 0.23.1.0
 ========

--- a/config/travis/installDependencies.py
+++ b/config/travis/installDependencies.py
@@ -15,7 +15,7 @@ buildDir = "build/gaffer-%d.%d.%d.%d-%s" % ( gafferMilestoneVersion, gafferMajor
 
 # get the prebuilt dependencies package and unpack it into the build directory
 
-downloadURL = "https://github.com/johnhaddon/gafferDependencies/releases/download/0.23.0.0/gafferDependencies-0.23.0.0-linux.tar.gz"
+downloadURL = "https://github.com/johnhaddon/gafferDependencies/releases/download/0.23.2.0/gafferDependencies-0.23.2.0-linux.tar.gz"
 
 sys.stderr.write( "Downloading dependencies \"%s\"" % downloadURL )
 tarFileName, headers = urllib.urlretrieve( downloadURL )


### PR DESCRIPTION
Also update Changes file to reflect this. We need to merge this before tagging 0.23.2.0.