### PR TITLE
ImageWriter binding : Allow subclassing in Python.

### DIFF
--- a/src/GafferImageBindings/ImageWriterBinding.cpp
+++ b/src/GafferImageBindings/ImageWriterBinding.cpp
@@ -43,11 +43,14 @@
 #include "GafferImageBindings/ImageWriterBinding.h"
 
 using namespace GafferImage;
+using namespace GafferDispatchBindings;
 
 void GafferImageBindings::bindImageWriter()
 {
 
-	boost::python::scope s = GafferDispatchBindings::ExecutableNodeClass<ImageWriter>()
+	typedef ExecutableNodeWrapper<ImageWriter> ImageWriterWrapper;
+
+	boost::python::scope s = ExecutableNodeClass<ImageWriter, ImageWriterWrapper>()
 		.def( "currentFileFormat", &ImageWriter::currentFileFormat )
 	;
 


### PR DESCRIPTION
I do wonder if we perhaps there's a case for making all executable nodes subclassable, on the grounds that performance of the dispatch nodes is much less critical than the compute nodes, but for now I've just added the one you need in particular, @ivanimanishi.