### PR TITLE
Arnold improvements

### DIFF
--- a/include/GafferScene/Preview/InteractiveRender.h
+++ b/include/GafferScene/Preview/InteractiveRender.h
@@ -118,9 +118,8 @@ class InteractiveRender : public Gaffer::Node
 		std::vector<boost::shared_ptr<SceneGraph> > m_sceneGraphs;
 		IECoreScenePreview::RendererPtr m_renderer;
 		State m_state;
-		unsigned m_dirtyFlags;
+		unsigned m_dirtyComponents;
 		IECore::ConstCompoundObjectPtr m_globals;
-		IECore::ConstCompoundObjectPtr m_globalAttributes;
 		GafferScene::PathMatcher m_lightSet;
 		GafferScene::PathMatcher m_cameraSet;
 		IECoreScenePreview::Renderer::ObjectInterfacePtr m_defaultCamera;

--- a/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
+++ b/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
@@ -61,7 +61,11 @@ class RendererTest( GafferTest.TestCase ) :
 			self.temporaryDirectory() + "/test.ass"
 		)
 
-		o = r.object( "testPlane", IECore.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ) )
+		o = r.object(
+			"testPlane",
+			IECore.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
+			r.attributes( IECore.CompoundObject() ),
+		)
 		o.transform( IECore.M44f().translate( IECore.V3f( 1, 2, 3 ) ) )
 
 		r.render()
@@ -89,7 +93,8 @@ class RendererTest( GafferTest.TestCase ) :
 					"resolution" : IECore.V2i( 2000, 1000 ),
 					"cropWindow" : IECore.Box2f( IECore.V2f( 0 ), IECore.V2f( 1, 0.75 ) ),
 				}
-			)
+			),
+			r.attributes( IECore.CompoundObject() )
 		)
 
 		r.option( "camera", IECore.StringData( "testCamera" ) )
@@ -124,11 +129,13 @@ class RendererTest( GafferTest.TestCase ) :
 				"ai:surface" : IECore.ObjectVector( [ IECore.Shader( "flat" ) ] ),
 			} )
 
-			o = r.object( "testPlane%d" % i, IECore.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ) )
-			# We keep specifying the same shader, but we'd like the renderer
-			# to be frugal and reuse a single arnold shader on the other side.
-			o.attributes( r.attributes( a ) )
-			del o
+			r.object(
+				"testPlane%d" % i,
+				IECore.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
+				# We keep specifying the same shader, but we'd like the renderer
+				# to be frugal and reuse a single arnold shader on the other side.
+				r.attributes( a )
+			)
 
 		r.render()
 		del r
@@ -146,7 +153,12 @@ class RendererTest( GafferTest.TestCase ) :
 			self.temporaryDirectory() + "/test.ass"
 		)
 
-		o = r.object( "testPlane", IECore.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ) )
+		o = r.object(
+			"testPlane",
+			IECore.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
+			r.attributes( IECore.CompoundObject() )
+		)
+
 		# Replace the shader a few times.
 		for shader in ( "utility", "flat", "standard" ) :
 			a = IECore.CompoundObject( {
@@ -177,8 +189,9 @@ class RendererTest( GafferTest.TestCase ) :
 			IECore.Shader( "flat", parameters = { "color" : "link:myHandle" } ),
 		] )
 
-		o1 = r.object( "testPlane1", IECore.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ) )
-		o1.attributes(
+		r.object(
+			"testPlane1",
+			IECore.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
 			r.attributes(
 				IECore.CompoundObject( {
 					"ai:surface" : shader1
@@ -191,8 +204,9 @@ class RendererTest( GafferTest.TestCase ) :
 			IECore.Shader( "standard", parameters = { "Kd_color" : "link:myHandle" } ),
 		] )
 
-		o2 = r.object( "testPlane2", IECore.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ) )
-		o2.attributes(
+		r.object(
+			"testPlane2",
+			IECore.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
 			r.attributes(
 				IECore.CompoundObject( {
 					"ai:surface" : shader2
@@ -200,7 +214,6 @@ class RendererTest( GafferTest.TestCase ) :
 			)
 		)
 
-		del o1, o2
 		r.render()
 		del r
 
@@ -221,8 +234,9 @@ class RendererTest( GafferTest.TestCase ) :
 		)
 
 		lightShader = IECore.ObjectVector( [ IECore.Shader( "point_light", "ai:light" ), ] )
-		o = r.light( "testLight", None )
-		o.attributes(
+		r.light(
+			"testLight",
+			None,
 			r.attributes(
 				IECore.CompoundObject( {
 					"ai:light" : lightShader
@@ -230,7 +244,6 @@ class RendererTest( GafferTest.TestCase ) :
 			)
 		)
 
-		del o
 		r.render()
 		del r
 
@@ -257,13 +270,10 @@ class RendererTest( GafferTest.TestCase ) :
 			} )
 		)
 
-		o = r.light( "testLight1", None )
-		o.attributes( lightAttributes )
+		r.light( "testLight1", None, lightAttributes )
+		r.light( "testLight2", None, lightAttributes )
 
-		o = r.light( "testLight2", None )
-		o.attributes( lightAttributes )
-
-		del o, lightAttributes
+		del lightAttributes
 		r.render()
 		del r
 
@@ -283,8 +293,9 @@ class RendererTest( GafferTest.TestCase ) :
 			self.temporaryDirectory() + "/test.ass"
 		)
 
-		o1 = r.object( "testMesh1", IECore.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ) )
-		o1.attributes(
+		r.object(
+			"testMesh1",
+			IECore.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
 			r.attributes( IECore.CompoundObject( {
 				"doubleSided" : IECore.BoolData( True ),
 				"ai:visibility:camera" : IECore.BoolData( False ),
@@ -297,11 +308,12 @@ class RendererTest( GafferTest.TestCase ) :
 				"ai:self_shadows" : IECore.BoolData( True ),
 				"ai:matte" : IECore.BoolData( True ),
 				"ai:opaque" : IECore.BoolData( True ),
-			} ) )
+			} ) ),
 		)
 
