### PR TITLE
UVWarp : Fix crashes triggered by negative data window origins.

### DIFF
--- a/python/GafferImageTest/UVWarpTest.py
+++ b/python/GafferImageTest/UVWarpTest.py
@@ -96,5 +96,23 @@ class UVWarpTest( GafferImageTest.ImageTestCase ) :
 				sampler1["pixel"].setValue( IECore.V2f( u * 2, v * 2 ) )
 				self.assertEqual( sampler1["color"].getValue(), sampler2["color"].getValue() )
 
+	def testNegativeDataWindowOrigin( self ) :
+
+		reader = GafferImage.ImageReader()
+		reader["fileName"].setValue( os.path.dirname( __file__ ) + "/images/checker.exr" )
+
+		constant = GafferImage.Constant()
+		constant["color"].setValue( IECore.Color4f( 0.5, 0, 0, 1 ) )
+
+		offset = GafferImage.Offset()
+		offset["in"].setInput( constant["out"] )
+		offset["offset"].setValue( IECore.V2i( -200, -250 ) )
+
+		uvWarp = GafferImage.UVWarp()
+		uvWarp["in"].setInput( reader["out"] )
+		uvWarp["uv"].setInput( offset["out"] )
+
+		GafferImageTest.processTiles( uvWarp["out"] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferImage/UVWarp.cpp
+++ b/src/GafferImage/UVWarp.cpp
@@ -63,7 +63,6 @@ struct UVWarp::Engine : public Warp::Engine
 			m_v( vData->readable() ),
 			m_a( aData->readable() )
 	{
-
 		V2i oP;
 		for( oP.y = validTileBound.min.y; oP.y < validTileBound.max.y; ++oP.y )
 		{
@@ -97,7 +96,8 @@ struct UVWarp::Engine : public Warp::Engine
 
 	virtual Imath::V2f inputPixel( const Imath::V2f &outputPixel ) const
 	{
-		const size_t i = index( outputPixel, m_tileBound );
+		const V2i outputPixelI( floorf( outputPixel.x ), floorf( outputPixel.y ) );
+		const size_t i = index( outputPixelI, m_tileBound );
 		if( m_a[i] == 0.0f )
 		{
 			return black;


### PR DESCRIPTION
We were relying on integer truncation to go from floating point pixel coordinates to integer coordinates. This is all well and good when the coordinates are positive :

    0.5, 0.5 -> 0, 0 (centre of pixel truncates to bottom left corner of pixel, aka its index)

But totally bogus when the coordinates are negative :

    -0.5, -0.5 -> 0, 0 (centre of pixel truncate to top right corner of pixel, aka index of a different pixel)

This was causing the UVWarp to index pixels outside of the bounds of it's tile buffers, and therefore crashing.