### PR TITLE
IECoreArnoldPreview : Renderer - aspect_ratio passed using AiNodeSetFlt

### DIFF
--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -432,11 +432,11 @@ class ArnoldRenderer : public IECoreScenePreview::Renderer
 			{
 				if( value == NULL )
 				{
-					AiNodeSetInt( options, "aspect_ratio", 1.0f );
+					AiNodeSetFlt( options, "aspect_ratio", 1.0f );
 				}
 				else if( const IECore::FloatData *d = reportedCast<const IECore::FloatData>( value, "option", name ) )
 				{
-					AiNodeSetInt( options, "aspect_ratio", 1.0f / d->readable() ); // arnold is y/x, we're x/y
+					AiNodeSetFlt( options, "aspect_ratio", 1.0f / d->readable() ); // arnold is y/x, we're x/y
 				}
 				return;
 			}


### PR DESCRIPTION
This was causing a warning that prevented builds on some gcc versions.  I assume it wasn't working either, since this value clearly needs to be a float.