### PR TITLE
File extension documentation

### DIFF
--- a/python/GafferSceneUI/SceneReaderUI.py
+++ b/python/GafferSceneUI/SceneReaderUI.py
@@ -50,7 +50,15 @@ Gaffer.Metadata.registerNode(
 
 	"description",
 	"""
-	Reads scenes in any of the formats supported by Cortex's SceneInterface.
+	The primary means of loading external assets (models, animation and cameras etc)
+	from caches into Gaffer. Gaffer's native file format is the .scc (SceneCache) format
+	provided by Cortex, but other formats may be supported by registering a new implementation
+	of Cortex's abstract SceneInterface.
+
+	> Note :
+	>
+	> Currently the SceneReader does not support Alembic caches - for those, the AlembicSource
+	> node should be used instead.
 	""",
 
 	plugs = {

--- a/python/GafferSceneUI/SceneWriterUI.py
+++ b/python/GafferSceneUI/SceneWriterUI.py
@@ -46,8 +46,9 @@ Gaffer.Metadata.registerNode(
 
 	"description",
 	"""
-	Writes scenes to disk. Supports all formats for which a
-	writeable Cortex SceneInterface exists.
+	Writes scenes to cache files on disk. Gaffer's native file format is the .scc
+	(SceneCache) format provided by Cortex, but other formats may be supported by
+	registering a new implementation of Cortex's abstract SceneInterface.
 	""",
 
 	plugs = {

--- a/python/GafferUI/DocumentationAlgo.py
+++ b/python/GafferUI/DocumentationAlgo.py
@@ -199,6 +199,10 @@ def __nodeDocumentation( node ) :
 			result += "\n\n" + __heading( plug.relativeName( node ), 1 )
 			result += description
 
+			extensions = Gaffer.Metadata.plugValue( plug, "fileSystemPathPlugValueWidget:extensions" ) or []
+			if extensions :
+				result += "\n\n**Supported file extensions** : "+ ", ".join( extensions )
+
 			if type( plug ) in ( Gaffer.Plug, Gaffer.ValuePlug, Gaffer.CompoundDataPlug ) :
 				result += walkPlugs( plug )
 

--- a/python/GafferUI/FileSystemPathPlugValueWidget.py
+++ b/python/GafferUI/FileSystemPathPlugValueWidget.py
@@ -61,6 +61,16 @@ class FileSystemPathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
 
 		self.__plugMetadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal().connect( Gaffer.WeakMethod( self.__plugMetadataChanged ) )
 
+	def getToolTip( self ) :
+
+		result = GafferUI.PathPlugValueWidget.getToolTip( self )
+
+		extensions = self.__extensions()
+		if extensions :
+			result += "\n\nSupported file extensions : " + ", ".join( extensions )
+
+		return result
+
 	def _pathChooserDialogue( self ) :
 
 		dialogue = GafferUI.PathPlugValueWidget._pathChooserDialogue( self )
@@ -77,15 +87,11 @@ class FileSystemPathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
 
 		GafferUI.PathPlugValueWidget._updateFromPlug( self )
 
-		extensions = Gaffer.Metadata.plugValue( self.getPlug(), "fileSystemPathPlugValueWidget:extensions" ) or []
-		if isinstance( extensions, str ) :
-			extensions = extensions.split()
-
 		includeSequences = Gaffer.Metadata.plugValue( self.getPlug(), "fileSystemPathPlugValueWidget:includeSequences" ) or False
 
 		self.path().setFilter(
 			Gaffer.FileSystemPath.createStandardFilter(
-				list( extensions ),
+				self.__extensions(),
 				Gaffer.Metadata.plugValue( self.getPlug(), "fileSystemPathPlugValueWidget:extensionsLabel" ) or "",
 				includeSequenceFilter = includeSequences,
 			)
@@ -116,3 +122,16 @@ class FileSystemPathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
 
 		if key.startswith( "fileSystemPathPlugValueWidget:" ) :
 			self._updateFromPlug()
+
+	def __extensions( self ) :
+
+		if self.getPlug() is None :
+			return []
+
+		extensions = Gaffer.Metadata.plugValue( self.getPlug(), "fileSystemPathPlugValueWidget:extensions" ) or []
+		if isinstance( extensions, str ) :
+			extensions = extensions.split()
+		else :
+			extensions = list( extensions )
+
+		return extensions

--- a/python/GafferUI/PathPlugValueWidget.py
+++ b/python/GafferUI/PathPlugValueWidget.py
@@ -95,10 +95,10 @@ class PathPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		result = GafferUI.PlugValueWidget.getToolTip( self )
 
-		result += "<ul>"
+		result += "\n\n<ul>"
 		result += "<li>Tab to auto-complete</li>"
 		result += "<li>Cursor down to list</li>"
-		result += "<ul>"
+		result += "</ul>"
 
 		return result
 


### PR DESCRIPTION
- Include supported extensions in tooltips for all file path widgets
- Include supported extensions in the node reference documentation
- Improve SceneReader/SceneWriter documentation to clarify that .scc is Gaffer's native format

This is in response to @timbowman's [question](https://groups.google.com/forum/#!topic/gaffer-dev/-uX_hoE0Y08) on the mailing list.