-		o2 = r.object( "testMesh2", IECore.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ) )
-		o2.attributes(
+		r.object(
+			"testMesh2",
+			IECore.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
 			r.attributes( IECore.CompoundObject( {
 				"doubleSided" : IECore.BoolData( False ),
 				"ai:visibility:camera" : IECore.BoolData( True ),
@@ -314,12 +326,15 @@ class RendererTest( GafferTest.TestCase ) :
 				"ai:self_shadows" : IECore.BoolData( False ),
 				"ai:matte" : IECore.BoolData( False ),
 				"ai:opaque" : IECore.BoolData( False ),
-			} ) )
+			} ) ),
 		)
 
-		o3 = r.object( "testMesh3", IECore.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ) )
+		r.object(
+			"testMesh3",
+			IECore.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
+			r.attributes( IECore.CompoundObject() ),
+		)
 
-		del o1, o2, o3
 		r.render()
 		del r
 

--- a/python/GafferArnoldUI/ArnoldAttributesUI.py
+++ b/python/GafferArnoldUI/ArnoldAttributesUI.py
@@ -75,10 +75,12 @@ def __subdivisionSummary( plug ) :
 	info = []
 	if plug["subdivIterations"]["enabled"].getValue() :
 		info.append( "Iterations %d" % plug["subdivIterations"]["value"].getValue() )
-	if plug["subdivPixelError"]["enabled"].getValue() :
-		info.append( "Error %s" % GafferUI.NumericWidget.valueToString( plug["subdivPixelError"]["value"].getValue() ) )
+	if plug["subdivAdaptiveError"]["enabled"].getValue() :
+		info.append( "Error %s" % GafferUI.NumericWidget.valueToString( plug["subdivAdaptiveError"]["value"].getValue() ) )
 	if plug["subdivAdaptiveMetric"]["enabled"].getValue() :
 		info.append( string.capwords( plug["subdivAdaptiveMetric"]["value"].getValue().replace( "_", " " ) ) + " Metric" )
+	if plug["subdivAdaptiveSpace"]["enabled"].getValue() :
+		info.append( string.capwords( plug["subdivAdaptiveSpace"]["value"].getValue() ) + " Space" )
 
 	return ", ".join( info )
 
