### PR TITLE
Metadata tidyup

### DIFF
--- a/python/GafferCortexUI/ParameterisedHolderUI.py
+++ b/python/GafferCortexUI/ParameterisedHolderUI.py
@@ -154,18 +154,6 @@ class _InfoButton( GafferUI.Button ) :
 		self.__window.reveal()
 
 ##########################################################################
-# Nodules
-##########################################################################
-
-def __parameterNoduleType( plug ) :
-
-	return "GafferUI::StandardNodule" if isinstance( plug, Gaffer.ObjectPlug ) else ""
-
-for nodeType in __nodeTypes :
-	GafferUI.Metadata.registerPlugValue( nodeType, "parameters", "nodule:type", "GafferUI::CompoundNodule" )
-	GafferUI.Metadata.registerPlugValue( nodeType, "parameters.*", "nodule:type", __parameterNoduleType )
-
-##########################################################################
 # Metadata
 ##########################################################################
 
@@ -264,14 +252,40 @@ def __plugWidgetType( plug ) :
 
 	return None
 
+def __plugNoduleType( plug ) :
+
+	return "GafferUI::StandardNodule" if isinstance( plug, Gaffer.ObjectPlug ) else ""
+
 for nodeType in __nodeTypes :
 
-	Gaffer.Metadata.registerNodeDescription( nodeType, __nodeDescription )
-	Gaffer.Metadata.registerNodeValue( nodeType, "summary", __nodeSummary )
-	Gaffer.Metadata.registerPlugDescription( nodeType, "parameters.*", __plugDescription )
-	Gaffer.Metadata.registerPlugValue( nodeType, "parameters.*", "presetNames", __plugPresetNames )
-	Gaffer.Metadata.registerPlugValue( nodeType, "parameters.*", "presetValues", __plugPresetValues )
-	Gaffer.Metadata.registerPlugValue( nodeType, "parameters.*", "plugValueWidget:type", __plugWidgetType )
+	Gaffer.Metadata.registerNode(
+
+		nodeType,
+
+		"description", __nodeDescription,
+		"summary", __nodeSummary,
+
+		plugs = {
+
+			"parameters" : [
+
+				"nodule:type", "GafferUI::CompoundNodule",
+
+			],
+
+			"parameters.*" : [
+
+				"description", __plugDescription,
+				"presetNames", __plugPresetNames,
+				"presetValues", __plugPresetValues,
+				"plugValueWidget:type", __plugWidgetType,
+				"nodule:type", __plugNoduleType,
+
+			],
+
+		},
+
+	)
 
 ##########################################################################
 # Node menu

--- a/python/GafferOSLUI/OSLShaderUI.py
+++ b/python/GafferOSLUI/OSLShaderUI.py
@@ -118,23 +118,37 @@ def __plugWidgetType( plug ) :
 		plug.node().parameterMetadata( plug, "widget" )
 	)
 
-Gaffer.Metadata.registerNodeDescription( GafferOSL.OSLShader, __nodeDescription )
-
-Gaffer.Metadata.registerPlugDescription( GafferOSL.OSLShader, "parameters.*", __plugDescription )
-Gaffer.Metadata.registerPlugValue( GafferOSL.OSLShader, "parameters.*", "label", __plugLabel )
-Gaffer.Metadata.registerPlugValue( GafferOSL.OSLShader, "parameters.*", "layout:divider", __plugDivider )
-Gaffer.Metadata.registerPlugValue( GafferOSL.OSLShader, "parameters.*", "presetNames", __plugPresetNames )
-Gaffer.Metadata.registerPlugValue( GafferOSL.OSLShader, "parameters.*", "presetValues", __plugPresetValues )
-Gaffer.Metadata.registerPlugValue( GafferOSL.OSLShader, "parameters.*", "plugValueWidget:type", __plugWidgetType )
-
-##########################################################################
-# Nodules
-##########################################################################
-
 def __outPlugNoduleType( plug ) :
 
 	return "GafferUI::CompoundNodule" if len( plug ) else "GafferUI::StandardNodule"
 
