### PR TITLE
Arnold Renderer : Don't apply default shader explicitly.

### DIFF
--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -352,11 +352,6 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 				surfaceShader = shaderCache->get( surfaceShaderAttribute );
 			}
 
-			if( !surfaceShader )
-			{
-				surfaceShader = shaderCache->get( g_defaultShader.get() );
-			}
-
 			lightShader = attribute<IECore::ObjectVector>( g_arnoldLightShaderAttributeName, attributes );
 			lightShader = lightShader ? lightShader : attribute<IECore::ObjectVector>( g_lightShaderAttributeName, attributes );
 		}
@@ -420,18 +415,7 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 			}
 		}
 
-		static IECore::ConstObjectVectorPtr g_defaultShader;
-
 };
-
-IECore::ConstObjectVectorPtr defaultShader()
-{
-	IECore::ObjectVectorPtr result = new IECore::ObjectVector;
-	result->members().push_back( new IECore::Shader( "utility" ) );
-	return result;
-}
-
-IECore::ConstObjectVectorPtr ArnoldAttributes::g_defaultShader = defaultShader();
 
 } // namespace
 
@@ -534,7 +518,14 @@ class ArnoldObject : public IECoreScenePreview::Renderer::ObjectInterface
 				AiNodeSetBool( m_node, "matte", arnoldAttributes->shadingFlags & ArnoldAttributes::Matte );
 
 				m_shader = arnoldAttributes->surfaceShader; // Keep shader alive as long as we are alive
-				AiNodeSetPtr( m_node, "shader", m_shader ? m_shader->root() : AiNodeLookUpByName( "ieCoreArnold:defaultShader" ) );
+				if( m_shader && m_shader->root() )
+				{
+					AiNodeSetPtr( m_node, "shader", m_shader->root() );
+				}
+				else
+				{
+					AiNodeResetParameter( m_node, "shader" );
+				}
 			}
 		}
 


### PR DESCRIPTION
Arnold will automatically use a default shader if none is applied, and it behaves exactly as the one we were applying anyway. The key realisation to making this work is that `AiNodeSetPtr( ..., NULL )` is _not_ the same as `AiNodeResetParameter( ... )` - the former gives the "bad shader" error colour and the latter reverts to the default shading behaviour we want.

Not only is this simpler, it also means we no longer assign a default shader to external procedurals, where Arnold's odd forced inheritance behaviour would override all shaders on nodes within the procedural.