@@ -254,7 +256,7 @@ Gaffer.Metadata.registerNode(
 			The maximum number of subdivision
 			steps to apply when rendering subdivision
 			surface. To set an exact number of
-			subdivisions, set the pixel error to
+			subdivisions, set the adaptive error to
 			0 so that the maximum becomes the
 			controlling factor.
 
@@ -268,7 +270,7 @@ Gaffer.Metadata.registerNode(
 
 		],
 
-		"attributes.subdivPixelError" : [
+		"attributes.subdivAdaptiveError" : [
 
 			"description",
 			"""
@@ -278,12 +280,12 @@ Gaffer.Metadata.registerNode(
 			metric below. Note also that the iterations
 			value above provides a hard limit on the maximum
 			number of subdivision steps, so if changing the
-			pixel error setting appears to have no effect,
+			error setting appears to have no effect,
 			you may need to raise the maximum.
 			""",
 
 			"layout:section", "Subdivision",
-			"label", "Pixel Error",
+			"label", "Adaptive Error",
 
 		],
 
@@ -292,13 +294,13 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			The metric used when performing adaptive
-			subdivision as specified by the pixel error.
+			subdivision as specified by the adaptive error.
 			The flatness metric ensures that the subdivided
 			surface doesn't deviate from the true surface
-			by more than the pixel error, and will tend to
+			by more than the error, and will tend to
 			increase detail in areas of high curvature. The
 			edge length metric ensures that the edge length
-			of a polygon is never longer than the pixel metric,
+			of a polygon is never longer than the error,
 			so will tend to subdivide evenly regardless of
 			curvature - this can be useful when applying a
 			displacement shader. The auto metric automatically
@@ -318,6 +320,34 @@ Gaffer.Metadata.registerNode(
 			"preset:Auto", "auto",
 			"preset:Edge Length", "edge_length",
 			"preset:Flatness", "flatness",
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
+		],
+
+		"attributes.subdivAdaptiveSpace" : [
+
+			"description",
+			"""
+			The space in which the error is measured when
+			performing adaptive subdivision. Raster space means
+			that the subdivision adapts to size on screen,
+			with subdivAdaptiveError being specified in pixels.
+			Object space means that the error is measured in
+			object space units and will not be sensitive to
+			size on screen.
+			""",
+
+			"layout:section", "Subdivision",
+			"label", "Adaptive Space",
+
+		],
+
+
+		"attributes.subdivAdaptiveSpace.value" : [
+
+			"preset:Raster", "raster",
+			"preset:Object", "object",
 
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 

--- a/python/GafferArnoldUI/ArnoldAttributesUI.py
+++ b/python/GafferArnoldUI/ArnoldAttributesUI.py
@@ -98,8 +98,7 @@ Gaffer.Metadata.registerNode(
 
 	"description",
 	"""
-	Applies Arnold attributes to objects
-	in the scene.
+	Applies Arnold attributes to objects in the scene.
 	""",
 
 	plugs = {
@@ -282,6 +281,10 @@ Gaffer.Metadata.registerNode(
 			number of subdivision steps, so if changing the
 			error setting appears to have no effect,
 			you may need to raise the maximum.
+
+			> Note : Objects with a non-zero value will not take part in
+			> Gaffer's automatic instancing unless subdivAdaptiveSpace is
+			> set to "object".
 			""",
 
 			"layout:section", "Subdivision",

--- a/src/GafferArnold/ArnoldAttributes.cpp
+++ b/src/GafferArnold/ArnoldAttributes.cpp
@@ -66,12 +66,12 @@ ArnoldAttributes::ArnoldAttributes( const std::string &name )
 	attributes->addOptionalMember( "ai:receive_shadows", new IECore::BoolData( true ), "receiveShadows", Gaffer::Plug::Default, false );
 	attributes->addOptionalMember( "ai:self_shadows", new IECore::BoolData( true ), "selfShadows", Gaffer::Plug::Default, false );
 
-
 	// Subdivision parameters
 
 	attributes->addOptionalMember( "ai:polymesh:subdiv_iterations", new IntPlug( "value", Plug::In, 1, 1 ), "subdivIterations", false );
-	attributes->addOptionalMember( "ai:polymesh:subdiv_pixel_error", new FloatPlug( "value", Plug::In, 0.0f, 0.0f ), "subdivPixelError", false );
+	attributes->addOptionalMember( "ai:polymesh:subdiv_adaptive_error", new FloatPlug( "value", Plug::In, 0.0f, 0.0f ), "subdivAdaptiveError", false );
 	attributes->addOptionalMember( "ai:polymesh:subdiv_adaptive_metric", new StringPlug( "value", Plug::In, "auto" ), "subdivAdaptiveMetric", false );
+	attributes->addOptionalMember( "ai:polymesh:subdiv_adaptive_space", new StringPlug( "value", Plug::In, "raster" ), "subdivAdaptiveSpace", false );
 
 	// Volume parameters
 

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -756,27 +756,35 @@ class ArnoldRenderer : public IECoreScenePreview::Renderer
 			return new ArnoldAttributes( attributes, m_shaderCache.get() );
 		}
 
-		virtual ObjectInterfacePtr camera( const std::string &name, const IECore::Camera *camera )
+		virtual ObjectInterfacePtr camera( const std::string &name, const IECore::Camera *camera, const AttributesInterface *attributes )
 		{
 			IECore::CameraPtr cameraCopy = camera->copy();
 			cameraCopy->addStandardParameters();
 			m_cameras[name] = cameraCopy;
-			return store( new ArnoldObject( name, cameraCopy.get() ) );
+			ObjectInterfacePtr result = store( new ArnoldObject( name, cameraCopy.get() ) );
+			result->attributes( attributes );
+			return result;
 		}
 
-		virtual ObjectInterfacePtr light( const std::string &name, const IECore::Object *object = NULL )
+		virtual ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes )
 		{
-			return store( new ArnoldLight( name, object ) );
+			ObjectInterfacePtr result = store( new ArnoldLight( name, object ) );
+			result->attributes( attributes );
+			return result;
 		}
 
-		virtual Renderer::ObjectInterfacePtr object( const std::string &name, const IECore::Object *object )
+		virtual Renderer::ObjectInterfacePtr object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes )
 		{
-			return store( new ArnoldObject( name, object ) );
+			ObjectInterfacePtr result = store( new ArnoldObject( name, object ) );
+			result->attributes( attributes );
+			return result;
 		}
 
-		virtual ObjectInterfacePtr object( const std::string &name, const std::vector<const IECore::Object *> &samples, const std::vector<float> &times )
+		virtual ObjectInterfacePtr object( const std::string &name, const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const AttributesInterface *attributes )
 		{
-			return store( new ArnoldObject( name, samples, times ) );
+			ObjectInterfacePtr result = store( new ArnoldObject( name, samples, times ) );
+			result->attributes( attributes );
+			return result;
 		}
 
 		virtual void render()
@@ -850,7 +858,9 @@ class ArnoldRenderer : public IECoreScenePreview::Renderer
 				{
 					IECore::CameraPtr defaultCortexCamera = new IECore::Camera();
 					defaultCortexCamera->addStandardParameters();
-					m_defaultCamera = camera( "ieCoreArnold:defaultCamera", defaultCortexCamera.get() );
+					IECore::CompoundObjectPtr defaultCortexAttributes = new IECore::CompoundObject();
+					AttributesInterfacePtr defaultAttributes = this->attributes( defaultCortexAttributes.get() );
+					m_defaultCamera = camera( "ieCoreArnold:defaultCamera", defaultCortexCamera.get(), defaultAttributes.get() );
 				}
 				cortexCamera = m_cameras["ieCoreArnold:defaultCamera"].get();
 				AiNodeSetPtr( options, "camera", AiNodeLookUpByName( "ieCoreArnold:defaultCamera" ) );

--- a/src/GafferScene/Preview/InteractiveRender.cpp
+++ b/src/GafferScene/Preview/InteractiveRender.cpp
@@ -345,7 +345,7 @@ class InteractiveRender::SceneGraph
 		// Returns true if the object changed.
 		bool updateObject( const ObjectPlug *objectPlug, Type type, IECoreScenePreview::Renderer *renderer, const IECore::CompoundObject *globals )
 		{
-			const bool hadObjectInterface = m_objectInterface;
+			const bool hadObjectInterface = static_cast<bool>( m_objectInterface );
 			if( type == NoType )
 			{
 				m_objectInterface = NULL;

--- a/src/GafferSceneBindings/RenderBinding.cpp
+++ b/src/GafferSceneBindings/RenderBinding.cpp
@@ -135,12 +135,12 @@ list rendererTypes()
 	return result;
 }
 
-IECoreScenePreview::Renderer::ObjectInterfacePtr rendererObject1( Renderer &renderer, const std::string &name, const IECore::Object *object )
+IECoreScenePreview::Renderer::ObjectInterfacePtr rendererObject1( Renderer &renderer, const std::string &name, const IECore::Object *object, const Renderer::AttributesInterface *attributes )
 {
-	return renderer.object( name, object );
+	return renderer.object( name, object, attributes );
 }
 
-IECoreScenePreview::Renderer::ObjectInterfacePtr rendererObject2( Renderer &renderer, const std::string &name, object pythonSamples, object pythonTimes )
+IECoreScenePreview::Renderer::ObjectInterfacePtr rendererObject2( Renderer &renderer, const std::string &name, object pythonSamples, object pythonTimes, const Renderer::AttributesInterface *attributes )
 {
 	std::vector<const IECore::Object *> samples;
 	container_utils::extend_container( samples, pythonSamples );
@@ -148,7 +148,7 @@ IECoreScenePreview::Renderer::ObjectInterfacePtr rendererObject2( Renderer &rend
 	std::vector<float> times;
 	container_utils::extend_container( times, pythonTimes );
 
-	return renderer.object( name, samples, times );
+	return renderer.object( name, samples, times, attributes );
 }
 
 void objectInterfaceTransform1( Renderer::ObjectInterface &objectInterface, const Imath::M44f &transform )


### PR DESCRIPTION
This adds :

- Automatic detection and instancing of identical meshes.
- Support for polymesh subdivision settings via the ArnoldAttributes node.
- Support for arbitrary user attributes.
- The groundwork for supporting displacement shaders.

Currently the InteractiveArnoldRender doesn't update correctly on changes to the subdivision attributes - either tweaking the mesh geometry directly or restarting the render is necessary to get those to come through. This is basically an Arnold limitation, but I do have a plan for addressing it soon on the Gaffer side. Since this is already a fairly complex PR, I'd like to address that as part of the upcoming displacement support rather than add more complexity here.

I feel sure that this PR will conflict with the [mesh light PR](#1772) that is still awaiting review. For what it's worth, I think it'd be easier to fix up that one after merging this...
