### PR TITLE
Arnold Threads

### DIFF
--- a/python/GafferArnold/ArnoldRender.py
+++ b/python/GafferArnold/ArnoldRender.py
@@ -142,11 +142,22 @@ class ArnoldRender( GafferScene.ExecutableRender ) :
 
 		fileName = self["fileName"].getValue()
 
+		threads = self["in"].globals().get( "option:ai:threads", 0 )
+		
 		mode = self["mode"].getValue()
 		if mode == "render" :
-			return "kick -dp -dw -v %d '%s'" % ( self["verbosity"].getValue(), fileName )
+			return "kick -dp -dw -v {verbosity} -t {threads} '{input}'".format(
+				verbosity = self["verbosity"].getValue(),
+				threads = threads,
+				input = fileName
+			)
 		elif mode == "expand" :
-			return "kick -v %d -forceexpand -resave '%s' '%s'" % ( self["verbosity"].getValue(), fileName, fileName )
+			return "kick -v {verbosity} -t {threads} -forceexpand -resave '{output}' '{input}'".format(
+				verbosity = self["verbosity"].getValue(),
+				threads = threads,
+				output = fileName,
+				input = fileName
+			)
 
 		return ""
 

--- a/python/GafferArnoldUI/ArnoldOptionsUI.py
+++ b/python/GafferArnoldUI/ArnoldOptionsUI.py
@@ -86,6 +86,13 @@ def __featuresSummary( plug ) :
 
 	return ", ".join( info )
 
+def __performanceSummary( plug ) :
+
+	info = []
+	if plug["threads"]["enabled"].getValue() :
+		info.append( "Threads %d" % plug["threads"]["value"].getValue() )
+	return ", ".join( info )
+
 def __searchPathsSummary( plug ) :
 
 	info = []
@@ -124,6 +131,7 @@ Gaffer.Metadata.registerNode(
 			"layout:section:Sampling:summary", __samplingSummary,
 			"layout:section:Ray Depth:summary", __rayDepthSummary,
 			"layout:section:Features:summary", __featuresSummary,
+			"layout:section:Performance:summary", __performanceSummary,
 			"layout:section:Search Paths:summary", __searchPathsSummary,
 			"layout:section:Error Colors:summary", __errorColorsSummary,
 
@@ -364,6 +372,21 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"layout:section", "Features",
+
+		],
+
+		# Performance
+
+		"options.threads" : [
+
+			"description",
+			"""
+			Specifies the number of threads Arnold
+			is allowed to use. A value of 0 gives
+			Arnold access to all available threads.
+			""",
+
+			"layout:section", "Performance",
 
 		],
 

--- a/src/GafferArnold/ArnoldOptions.cpp
+++ b/src/GafferArnold/ArnoldOptions.cpp
@@ -74,6 +74,10 @@ ArnoldOptions::ArnoldOptions( const std::string &name )
 	options->addOptionalMember( "ai:ignore_motion_blur", new IECore::BoolData( false ), "ignoreMotionBlur", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:ignore_sss", new IECore::BoolData( false ), "ignoreSSS", Gaffer::Plug::Default, false );
 
+	// performance parameters
+
+	options->addOptionalMember( "ai:threads", new IECore::IntData( 0 ), "threads", Gaffer::Plug::Default, false );
+
 	// searchpath parameters
 
 	options->addOptionalMember( "ai:texture_searchpath", new IECore::StringData( "" ), "textureSearchPath", Gaffer::Plug::Default, false );


### PR DESCRIPTION
- Added "ai:threads" to ArnoldOptions under the Performance section.
- ArnoldRender uses ai:threads option to drive the kick -t command line arg.

I wasn't quite sure how to add tests for this. Maybe its alright without? The other ArnoldOptions don't seem to be tested anyways, and all current GafferArnoldTest and GafferArnoldUITests pass (at IE anyways).