### PR TITLE
SConstruct : Include Appleseed headers with -isystem, not -I.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -675,12 +675,12 @@ libraries = {
 
 	"GafferAppleseed" : {
 		"envAppends" : {
-			"CPPPATH" : [ "$APPLESEED_INCLUDE_PATH" ],
+			"CXXFLAGS" : [ "-isystem", "$APPLESEED_INCLUDE_PATH" ],
 			"LIBPATH" : [ "$APPLESEED_LIB_PATH" ],
 			"LIBS" : [ "Gaffer", "GafferScene", "appleseed", "IECoreAppleseed$CORTEX_LIB_SUFFIX" ],
 		},
 		"pythonEnvAppends" : {
-			"CPPPATH" : [ "$APPLESEED_INCLUDE_PATH" ],
+			"CXXFLAGS" : [ "-isystem", "$APPLESEED_INCLUDE_PATH" ],
 			"LIBPATH" : [ "$APPLESEED_LIB_PATH" ],
 			"LIBS" : [ "Gaffer", "GafferScene", "GafferBindings", "GafferAppleseed" ],
 		},


### PR DESCRIPTION
This should fix this compilation error seen on Travis with GCC 5.

```
In file included from build/gaffer-0.24.1.0-linux/appleseed/include/renderer/api/light.h:37:0,

from src/GafferAppleseed/AppleseedLight.cpp:41:

build/gaffer-0.24.1.0-linux/appleseed/include/renderer/modeling/light/lightfactoryregistrar.h:74:32: error: 'template<class> class std::auto_ptr' is deprecated [-Werror=deprecated-declarations]

void register_factory(std::auto_ptr<FactoryType> factory);

^

In file included from /usr/include/c++/5/bits/locale_conv.h:41:0,

from /usr/include/c++/5/locale:43,

from /home/travis/build/ImageEngine/gaffer/build/gaffer-0.24.1.0-linux/include/boost/format.hpp:23,

from src/GafferAppleseed/AppleseedLight.cpp:37:

/usr/include/c++/5/bits/unique_ptr.h:49:28: note: declared here

template<typename> class auto_ptr;
```