### PR TITLE
Remove reliance on deprecated IECorePython::Wrapper

### DIFF
--- a/include/GafferCortexBindings/ParameterisedHolderBinding.h
+++ b/include/GafferCortexBindings/ParameterisedHolderBinding.h
@@ -41,7 +41,6 @@
 #include "boost/format.hpp"
 
 #include "IECore/Parameter.h"
-#include "IECorePython/Wrapper.h"
 
 #include "GafferBindings/NodeBinding.h"
 #include "GafferBindings/ExceptionAlgo.h"

--- a/python/Gaffer/Application.py
+++ b/python/Gaffer/Application.py
@@ -74,7 +74,7 @@ class Application( IECore.Parameterised ) :
 
 		)
 
-		self.__root = Gaffer.ApplicationRoot( self.__class__.__name__ )
+		self.__root = _NonSlicingApplicationRoot( self.__class__.__name__ )
 
 	## All Applications have an ApplicationRoot which forms the root of the
 	# hierarchy for all scripts, preferences, nodes etc.
@@ -129,3 +129,22 @@ class Application( IECore.Parameterised ) :
 			return self._run( args )
 
 IECore.registerRunTimeTyped( Application, typeName = "Gaffer::Application" )
+
+# Various parts of the UI try to store their state as attributes on
+# the root object, and therefore require it's identity in python to
+# be stable, even when acquiring it from separate calls to C++ methods
+# like `ancestor( ApplicationRoot )`. The IECorePython::RunTimeTypedWrapper
+# only guarantees this stability if we've derived from it in Python,
+# which is what we do here.
+## \todo Either :
+#
+# - Fix the object identity problem in Cortex
+# - Or at least add a way of requesting that identity be
+#   preserved without needing to derive.
+# - Or stop the UI relying on storing it's own members on
+#   the root.
+class _NonSlicingApplicationRoot( Gaffer.ApplicationRoot ) :
+
+	def __init__( self, name ) :
+
+		Gaffer.ApplicationRoot.__init__( self, name )

--- a/src/GafferBindings/ApplicationRootBinding.cpp
+++ b/src/GafferBindings/ApplicationRootBinding.cpp
@@ -43,7 +43,6 @@
 
 #include "IECorePython/ScopedGILLock.h"
 #include "IECorePython/RunTimeTypedBinding.h"
-#include "IECorePython/Wrapper.h"
 
 #include "Gaffer/ApplicationRoot.h"
 #include "Gaffer/Preferences.h"
@@ -56,13 +55,13 @@ using namespace boost::python;
 using namespace GafferBindings;
 using namespace Gaffer;
 
