### PR TITLE
Support Matrix Parameters On Arnold Shaders

### DIFF
--- a/python/GafferTest/CompoundDataPlugTest.py
+++ b/python/GafferTest/CompoundDataPlugTest.py
@@ -149,6 +149,34 @@ class CompoundDataPlugTest( GafferTest.TestCase ) :
 		self.assertEqual( d, IECore.V2fData( IECore.V2f( 1, 2 ) ) )
 		self.assertEqual( n, "b" )
 
+	def testImathMatrixData( self ) :
+
+		p = Gaffer.CompoundDataPlug()
+
+		m1 = p.addMember( "a", IECore.M44fData( IECore.M44f( *range(16) ) ) )
+		self.failUnless( isinstance( m1, Gaffer.ValuePlug ) )
+
+		d, n = p.memberDataAndName( m1 )
+		self.assertEqual( d, IECore.M44fData( IECore.M44f( *range(16) ) ) )
+		self.assertEqual( n, "a" )
+
+	def testTransformPlugData( self ) :
+
+		p = Gaffer.CompoundDataPlug()
+
+		m1 = p.addMember( "a", Gaffer.TransformPlug() )
+		m1["value"]["translate"].setValue( IECore.V3f( 1,2,3 ) )
+		self.failUnless( isinstance( m1, Gaffer.ValuePlug ) )
+
+		d, n = p.memberDataAndName( m1 )
+		self.assertEqual( d, IECore.M44fData( IECore.M44f( [
+			1, 0, 0, 0,
+			0, 1, 0, 0,
+			0, 0, 1, 0,
+			1, 2, 3, 1,
+		] ) ) )
+		self.assertEqual( n, "a" )
+
 	def testPlugFlags( self ) :
 
 		p = Gaffer.CompoundDataPlug()

--- a/python/GafferTest/TransformPlugTest.py
+++ b/python/GafferTest/TransformPlugTest.py
@@ -145,5 +145,20 @@ class TransformPlugTest( GafferTest.TestCase ) :
 			)
 		)
 
+	def testDynamicSerialisation( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["n"] = Gaffer.Node()
+		s["n"]["p"] = Gaffer.TransformPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["n"]["p"]["translate"].setValue( IECore.V3f( 1, 2, 3 ) )
+		s["n"]["p"]["rotate"].setValue( IECore.V3f( 4, 5, 6 ) )
+		ss = s.serialise()
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( ss )
+
+		self.assertEqual( s2["n"]["p"]["translate"].getValue(), IECore.V3f( 1, 2, 3 ) )
+		self.assertEqual( s2["n"]["p"]["rotate"].getValue(), IECore.V3f( 4, 5, 6 ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/CompoundDataPlug.cpp
+++ b/src/Gaffer/CompoundDataPlug.cpp
@@ -45,6 +45,7 @@
 #include "Gaffer/SplinePlug.h"
 #include "Gaffer/BoxPlug.h"
 #include "Gaffer/StringPlug.h"
+#include "Gaffer/TransformPlug.h"
 
 using namespace Imath;
 using namespace IECore;
@@ -376,6 +377,15 @@ ValuePlugPtr CompoundDataPlug::createPlugFromData( const std::string &name, Plug
 		{
 			return boxValuePlug( name, direction, flags, static_cast<const Box3iData *>( value ) );
 		}
+		case M44fDataTypeId :
+		{
+			M44fPlugPtr valuePlug = new M44fPlug(
+				name,
+				direction,
+				static_cast<const M44fData *>( value )->readable(),
+				flags
+			);
+		}
 		case FloatVectorDataTypeId :
 		{
 			return typedObjectValuePlug( name, direction, flags, static_cast<const FloatVectorData *>( value ) );
@@ -492,6 +502,10 @@ IECore::DataPtr CompoundDataPlug::extractDataFromPlug( const ValuePlug *plug )
 			return new SplineffData( static_cast<const SplineffPlug *>( plug )->getValue() );
 		case SplinefColor3fPlugTypeId :
 			return new SplinefColor3fData( static_cast<const SplinefColor3fPlug *>( plug )->getValue() );
+		case TransformPlugTypeId :
+			return new M44fData( static_cast<const TransformPlug *>( plug )->matrix() );
+		case M44fPlugTypeId :
+			return new M44fData( static_cast<const M44fPlug *>( plug )->getValue() );
 		default :
 			throw IECore::Exception(
 				boost::str( boost::format( "Plug \"%s\" has unsupported type \"%s\"" ) % plug->getName().string() % plug->typeName() )

--- a/src/Gaffer/TransformPlug.cpp
+++ b/src/Gaffer/TransformPlug.cpp
@@ -51,6 +51,9 @@ TransformPlug::TransformPlug( const std::string &name, Direction direction, unsi
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 
+	// We create our children automatically, so they should never be created dynamically
+	unsigned childFlags = flags & ~Plug::Dynamic;
+
 	addChild(
 		new V3fPlug(
 			"translate",
@@ -58,7 +61,7 @@ TransformPlug::TransformPlug( const std::string &name, Direction direction, unsi
 			V3f( 0 ),
 			V3f( limits<float>::min() ),
 			V3f( limits<float>::max() ),
-			flags
+			childFlags
 		)
 	);
 
@@ -69,7 +72,7 @@ TransformPlug::TransformPlug( const std::string &name, Direction direction, unsi
 			V3f( 0 ),
 			V3f( limits<float>::min() ),
 			V3f( limits<float>::max() ),
-			flags
+			childFlags
 		)
 	);
 
@@ -80,7 +83,7 @@ TransformPlug::TransformPlug( const std::string &name, Direction direction, unsi
 			V3f( 1 ),
 			V3f( limits<float>::min() ),
 			V3f( limits<float>::max() ),
-			flags
+			childFlags
 		)
 	);
 
@@ -91,7 +94,7 @@ TransformPlug::TransformPlug( const std::string &name, Direction direction, unsi
 			V3f( 0 ),
 			V3f( limits<float>::min() ),
 			V3f( limits<float>::max() ),
-			flags
+			childFlags
 		)
 	);
 }

--- a/src/GafferArnold/ParameterHandler.cpp
+++ b/src/GafferArnold/ParameterHandler.cpp
@@ -179,6 +179,20 @@ Gaffer::Plug *ParameterHandler::setupPlug( const AtParamEntry *parameter, Gaffer
 				);
 
 			}
+			break;
+
+		case AI_TYPE_MATRIX :
+
+			{
+				
+				M44f defaultValue( *AiParamGetDefault( parameter )->pMTX );
+				plug = new M44fPlug(
+					name,
+					direction,
+					defaultValue
+				);
+
+			}
 
 	}
 


### PR DESCRIPTION
Putting up for comment.  The first commit is a dependency which is a clear fix with corresponding test case.

The actual goal is in the second commit, and isn't ready to merge yet, but I'd like feedback from John on.  If we expose Matrix parameters on Arnold shaders, should we expose them as TransformPlug or M44fPlug?  I tried out TransformPlug, and it seems to be working reasonably.  If that sounds good to you, I think the only thing left is to fill in the default by doing a Euler extract on the default matrix provided the shader, and add a test case.

Either way, this will also require:

https://github.com/ImageEngine/cortex/pull/499