### PR TITLE
PerformanceMonitor: Fix compile error: linux, gcc 4.8, tbb 4.3.1

### DIFF
--- a/src/Gaffer/PerformanceMonitor.cpp
+++ b/src/Gaffer/PerformanceMonitor.cpp
@@ -34,8 +34,6 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include <stack>
-
 #include "Gaffer/PerformanceMonitor.h"
 #include "Gaffer/Process.h"
 #include "Gaffer/Plug.h"
@@ -80,23 +78,6 @@ bool PerformanceMonitor::Statistics::operator != ( const Statistics &rhs )
 {
 	return !( *this == rhs );
 }
-
-//////////////////////////////////////////////////////////////////////////
-// PerformanceMonitor::ThreadData
-//////////////////////////////////////////////////////////////////////////
-
-struct PerformanceMonitor::ThreadData
-{
-	// Stores the per-plug statistics captured by this thread.
-	StatisticsMap statistics;
-	// Stack of durations pointing into the statistics map.
-	// The top of the stack is the duration we're billing the
-	// current chunk of time to.
-	typedef std::stack<boost::chrono::nanoseconds *> DurationStack;
-	DurationStack durationStack;
-	// The last time measurement we made.
-	boost::chrono::high_resolution_clock::time_point then;
-};
 
 //////////////////////////////////////////////////////////////////////////
 // PerformanceMonitor


### PR DESCRIPTION
In file included from include/Gaffer/PerformanceMonitor.h:40:0,
                 from src/Gaffer/MonitorAlgo.cpp:39:
/usr/include/tbb/enumerable_thread_specific.h: In instantiation of 'class tbb::interface6::enumerable_thread_specific<Gaffer::PerformanceMonitor::ThreadData, tbb::cache_aligned_allocator<Gaffer::PerformanceMonitor::ThreadData>, (tbb::ets_key_usage_type)0u>':
include/Gaffer/PerformanceMonitor.h:101:116:   required from here
/usr/include/tbb/enumerable_thread_specific.h:699:47: error: invalid application of 'sizeof' to incomplete type 'Gaffer::PerformanceMonitor::ThreadData'
         typedef internal::ets_element<T,sizeof(T)%tbb::internal::NFS_MaxLineSize> padded_element;
                                               ^
scons: *** [src/Gaffer/MonitorAlgo.os] Error 1