-class ApplicationRootWrapper : public ApplicationRoot, public IECorePython::Wrapper<ApplicationRoot>
+class ApplicationRootWrapper : public IECorePython::RunTimeTypedWrapper<ApplicationRoot>
 {
 
 	public :
 
 		ApplicationRootWrapper( PyObject *self, const std::string &name = defaultName<ApplicationRoot>() )
-			:	ApplicationRoot( name ), IECorePython::Wrapper<ApplicationRoot>( self, this )
+			:	IECorePython::RunTimeTypedWrapper<ApplicationRoot>( self, name )
 		{
 		}
 

--- a/src/GafferCortexBindings/CompoundParameterHandlerBinding.cpp
+++ b/src/GafferCortexBindings/CompoundParameterHandlerBinding.cpp
@@ -37,7 +37,6 @@
 #include "boost/python.hpp"
 
 #include "IECorePython/RefCountedBinding.h"
-#include "IECorePython/Wrapper.h"
 #include "IECorePython/ScopedGILLock.h"
 
 #include "Gaffer/GraphComponent.h"
@@ -50,25 +49,25 @@ using namespace boost::python;
 using namespace GafferCortex;
 using namespace GafferCortexBindings;
 
-/// Note that we've copied parts of the ParameterHandlerWrapper here. Typically we'd macroise
-/// the repeated parts and make it possible to wrap any of the ParameterHandler classes
+/// Note that we've copied parts of the ParameterHandlerWrapper here. Typically we'd template
+/// the ParameterHandlerWrapper class and make it possible to wrap any of the ParameterHandler classes
 /// easily (see GraphComponentBinding.h for an example). However, doing that would necessitate
 /// binding every single one of the ParameterHandlers, which isn't something we want to do
 /// right now.
-class CompoundParameterHandlerWrapper : public CompoundParameterHandler, public IECorePython::Wrapper<ParameterHandler>
+class CompoundParameterHandlerWrapper : public IECorePython::RefCountedWrapper<CompoundParameterHandler>
 {
 
 	public :
 
 		CompoundParameterHandlerWrapper( PyObject *self, IECore::CompoundParameterPtr parameter )
-			:	CompoundParameterHandler( parameter ), IECorePython::Wrapper<ParameterHandler>( self, this )
+			:	 IECorePython::RefCountedWrapper<CompoundParameterHandler>( self, parameter )
 		{
 		}
 
 		virtual void restore( Gaffer::GraphComponent *plugParent )
 		{
 			IECorePython::ScopedGILLock gilLock;
-			override o = this->get_override( "restore" );
+			object o = methodOverride( "restore" );
 			if( o )
 			{
 				o( Gaffer::GraphComponentPtr( plugParent ) );
@@ -82,10 +81,10 @@ class CompoundParameterHandlerWrapper : public CompoundParameterHandler, public 
 		virtual Gaffer::Plug *setupPlug( Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction, unsigned flags )
 		{
 			IECorePython::ScopedGILLock gilLock;
-			override o = this->get_override( "setupPlug" );
+			object o = methodOverride( "setupPlug" );
 			if( o )
 			{
-				return o( Gaffer::GraphComponentPtr( plugParent ), direction, flags );
+				return extract<Gaffer::Plug *>( o( Gaffer::GraphComponentPtr( plugParent ), direction, flags ) );
 			}
 			else
 			{
@@ -96,7 +95,7 @@ class CompoundParameterHandlerWrapper : public CompoundParameterHandler, public 
 		virtual void setParameterValue()
 		{
 			IECorePython::ScopedGILLock gilLock;
-			override o = this->get_override( "setParameterValue" );
+			object o = methodOverride( "setParameterValue" );
 			if( o )
 			{
 				o();
@@ -110,7 +109,7 @@ class CompoundParameterHandlerWrapper : public CompoundParameterHandler, public 
 		virtual void setPlugValue()
 		{
 			IECorePython::ScopedGILLock gilLock;
-			override o = this->get_override( "setPlugValue" );
+			object o = methodOverride( "setPlugValue" );
 			if( o )
 			{
 				o();
@@ -124,10 +123,10 @@ class CompoundParameterHandlerWrapper : public CompoundParameterHandler, public 
 		virtual IECore::RunTimeTyped *childParameterProvider( IECore::Parameter *childParameter )
 		{
 			IECorePython::ScopedGILLock gilLock;
-			override o = this->get_override( "childParameterProvider" );
+			object o = methodOverride( "childParameterProvider" );
 			if( o )
 			{
-				return o( IECore::ParameterPtr( childParameter ) );
+				return extract<IECore::RunTimeTyped *>( o( IECore::ParameterPtr( childParameter ) ) );
 			}
 			else
 			{

--- a/src/GafferCortexBindings/ParameterHandlerBinding.cpp
+++ b/src/GafferCortexBindings/ParameterHandlerBinding.cpp
@@ -39,7 +39,6 @@
 
 #include "IECorePython/RefCountedBinding.h"
 #include "IECorePython/ScopedGILLock.h"
-#include "IECorePython/Wrapper.h"
 
 #include "Gaffer/Plug.h"
 
@@ -51,28 +50,28 @@ using namespace boost::python;
 using namespace GafferCortex;
 using namespace GafferCortexBindings;
 
-class ParameterHandlerWrapper : public ParameterHandler, public IECorePython::Wrapper<ParameterHandler>
+class ParameterHandlerWrapper : public IECorePython::RefCountedWrapper<ParameterHandler>
 {
 
 	public :
 
 		ParameterHandlerWrapper( PyObject *self )
-			:	ParameterHandler(), IECorePython::Wrapper<ParameterHandler>( self, this )
+			:	IECorePython::RefCountedWrapper<ParameterHandler>( self )
 		{
 		}
 
 		virtual IECore::Parameter *parameter()
 		{
 			IECorePython::ScopedGILLock gilLock;
-			override o = this->get_override( "parameter" );
-			return o();
+			object o = methodOverride( "parameter" );
+			return extract<IECore::Parameter *>( o() );
 		}
 
 		virtual const IECore::Parameter *parameter() const
 		{
 			IECorePython::ScopedGILLock gilLock;
-			override o = this->get_override( "parameter" );
-			return o();
+			object o = methodOverride( "parameter" );
+			return extract<IECore::Parameter *>( o() );
 		}
 
 		virtual void restore( Gaffer::GraphComponent *plugParent )
@@ -85,35 +84,35 @@ class ParameterHandlerWrapper : public ParameterHandler, public IECorePython::Wr
 		virtual Gaffer::Plug *setupPlug( Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction, unsigned flags )
 		{
 			IECorePython::ScopedGILLock gilLock;
-			override o = this->get_override( "setupPlug" );
-			return o( Gaffer::GraphComponentPtr( plugParent ), direction, flags );
+			object o = methodOverride( "setupPlug" );
+			return extract<Gaffer::Plug *>( o( Gaffer::GraphComponentPtr( plugParent ), direction, flags ) );
 		}
 
 		virtual Gaffer::Plug *plug()
 		{
 			IECorePython::ScopedGILLock gilLock;
-			override o = this->get_override( "plug" );
-			return o();
+			object o = methodOverride( "plug" );
+			return extract<Gaffer::Plug *>( o() );
 		}
 
 		virtual const Gaffer::Plug *plug() const
 		{
 			IECorePython::ScopedGILLock gilLock;
-			override o = this->get_override( "plug" );
-			return o();
+			object o = methodOverride( "plug" );
+			return extract<Gaffer::Plug *>( o() );
 		}
 
 		virtual void setParameterValue()
 		{
 			IECorePython::ScopedGILLock gilLock;
-			override o = this->get_override( "setParameterValue" );
+			object o = methodOverride( "setParameterValue" );
 			o();
 		}
 
 		virtual void setPlugValue()
 		{
 			IECorePython::ScopedGILLock gilLock;
-			override o = this->get_override( "setPlugValue" );
+			object o = methodOverride( "setPlugValue" );
 			o();
 		}
 


### PR DESCRIPTION
This is a long overdue followup to #780, totally removing our use of a class that has been deprecated in Cortex.