### PR TITLE
ArnoldShaderUI : Fix ArnoldLight metadata.

### DIFF
--- a/python/GafferArnoldUI/ArnoldShaderUI.py
+++ b/python/GafferArnoldUI/ArnoldShaderUI.py
@@ -116,17 +116,26 @@ with IECoreArnold.UniverseBlock() :
 
 def __nodeDescription( node ) :
 
-	shaderDefault = """Loads shaders for use in Arnold renderers. Use the ShaderAssignment node to assign shaders to objects in the scene."""
-	lightDefault = """Loads an Arnold light shader and uses it to output a scene with a single light."""
-
-	return __metadata[node["name"].getValue()].get(
-		"description",
-		shaderDefault if isinstance( node, GafferArnold.ArnoldShader ) else lightDefault
-	)
+	if isinstance( node, GafferArnold.ArnoldShader ) :
+		return __metadata[node["name"].getValue()].get(
+			"description",
+			"""Loads shaders for use in Arnold renders. Use the ShaderAssignment node to assign shaders to objects in the scene.""",
+		)
+	else :
+		return __metadata[node["__shaderName"].getValue()].get(
+			"description",
+			"""Loads an Arnold light shader and uses it to output a scene with a single light."""
+		)
 
 def __plugMetadata( plug, name ) :
 
-	return __metadata[plug.node()["name"].getValue() + "." + plug.getName()].get( name )
+	if isinstance( plug.node(), GafferArnold.ArnoldShader ) :
+		key = plug.node()["name"].getValue() + "." + plug.getName()
+	else :
+		# Node type is ArnoldLight.
+		key = plug.node()["__shaderName"].getValue() + "." + plug.getName()
+
+	return __metadata[key].get( name )
 
 def __noduleType( plug ) :
 

--- a/python/GafferArnoldUITest/ArnoldShaderUITest.py
+++ b/python/GafferArnoldUITest/ArnoldShaderUITest.py
@@ -78,5 +78,47 @@ class ArnoldShaderUITest( GafferUITest.TestCase ) :
 			Gaffer.Metadata.plugValue( shader["parameters"]["coord_space"], "presetNames" ),
 		)
 
+	def testLightMetadata( self ) :
+
+		light = GafferArnold.ArnoldLight()
+		with IECore.CapturingMessageHandler() as mh :
+			light.loadShader( "skydome_light" )
+
+		## \todo Here we're suppressing warnings about not being
+		# able to create plugs for some parameters. In many cases
+		# these are parameters like "matrix" and "time_samples"
+		# that we don't actually want to represent anyway. We should
+		# add a mechanism for ignoring irrelevant parameters (perhaps
+		# using custom gaffer.something metadata in additional Arnold
+		# .mtd files), and then remove this suppression.
+		for message in mh.messages :
+			self.assertEqual( message.level, mh.Level.Warning )
+			self.assertTrue( "Unsupported parameter" in message.message )
+
+		self.assertEqual(
+			Gaffer.Metadata.plugValue( light["parameters"]["cast_shadows"], "nodule:type" ),
+			""
+		)
+
+		self.assertEqual(
+			Gaffer.Metadata.plugValue( light["parameters"]["color"], "nodule:type" ),
+			"GafferUI::StandardNodule"
+		)
+
+		self.assertEqual(
+			Gaffer.Metadata.plugValue( light["parameters"]["format"], "plugValueWidget:type" ),
+			"GafferUI.PresetsPlugValueWidget"
+		)
+
+		self.assertEqual(
+			Gaffer.Metadata.plugValue( light["parameters"]["format"], "presetNames" ),
+			IECore.StringVectorData( [ "mirrored_ball", "angular", "latlong" ] ),
+		)
+
+		self.assertEqual(
+			Gaffer.Metadata.plugValue( light["parameters"]["format"], "presetValues" ),
+			Gaffer.Metadata.plugValue( light["parameters"]["format"], "presetNames" ),
+		)
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
The ArnoldLight node uses an "__shaderName" plug whereas the ArnoldShader node uses a "name" plug. We were using the wrong name when looking up light metadata and our queries were coming up empty.