### PR TITLE
ArnoldRenderTest : Fix use of ImageStats node.

### DIFF
--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -291,12 +291,14 @@ class ArnoldRenderTest( GafferTest.TestCase ) :
 
 		hiddenStats = GafferImage.ImageStats()
 		hiddenStats["in"].setInput( hidden["out"] )
+		hiddenStats["regionOfInterest"].setValue( hiddenStats["in"]["dataWindow"].getValue() )
 
 		visibleStats = GafferImage.ImageStats()
 		visibleStats["in"].setInput( visible["out"] )
+		visibleStats["regionOfInterest"].setValue( visibleStats["in"]["dataWindow"].getValue() )
 
-		self.assertTrue( hiddenStats["average"].getValue()[0] < 0.05 )
-		self.assertTrue( visibleStats["average"].getValue()[0] > .35 )
+		self.assertLess( hiddenStats["average"].getValue()[0], 0.05 )
+		self.assertGreater( visibleStats["average"].getValue()[0], .35 )
 
 	def testBounds( self ) :
 


### PR DESCRIPTION
Once upon a time the ImageStats node inadvisedly set its own region of interest when the first input was connected, but now it doesn't. Setting it manually means the test passes again. This had gone unnoticed for some time because we're unable to run the GafferArnold tests on Travis.