### PR TITLE
OSLExpressionEngine : Support BoolPlugs.

### DIFF
--- a/python/GafferOSLTest/OSLExpressionEngineTest.py
+++ b/python/GafferOSLTest/OSLExpressionEngineTest.py
@@ -49,6 +49,22 @@ import GafferOSLTest
 
 class OSLExpressionEngineTest( GafferOSLTest.OSLTestCase ) :
 
+	def testBoolPlugs( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["n"] = Gaffer.Node()
+		s["n"]["user"]["i"] = Gaffer.BoolPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["n"]["user"]["o"] = Gaffer.BoolPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression( "parent.n.user.o = !parent.n.user.i;", "OSL" )
+
+		s["n"]["user"]["i"].setValue( True )
+		self.assertEqual( s["n"]["user"]["o"].getValue(), False )
+
+		s["n"]["user"]["i"].setValue( False )
+		self.assertEqual( s["n"]["user"]["o"].getValue(), True )
+
 	def testFloatPlugs( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/src/GafferOSL/OSLExpressionEngine.cpp
+++ b/src/GafferOSL/OSLExpressionEngine.cpp
@@ -274,6 +274,9 @@ class RendererServices : public OSL::RendererServices
 				const ValuePlug *plug = (*renderState->inPlugs)[index];
 				switch( (Gaffer::TypeId)plug->typeId() )
 				{
+					case BoolPlugTypeId :
+						*(int *)value = static_cast<const BoolPlug *>( plug )->getValue();
+						return true;
 					case FloatPlugTypeId :
 						*(float *)value = static_cast<const FloatPlug *>( plug )->getValue();
 						return true;
@@ -472,7 +475,14 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 					static_cast<FloatPlug *>( proxyOutput )->setValue( static_cast<const FloatData *>( value )->readable() );
 					break;
 				case IntDataTypeId :
-					static_cast<IntPlug *>( proxyOutput )->setValue( static_cast<const IntData *>( value )->readable() );
+					if( IntPlug *intPlug = runTimeCast<IntPlug>( proxyOutput ) )
+					{
+						intPlug->setValue( static_cast<const IntData *>( value )->readable() );
+					}
+					else
+					{
+						static_cast<BoolPlug *>( proxyOutput )->setValue( static_cast<const IntData *>( value )->readable() );
+					}
 					break;
 				case Color3fDataTypeId :
 				{
@@ -514,6 +524,7 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 		{
 			switch( (Gaffer::TypeId)plug->typeId() )
 			{
+				case BoolPlugTypeId :
 				case FloatPlugTypeId :
 				case IntPlugTypeId :
 				case Color3fPlugTypeId :
@@ -579,6 +590,9 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 			string value;
 			switch( (Gaffer::TypeId)output->typeId() )
 			{
+				case BoolPlugTypeId :
+					value = lexical_cast<string>( static_cast<int>( static_cast<const BoolPlug *>( output )->getValue() ) );
+					break;
 				case FloatPlugTypeId :
 					value = lexical_cast<string>( static_cast<const FloatPlug *>( output )->getValue() );
 					break;
@@ -671,6 +685,9 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 		{
 			switch( (Gaffer::TypeId)plug->typeId() )
 			{
+				case BoolPlugTypeId :
+					defaultValue = "0";
+					return "int";
 				case FloatPlugTypeId :
 					defaultValue = "0.0";
 					return "float";


### PR DESCRIPTION
There is no bool type in OSL, so we use ints instead.