### PR TITLE
PythonCommand : Disable automatic substitutions for command plug.

### DIFF
--- a/python/GafferDispatch/PythonCommand.py
+++ b/python/GafferDispatch/PythonCommand.py
@@ -47,7 +47,10 @@ class PythonCommand( GafferDispatch.ExecutableNode ) :
 
 		GafferDispatch.ExecutableNode.__init__( self, name )
 
-		self["command"] = Gaffer.StringPlug()
+		# Turn off automatic substitutions for the command, since it's a pain
+		# to have to manually escape things, and the context is available
+		# directly anyway.
+		self["command"] = Gaffer.StringPlug( substitutions = Gaffer.Context.Substitutions.NoSubstitutions )
 		self["variables"] = Gaffer.CompoundDataPlug()
 		self["sequence"] = Gaffer.BoolPlug()
 

--- a/python/GafferDispatchTest/PythonCommandTest.py
+++ b/python/GafferDispatchTest/PythonCommandTest.py
@@ -299,5 +299,13 @@ class PythonCommandTest( GafferTest.TestCase ) :
 
 		self.assertEqual( s["n"].frameString, "010" )
 
+	def testComments( self ) :
+
+		c = Gaffer.PythonCommand()
+		c["command"].setValue( "self.test = 10 # this is a comment" )
+
+		c["task"].execute()
+		self.assertEqual( c.test, 10 )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This was broken by #1671. Although automatic substutions are generally a great thing, in this case they were not.