### PR TITLE
SceneReader : Remove scene:path from context

### DIFF
--- a/include/GafferScene/SceneReader.h
+++ b/include/GafferScene/SceneReader.h
@@ -122,12 +122,17 @@ class SceneReader : public SceneNode
 			IECore::ConstSceneInterfacePtr pathScene;
 		};
 		mutable tbb::enumerable_thread_specific<LastScene> m_lastScene;
-		// Returns the SceneInterface for the current filename (in the current Context)
+		// Returns the SceneInterface for the current filename
 		// and specified path, using m_lastScene to accelerate the lookups.
-		IECore::ConstSceneInterfacePtr scene( const ScenePath &path ) const;
+		IECore::ConstSceneInterfacePtr scene( const ScenePath &path, const Gaffer::Context *context ) const;
 
 		static const double g_frameRate;
 		static size_t g_firstPlugIndex;
+
+		// Utilities to compute the fileName plug hash and value in a context
+		// that doesn't include unnecessary and frequently changing variables
+		std::string fileNameValue( const Gaffer::Context *context ) const;
+		void hashFileName( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 
 };
 


### PR DESCRIPTION
Hashing the fileName plug for every scene location can cause significant
performance loss, in particular in situations where we are dynamically setting
the fileName using an expression.
This has the downside of preventing us from changing the fileName per
scene location, but giving that up seems like worth the advantage gained in
performance, given that we don't actually have a practical use for such feature.

---
@johnhaddon, I made this pull request based on your suggestion, and indeed it had a noticeable impact in performance in the dynamic scene builder.
However, given my lack of experience in the details of the code I changed, feel free to close the PR and make a new one yourself if you feel that patching the PR is more work :smile: 

