### PR TITLE
SystemCommand : Don't swallow stdout.

### DIFF
--- a/python/GafferDispatch/SystemCommand.py
+++ b/python/GafferDispatch/SystemCommand.py
@@ -67,7 +67,7 @@ class SystemCommand( GafferDispatch.ExecutableNode ) :
 		for name, value in environmentVariables.items() :
 			env[name] = str( value )
 
-		subprocess.check_output( command, shell = True, env = env )
+		subprocess.check_call( command, shell = True, env = env )
 
 	def hash( self, context ) :
 


### PR DESCRIPTION
At some point we might want a mechanism the LocalDispatcher can use for redirecting this to the jobs window, but for now at least we'll be able to see it in the terminal. For dispatchers like TractorDispatcher, allowing the output direct to stdout is ideal anyway, because that's already the primary means of getting output into the logs.