### PR TITLE
GafferArnold : Move path setup from __init__.py to wrapper.

### DIFF
--- a/bin/gaffer
+++ b/bin/gaffer
@@ -158,6 +158,14 @@ if [[ -z $APPLESEED && -d $GAFFER_ROOT/appleseed ]] ; then
 
 fi
 
+# Set up Arnold
+##########################################################################
+
+export ARNOLD_PLUGIN_PATH=$GAFFER_ROOT/arnold/plugins${ARNOLD_PLUGIN_PATH:+:}${ARNOLD_PLUGIN_PATH:-}
+# \todo This is just backwards compatibility for an old gafferDependencies layout - remove once
+# the new layout becomes the current one.
+export ARNOLD_PLUGIN_PATH=$GAFFER_ROOT/arnold/outputDrivers:${ARNOLD_PLUGIN_PATH}
+
 # Run gaffer itself
 ##########################################################################
 

--- a/python/GafferArnold/__init__.py
+++ b/python/GafferArnold/__init__.py
@@ -36,15 +36,6 @@
 
 __import__( "GafferScene" )
 
-def __setupEnvironment() :
-
-	import os
-	arnoldPluginPath = os.environ.get( "ARNOLD_PLUGIN_PATH", "" ).split( ":" )
-	arnoldPluginPath = [ "$GAFFER_ROOT/arnold/procedurals", "$GAFFER_ROOT/arnold/outputDrivers" ] + arnoldPluginPath
-	os.environ["ARNOLD_PLUGIN_PATH"] = os.path.expandvars( ":".join( arnoldPluginPath ) )
-
-__setupEnvironment()
-
 from _GafferArnold import *
 
 __import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", {}, subdirectory = "GafferArnold" )


### PR DESCRIPTION
This means that `gaffer env kick` can be used successfully to render a pregenerated ass file containing a Gaffer output driver, and also that a SystemCommand can be used to call `kick` even if no GafferArnold nodes are in the script.

Deliberately omitted the procedurals location, because we no longer use the Cortex python procedural for Arnold rendering.