-Gaffer.Metadata.registerPlugValue( GafferOSL.OSLShader, "out", "nodule:type", __outPlugNoduleType )
-Gaffer.Metadata.registerPlugValue( GafferOSL.OSLShader, "out", "compoundNodule:spacing", 0.2 )
-Gaffer.Metadata.registerPlugValue( GafferOSL.OSLShader, "out", "compoundNodule:orientation", "y" )
+Gaffer.Metadata.registerNode(
+
+	GafferOSL.OSLShader,
+
+	"description", __nodeDescription,
+
+	plugs = {
+
+		"parameters.*" : [
+
+			"description", __plugDescription,
+			"label", __plugLabel,
+			"layout:divider", __plugDivider,
+			"presetNames", __plugPresetNames,
+			"presetValues", __plugPresetValues,
+			"plugValueWidget:type", __plugWidgetType,
+
+		],
+
+		"out" : [
+
+			"nodule:type", __outPlugNoduleType,
+			"compoundNodule:spacing", 0.2,
+			"compoundNodule:orientation", "y",
+
+		],
+
+	}
+
+)

--- a/python/GafferRenderManUI/RenderManShaderUI.py
+++ b/python/GafferRenderManUI/RenderManShaderUI.py
@@ -67,27 +67,6 @@ def _shaderAnnotations( shaderNode ) :
 	return shader.blindData().get( "ri:annotations", {} ) if shader is not None else {}
 
 ##########################################################################
-# Nodules
-##########################################################################
-
-def __parameterNoduleType( plug ) :
-
-	# only coshader parameters should be connectable in the node
-	# graph.
-	if plug.typeId() == Gaffer.Plug.staticTypeId() :
-		return "GafferUI::StandardNodule"
-	elif plug.typeId() == Gaffer.ArrayPlug.staticTypeId() :
-		return "GafferUI::CompoundNodule"
-
-	return ""
-
-GafferUI.Metadata.registerPlugValue( GafferRenderMan.RenderManShader, "parameters.*", "nodule:type", __parameterNoduleType )
-GafferUI.Metadata.registerPlugValue( GafferRenderMan.RenderManShader, "parameters.*", "compoundNodule:orientation", "y" )
-# coshader arrays tend to be used for layering, so we prefer to present the
-# last entry at the top, hence the increasing direction.
-GafferUI.Metadata.registerPlugValue( GafferRenderMan.RenderManShader, "parameters.*", "compoundNodule:direction", "increasing" )
-
-##########################################################################
 # PlugValueWidget creator for the parameters plug itself.
 ##########################################################################
 
@@ -395,14 +374,44 @@ def __plugActivator( plug ) :
 	annotations = _shaderAnnotations( plug.node() )
 	return annotations.get( plug.getName() + ".activator", None )
 
-Gaffer.Metadata.registerNodeDescription( GafferRenderMan.RenderManShader, __nodeDescription )
+def __plugNoduleType( plug ) :
 
-Gaffer.Metadata.registerNodeValue( GafferRenderMan.RenderManShader, "nodeGadget:color", __nodeColor )
+	# only coshader parameters should be connectable in the node
+	# graph.
+	if plug.typeId() == Gaffer.Plug.staticTypeId() :
+		return "GafferUI::StandardNodule"
+	elif plug.typeId() == Gaffer.ArrayPlug.staticTypeId() :
+		return "GafferUI::CompoundNodule"
+
+	return ""
+
+Gaffer.Metadata.registerNode(
+
+	GafferRenderMan.RenderManShader,
+
+	"description", __nodeDescription,
+	"nodeGadget:color", __nodeColor,
+
+	plugs = {
+
+		"parameters.*" : [
+
+			"nodule:type", __plugNoduleType,
+			"compoundNodule:orientation", "y",
+			# Coshader arrays tend to be used for layering, so we prefer to
+			# present the last entry at the top, hence the increasing direction.
+			"compoundNodule:direction", "increasing",
+
+		],
+
+	}
+
+)
 
 for nodeType in( GafferRenderMan.RenderManShader, GafferRenderMan.RenderManLight ) :
 
 	Gaffer.Metadata.registerPlugValue( nodeType, "parameters", "layout:activators", __parameterActivators )
-	Gaffer.Metadata.registerPlugDescription( nodeType, "parameters.*", __plugDescription )
+	Gaffer.Metadata.registerPlugValue( nodeType, "parameters.*", "description", __plugDescription )
 	Gaffer.Metadata.registerPlugValue( nodeType, "parameters.*", "label", __plugLabel )
 	Gaffer.Metadata.registerPlugValue( nodeType, "parameters.*", "layout:divider", __plugDivider )
 	Gaffer.Metadata.registerPlugValue( nodeType, "parameters.*", "ui:visibleDimensions", __plugVisibleDimensions )

