### PR TITLE
do not set defaults on nodes within nodes.

### DIFF
--- a/python/Gaffer/NodeAlgo.py
+++ b/python/Gaffer/NodeAlgo.py
@@ -136,5 +136,5 @@ def __applyUserDefaults( graphComponent ) :
 		if plugValue is not None :
 			graphComponent.setValue( plugValue )
 
-	for child in graphComponent.children() :
-		__applyUserDefaults( child )
+	for plug in graphComponent.children( Gaffer.Plug ) :
+		__applyUserDefaults( plug )


### PR DESCRIPTION
I am in the process of writing a node for a renderpass which contains an ArnoldOptions node. I expose some of the parameters of that node on the renderpass node by connecting some of the plugs. Since there's a default that is being set on the ArnoldOptions node (the procedurals search path is set to [ARNOLD_PLUGIN_PATH]), gaffer bails on me with the following message when it tries to set the defaults on a connected plug.

ERROR : Line 125 of /home/mattig/gaffer/projects/default/scripts/arnoldrender.gfr : RuntimeError: Exception : Cannot set value for plug "ScriptNode.IEArnoldRenderPassSettings.arnoldOptions.options.proceduralSearchPath.value" except during computation.

The code submitted here disallows recursion into contained nodes so that ArnoldOptions still get that default value as long as they are not contained in another node. If they are contained, the parent is expected to manage these values.