### PR TITLE
FileSystemPathTest : Raise threshold for modification time comparisons.

### DIFF
--- a/python/GafferTest/FileSystemPathTest.py
+++ b/python/GafferTest/FileSystemPathTest.py
@@ -180,7 +180,7 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 
 		mt = p.property( "fileSystem:modificationTime" )
 		self.assertTrue( isinstance( mt, datetime.datetime ) )
-		self.assertLess( (datetime.datetime.utcnow() - mt).total_seconds(), 1 )
+		self.assertLess( (datetime.datetime.utcnow() - mt).total_seconds(), 2 )
 
 		time.sleep( 1 )
 
@@ -189,7 +189,7 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 
 		mt = p.property( "fileSystem:modificationTime" )
 		self.assertTrue( isinstance( mt, datetime.datetime ) )
-		self.assertLess( (datetime.datetime.utcnow() - mt).total_seconds(), 1 )
+		self.assertLess( (datetime.datetime.utcnow() - mt).total_seconds(), 2 )
 
 	def testOwner( self ) :
 
@@ -262,7 +262,7 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 
 			self.assertEqual( x.property( "fileSystem:owner" ), pwd.getpwuid( os.stat( str( p ) ).st_uid ).pw_name )
 			self.assertEqual( x.property( "fileSystem:group" ), grp.getgrgid( os.stat( str( p ) ).st_gid ).gr_name )
-			self.assertLess( (datetime.datetime.utcnow() - x.property( "fileSystem:modificationTime" )).total_seconds(), 1 )
+			self.assertLess( (datetime.datetime.utcnow() - x.property( "fileSystem:modificationTime" )).total_seconds(), 2 )
 			if "###" not in str(x) :
 				self.assertFalse( x.isFileSequence() )
 				self.assertEqual( x.fileSequence(), None )


### PR DESCRIPTION
We've been seeing occasional failures on Travis if the tests are run on a machine under heavy load. For example,
https://travis-ci.org/ImageEngine/gaffer/jobs/120951560 took almost twice as long as a more typical build and has the following output :

> ======================================================================
> FAIL: testSequences (GafferTest.FileSystemPathTest.FileSystemPathTest)
> ----------------------------------------------------------------------
> Traceback (most recent call last):
>  File "/home/travis/build/ImageEngine/gaffer/install/gaffer-0.23.2.0-linux/python/GafferTest/FileSystemPathTest.py", line 265, in testSequences
>    self.assertLess( (datetime.datetime.utcnow() - x.property( "fileSystem:modificationTime" )).total_seconds(), 1 )
> AssertionError: 1.000557 not less than 1

Doubling the threshold to 2 seconds seems reasonable.