--- a/python/GafferRenderManUI/RenderManShaderUI.py
+++ b/python/GafferRenderManUI/RenderManShaderUI.py
@@ -88,19 +88,6 @@ GafferUI.Metadata.registerPlugValue( GafferRenderMan.RenderManShader, "parameter
 GafferUI.Metadata.registerPlugValue( GafferRenderMan.RenderManShader, "parameters.*", "compoundNodule:direction", "increasing" )
 
 ##########################################################################
-# NodeUI - this exists only for backwards compatibility, and will be
-# removed.
-##########################################################################
-
-class RenderManShaderUI( GafferUI.StandardNodeUI ) :
-
-	def __init__( self, node, displayMode = None, **kw ) :
-
-		GafferUI.StandardNodeUI.__init__( self, node, displayMode, **kw )
-
-		warnings.warn( "RenderManShaderUI is deprecated, use either StandardNodeUI or LayoutPlugValueWidget.", DeprecationWarning, 2 )
-
-##########################################################################
 # PlugValueWidget creator for the parameters plug itself.
 ##########################################################################
 

--- a/python/GafferRenderManUI/__init__.py
+++ b/python/GafferRenderManUI/__init__.py
@@ -39,7 +39,7 @@ import RenderManAttributesUI
 import RenderManOptionsUI
 import InteractiveRenderManRenderUI
 import RenderManLightUI
-from RenderManShaderUI import RenderManShaderUI
+import RenderManShaderUI
 import ShaderMenu
 
 __import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", {}, subdirectory = "GafferRenderManUI" )

--- a/python/GafferSceneUI/CropWindowToolUI.py
+++ b/python/GafferSceneUI/CropWindowToolUI.py
@@ -37,15 +37,20 @@
 import Gaffer
 import GafferSceneUI
 
-Gaffer.Metadata.registerNodeDescription(
+Gaffer.Metadata.registerNode(
 
-GafferSceneUI.CropWindowTool,
+	GafferSceneUI.CropWindowTool,
 
-"""Tool for adjusting crop window for rendering.
+	"description",
+	"""
+	Tool for adjusting crop window for rendering. The crop window is displayed as a
+	masked area which can be adjusted using drag and drop.
 
-The crop window is displayed as a masked area which can be adjusted using drag and drop.
-
-Note that the view must be locked to a render camera for this tool to be used. Additionally, an upstream node much be capable of setting the crop window so that there is something to adjust - typically this will be a StandardOptions node. The name of the plug being manipulated is displayed underneath the cropped area - it can be used to verify that the expected node is being adjusted.
-"""
+	Note that the view must be locked to a render camera for this tool to be used.
+	Additionally, an upstream node much be capable of setting the crop window so
+	that there is something to adjust - typically this will be a StandardOptions
+	node. The name of the plug being manipulated is displayed underneath the
+	cropped area - it can be used to verify that the expected node is being adjusted.
+	"""
 
 )

--- a/python/GafferSceneUI/MapOffsetUI.py
+++ b/python/GafferSceneUI/MapOffsetUI.py
@@ -38,22 +38,57 @@ import Gaffer
 import GafferUI
 import GafferScene
 
-Gaffer.Metadata.registerNodeDescription(
+Gaffer.Metadata.registerNode(
 
-GafferScene.MapOffset,
+	GafferScene.MapOffset,
 
-"""Adds an offset to object texture coordinates. Provides a convenient way of looking at specific texture UDIMs.""",
+	"description",
+	"""
+	Adds an offset to object texture coordinates. This provides a convenient way of
+	looking at specific texture UDIMs.
+	""",
 
-"offset",
-"An offset added to the texture coordinates. Note that moving the texture coordinates in the positive direction will move the texture in the negative direction.",
+	plugs = {
 
-"udim",
-"A specific UDIM to offset the texture coordinates to. The UDIM is converted to an offset which is added to the offset above.",
+		"offset" : [
 
-"sName",
-"The name of the primitive variable holding the s coordinate.",
+			"description",
+			"""
+			An offset added to the texture coordinates. Note that moving the
+			texture coordinates in the positive direction will move the texture
+			in the negative direction.
+			""",
 
-"tName",
-"The name of the primitive variable holding the t coordinate.",
+		],
+
+		"udim" : [
+
+			"description",
+			"""
+			A specific UDIM to offset the texture coordinates to. The UDIM is
+			converted to an offset which is added to the offset above.
+			""",
+
+		],
+
+		"sName" : [
+
+			"description",
+			"""
+			The name of the primitive variable holding the s coordinate.
+			""",
+
+		],
+
+		"tName" : [
+
+			"description",
+			"""
+			The name of the primitive variable holding the t coordinate.
+			""",
+
+		],
+
+	}
 
 )

--- a/python/GafferSceneUI/PrimitiveVariablesUI.py
+++ b/python/GafferSceneUI/PrimitiveVariablesUI.py
@@ -39,16 +39,31 @@ import GafferUI
 
 import GafferScene
 
-Gaffer.Metadata.registerNodeDescription(
+Gaffer.Metadata.registerNode(
 
-GafferScene.PrimitiveVariables,
+	GafferScene.PrimitiveVariables,
 
-"""Adds arbitrary primitive variables to objects. Currently only primitive variables with constant interpolation
-are supported - see the OSLObject node for a means of creating variables with vertex interpolation.""",
+	"description",
+	"""
+	Adds arbitrary primitive variables to objects. Currently only primitive
+	variables with constant interpolation are supported - see the OSLObject
+	node for a means of creating variables with vertex interpolation.
+	""",
 
-"primitiveVariables",
-"""The primitive variables to be applied - arbitrary numbers of user defined primitive variables may be added
-as children of this plug via the user interface, or using the CompoundDataPlug API via
-python.""",
+	plugs = {
+
+		"primitiveVariables" : [
+
+			"description",
+			"""
+			The primitive variables to be applied - arbitrary numbers of user
+			defined primitive variables may be added as children of this plug
+			via the user interface, or using the CompoundDataPlug API via
+			python.
+			""",
+
+		]
+
+	}
 
 )

--- a/python/GafferSceneUI/PruneUI.py
+++ b/python/GafferSceneUI/PruneUI.py
@@ -35,21 +35,41 @@
 ##########################################################################
 
 import Gaffer
-import GafferUI
-
 import GafferScene
-import GafferSceneUI
 
-Gaffer.Metadata.registerNodeDescription(
+Gaffer.Metadata.registerNode(
 
-GafferScene.Prune,
+	GafferScene.Prune,
 
-"""A node for removing whole branches from the scene hierarchy.""",
+	"description",
+	"""
+	A node for removing whole branches from the scene hierarchy.
+	""",
 
-"filter",
-"""The branches to prune. The specified locations and all locations below them will be removed from the scene.""",
+	plugs = {
 
-"adjustBounds",
-"""Computes new tightened bounding boxes taking into account the removed locations. This can be an expensive operation - turn on with care.""",
+		"filter" : [
+
+			"description",
+			"""
+			Filter to specify the branches to prune. The specified
+			locations and all locations below them will be removed from
+			the scene.
+			""",
+
+		],
+
+		"adjustBounds" : [
+
+			"description",
+			"""
+			Computes new tightened bounding boxes taking into account
+			the removed locations. This can be an expensive operation -
+			turn on with care.
+			""",
+
+		],
+
+	}
 
 )

--- a/python/GafferSceneUI/SelectionToolUI.py
+++ b/python/GafferSceneUI/SelectionToolUI.py
@@ -37,19 +37,21 @@
 import Gaffer
 import GafferSceneUI
 
-Gaffer.Metadata.registerNodeDescription(
+Gaffer.Metadata.registerNode(
 
-GafferSceneUI.SelectionTool,
+	GafferSceneUI.SelectionTool,
 
-"""Tool for selecting objects.
+	"description",
+	"""
+	Tool for selecting objects.
 
- - Click or drag to set selection
- - Shift-click or shift-drag to add to selection
- - Drag and drop selected objects
-	- Drag to ScriptEditor to get their names
-	- Drag to PathFilter or Sets node to add/remove their paths
-"""
+	- Click or drag to set selection
+	- Shift-click or shift-drag to add to selection
+	- Drag and drop selected objects
+		- Drag to ScriptEditor to get their names
+		- Drag to PathFilter or Sets node to add/remove their paths
+	""",
+
+	"order", 0,
 
 )
-
-Gaffer.Metadata.registerNodeValue( GafferSceneUI.SelectionTool, "order", 0 )


### PR DESCRIPTION
This removes all the last uses of `Metadata.registerNodeDescription()`, so we're now only using the more concise one-shot `registerNode()` method. I'm hoping to have a bit of a tidy up of the Metadata API itself at some point, and this is a step towards that.