### PR TITLE
ArnoldDisplacement node

### DIFF
--- a/include/GafferArnold/ArnoldDisplacement.h
+++ b/include/GafferArnold/ArnoldDisplacement.h
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012, John Haddon. All rights reserved.
-//  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,26 +34,65 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef GAFFERARNOLD_TYPEIDS_H
-#define GAFFERARNOLD_TYPEIDS_H
+#ifndef GAFFERARNOLD_ARNOLDDISPLACEMENT_H
+#define GAFFERARNOLD_ARNOLDDISPLACEMENT_H
+
+#include "GafferScene/Shader.h"
+
+#include "GafferArnold/TypeIds.h"
 
 namespace GafferArnold
 {
 
-enum TypeId
+/// \todo It's slightly awkward that this inherits from Shader, because
+/// it inherits namePlug(), typePlug() and parametersPlug(), none of
+/// which are needed. We should consider creating a fully abstract Shader
+/// base class and renaming the current Shader class to StandardShader,
+/// or defining an even more general Assignable base class which both
+/// Shader and ArnoldDisplacement can inherit from.
+class ArnoldDisplacement : public GafferScene::Shader
 {
-	ArnoldShaderTypeId = 110900,
-	ArnoldOptionsTypeId = 110901,
-	ArnoldAttributesTypeId = 110902,
-	ArnoldLightTypeId = 110903,
-	ArnoldVDBTypeId = 110904,
-	InteractiveArnoldRenderTypeId = 110905,
-	ArnoldRenderTypeId = 110906,
-	ArnoldDisplacementTypeId = 110907,
 
-	LastTypeId = 110949
+	public :
+
+		ArnoldDisplacement( const std::string &name=defaultName<ArnoldDisplacement>() );
+		virtual ~ArnoldDisplacement();
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferArnold::ArnoldDisplacement, ArnoldDisplacementTypeId, GafferScene::Shader );
+
+		Gaffer::Plug *mapPlug();
+		const Gaffer::Plug *mapPlug() const;
+
+		Gaffer::FloatPlug *heightPlug();
+		const Gaffer::FloatPlug *heightPlug() const;
+
+		Gaffer::FloatPlug *paddingPlug();
+		const Gaffer::FloatPlug *paddingPlug() const;
+
+		Gaffer::FloatPlug *zeroValuePlug();
+		const Gaffer::FloatPlug *zeroValuePlug() const;
+
+		Gaffer::BoolPlug *autoBumpPlug();
+		const Gaffer::BoolPlug *autoBumpPlug() const;
+
+		Gaffer::Plug *outPlug();
+		const Gaffer::Plug *outPlug() const;
+
+		virtual void attributesHash( IECore::MurmurHash &h ) const;
+		virtual IECore::ConstCompoundObjectPtr attributes() const;
+
+	protected :
+
+		virtual bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const;
+
+	private :
+
+		static size_t g_firstPlugIndex;
+
 };
+
+IE_CORE_DECLAREPTR( ArnoldDisplacement )
 
 } // namespace GafferArnold
 
-#endif // GAFFERARNOLD_TYPEIDS_H
+#endif // GAFFERARNOLD_ARNOLDDISPLACEMENT_H

--- a/include/GafferScene/Shader.h
+++ b/include/GafferScene/Shader.h
@@ -42,6 +42,7 @@
 
 #include "IECore/ObjectVector.h"
 #include "IECore/Shader.h"
+#include "IECore/CompoundObject.h"
 
 #include "Gaffer/DependencyNode.h"
 #include "Gaffer/TypedPlug.h"
@@ -102,11 +103,18 @@ class Shader : public Gaffer::DependencyNode
 		/// outPlug().
 		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
 
-		/// Returns a hash representing the result of state().
+		/// Returns a hash representing the result of attributes().
+		IECore::MurmurHash attributesHash() const;
+		virtual void attributesHash( IECore::MurmurHash &h ) const;
+		/// Returns a block of attributes representing this
+		/// shader, suitable for use in ScenePlug::attributesPlug().
+		virtual IECore::ConstCompoundObjectPtr attributes() const;
+
+		/// \deprecated
 		IECore::MurmurHash stateHash() const;
+		/// \deprecated
 		void stateHash( IECore::MurmurHash &h ) const;
-		/// Returns a series of IECore::StateRenderables suitable for specifying this
-		/// shader (and it's inputs) to an IECore::Renderer.
+		/// \deprecated
 		IECore::ConstObjectVectorPtr state() const;
 
 	protected :

--- a/python/GafferArnoldTest/ArnoldDisplacementTest.py
+++ b/python/GafferArnoldTest/ArnoldDisplacementTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2012, John Haddon. All rights reserved.
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,15 +34,43 @@
 #
 ##########################################################################
 
-from ArnoldShaderTest import ArnoldShaderTest
-from ArnoldRenderTest import ArnoldRenderTest
-from ArnoldOptionsTest import ArnoldOptionsTest
-from ArnoldAttributesTest import ArnoldAttributesTest
-from ArnoldVDBTest import ArnoldVDBTest
-from InteractiveArnoldRenderTest import InteractiveArnoldRenderTest
-from ArnoldDisplacementTest import ArnoldDisplacementTest
-import IECoreArnoldPreviewTest
+import unittest
+
+import IECore
+
+import GafferSceneTest
+import GafferArnold
+
+class ArnoldDisplacementTest( GafferSceneTest.SceneTestCase ) :
+
+	def test( self ) :
+
+		n = GafferArnold.ArnoldShader()
+		n.loadShader( "noise" )
+
+		d = GafferArnold.ArnoldDisplacement()
+		d["map"].setInput( n["out"] )
+		d["height"].setValue( 2.5 )
+		d["padding"].setValue( 25 )
+		d["zeroValue"].setValue( .25 )
+		d["autoBump"].setValue( True )
+
+		na = n.attributes()
+		da = d.attributes()
+
+		self.assertEqual(
+			da,
+			IECore.CompoundObject( {
+				"ai:disp_map" : na["ai:surface"],
+				"ai:disp_height" : IECore.FloatData( 2.5 ),
+				"ai:disp_padding" : IECore.FloatData( 25 ),
+				"ai:disp_zero_value" : IECore.FloatData( .25 ),
+				"ai:disp_auto_bump" : IECore.BoolData( True ),
+			} )
+		)
+
+		d["enabled"].setValue( False )
+		self.assertEqual( d.attributes(), IECore.CompoundObject() )
 
 if __name__ == "__main__":
-	import unittest
 	unittest.main()

--- a/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
+++ b/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
@@ -613,6 +613,81 @@ class RendererTest( GafferTest.TestCase ) :
 			self.assertEqual( arnold.AiNodeGetRGB( plane2, "user:testColor3f" ), arnold.AtRGB( 1, 0.5, 0 ) )
 			self.assertEqual( arnold.AiNodeGetStr( plane2, "user:testString" ), "indeed" )
 
+	def testDisplacementAttributes( self ) :
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"IECoreArnold::Renderer",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
+			self.temporaryDirectory() + "/test.ass"
+		)
+
+		plane = IECore.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) )
+		noise = IECore.ObjectVector( [ IECore.Shader( "noise", "ai:displacement", {} ) ] )
+
+		sharedAttributes = r.attributes(
+			IECore.CompoundObject( {
+				"ai:disp_map" : noise,
+				"ai:disp_height" : IECore.FloatData( 0.25 ),
+				"ai:disp_padding" : IECore.FloatData( 2.5 ),
+				"ai:disp_zero_value" : IECore.FloatData( 0.5 ),
+				"ai:disp_autobump" : IECore.BoolData( True ),
+			} )
+		)
+
+		r.object( "plane1", plane, sharedAttributes )
+		r.object( "plane2", plane, sharedAttributes )
+
+		r.object(
+			"plane3",
+			plane,
+			r.attributes(
+				IECore.CompoundObject( {
+					"ai:disp_map" : noise,
+					"ai:disp_height" : IECore.FloatData( 0.5 ),
+					"ai:disp_padding" : IECore.FloatData( 5.0 ),
+					"ai:disp_zero_value" : IECore.FloatData( 0.0 ),
+					"ai:disp_autobump" : IECore.BoolData( True ),
+				} )
+			)
+		)
+
+		r.render()
+		del r
+
+		with IECoreArnold.UniverseBlock() :
+
+			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
+
+			shapes = self.__allNodes( type = arnold.AI_NODE_SHAPE )
+			self.assertEqual( len( shapes ), 5 )
+
+			plane1 = arnold.AiNodeLookUpByName( "plane1" )
+			plane2 = arnold.AiNodeLookUpByName( "plane2" )
+			plane3 = arnold.AiNodeLookUpByName( "plane3" )
+
+			self.assertTrue( arnold.AiNodeIs( plane1, "ginstance" ) )
+			self.assertTrue( arnold.AiNodeIs( plane2, "ginstance" ) )
+			self.assertTrue( arnold.AiNodeIs( plane3, "ginstance" ) )
+
+			self.assertEqual( arnold.AiNodeGetPtr( plane1, "node" ), arnold.AiNodeGetPtr( plane2, "node" ) )
+			self.assertNotEqual( arnold.AiNodeGetPtr( plane2, "node" ), arnold.AiNodeGetPtr( plane3, "node" ) )
+
+			polymesh1 = arnold.AtNode.from_address( arnold.AiNodeGetPtr( plane1, "node" ) )
+			polymesh2 = arnold.AtNode.from_address( arnold.AiNodeGetPtr( plane3, "node" ) )
+
+			self.assertTrue( arnold.AiNodeIs( polymesh1, "polymesh" ) )
+			self.assertTrue( arnold.AiNodeIs( polymesh2, "polymesh" ) )
+
+			self.assertEqual( arnold.AiNodeGetPtr( polymesh1, "disp_map" ), arnold.AiNodeGetPtr( polymesh2, "disp_map" ) )
+			self.assertEqual( arnold.AiNodeGetFlt( polymesh1, "disp_height" ), 0.25 )
+			self.assertEqual( arnold.AiNodeGetFlt( polymesh2, "disp_height" ), 0.5 )
+			self.assertEqual( arnold.AiNodeGetFlt( polymesh1, "disp_padding" ), 2.5 )
+			self.assertEqual( arnold.AiNodeGetFlt( polymesh2, "disp_padding" ), 5.0 )
+			self.assertEqual( arnold.AiNodeGetFlt( polymesh1, "disp_zero_value" ), 0.5 )
+			self.assertEqual( arnold.AiNodeGetFlt( polymesh2, "disp_zero_value" ), 0.0 )
+			self.assertEqual( arnold.AiNodeGetBool( polymesh1, "disp_autobump" ), True )
+			self.assertEqual( arnold.AiNodeGetBool( polymesh2, "disp_autobump" ), True )
+
 	def __allNodes( self, type = arnold.AI_NODE_ALL, ignoreBuiltIn = True ) :
 
 		result = []

--- a/python/GafferArnoldUI/ArnoldAttributesUI.py
+++ b/python/GafferArnoldUI/ArnoldAttributesUI.py
@@ -73,6 +73,8 @@ def __shadingSummary( plug ) :
 def __subdivisionSummary( plug ) :
 
 	info = []
+	if plug["subdivType"]["enabled"].getValue() :
+		info.append( "Type %s" % string.capwords( plug["subdivType"]["value"].getValue() ) )
 	if plug["subdivIterations"]["enabled"].getValue() :
 		info.append( "Iterations %d" % plug["subdivIterations"]["value"].getValue() )
 	if plug["subdivAdaptiveError"]["enabled"].getValue() :
@@ -247,6 +249,35 @@ Gaffer.Metadata.registerNode(
 		],
 
 		# Subdivision
+
+		"attributes.subdivType" : [
+
+			"description",
+			"""
+			The type of subdivision to apply to mesh geometry.
+			By default, polygon meshes are not subdivided and
+			subdivision meshes are, but this attribute allows
+			that behaviour to be overridden.
+
+			> Tip : Use "Linear" subdivision to subdivide polygon
+			> meshes so they can have more detailed displacement
+			> applied, or to improve the appearance of mesh lights.
+			""",
+
+			"layout:section", "Subdivision",
+			"label", "Type",
+
+		],
+
+		"attributes.subdivType.value" : [
+
+			"preset:None", "none",
+			"preset:Linear", "linear",
+			"preset:Catclark", "catclark",
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
+		],
 
 		"attributes.subdivIterations" : [
 

--- a/python/GafferArnoldUI/ArnoldAttributesUI.py
+++ b/python/GafferArnoldUI/ArnoldAttributesUI.py
@@ -73,8 +73,8 @@ def __shadingSummary( plug ) :
 def __subdivisionSummary( plug ) :
 
 	info = []
-	if plug["subdivType"]["enabled"].getValue() :
-		info.append( "Type %s" % string.capwords( plug["subdivType"]["value"].getValue() ) )
+	if plug["subdividePolygons"]["enabled"].getValue() :
+		info.append( "Subdivide Polygons " + "On" if plug["subdividePolygons"]["value"].getValue() else "Off" )
 	if plug["subdivIterations"]["enabled"].getValue() :
 		info.append( "Iterations %d" % plug["subdivIterations"]["value"].getValue() )
 	if plug["subdivAdaptiveError"]["enabled"].getValue() :
@@ -250,22 +250,19 @@ Gaffer.Metadata.registerNode(
 
 		# Subdivision
 
-		"attributes.subdivType" : [
+		"attributes.subdividePolygons" : [
 
 			"description",
 			"""
-			The type of subdivision to apply to mesh geometry.
-			By default, polygon meshes are not subdivided and
-			subdivision meshes are, but this attribute allows
-			that behaviour to be overridden.
-
-			> Tip : Use "Linear" subdivision to subdivide polygon
-			> meshes so they can have more detailed displacement
-			> applied, or to improve the appearance of mesh lights.
+			Causes polygon meshes to be rendered with Arnold's
+			subdiv_type parameter set to "linear" rather than
+			"none". This can be used to increase detail when
+			using polygons with displacement shaders and/or mesh
+			lights.
 			""",
 
 			"layout:section", "Subdivision",
-			"label", "Type",
+			"label", "Subdivide Polygons",
 
 		],
 

--- a/python/GafferArnoldUI/ArnoldDisplacementUI.py
+++ b/python/GafferArnoldUI/ArnoldDisplacementUI.py
@@ -1,0 +1,134 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferArnold
+
+Gaffer.Metadata.registerNode(
+
+	GafferArnold.ArnoldDisplacement,
+
+	"description",
+	"""
+	Creates displacements to be applied to meshes for
+	rendering in Arnold. A displacement consists of a
+	shader to provide the displacement map and several
+	attributes to control the height and other displacement
+	properties.
+
+	Use an ArnoldAttributes node to control the subdivision
+	settings of the mesh, which in turn controls the detail
+	of the displacement. Use a ShaderAssignment node to assign
+	the ArnoldDisplacement to specific objects.
+	""",
+
+	plugs = {
+
+		"map" : [
+
+			"description",
+			"""
+			The Arnold shader that provides the displacement
+			map. Connect a float or colour input to displace
+			along the object normals or a vector input to displace
+			in a specific direction.
+			""",
+
+			"nodule:type", "GafferUI::StandardNodule",
+			"nodeGadget:nodulePosition", "left",
+
+		],
+
+		"height" : [
+
+			"description",
+			"""
+			Controls the amount of displacement. Only used when
+			performing displacement along the normal.
+			""",
+
+			"nodule:type", "",
+
+		],
+
+		"padding" : [
+
+			"description",
+			"""
+			Padding added to an object's bounding box to take
+			into account displacement. Arnold will subdivide
+			and displace an object the first time a ray intersects
+			its bounding box, so if the padding is too small,
+			parts of the object will be clipped. If the padding
+			is too large, rendertime will suffer and Arnold
+			will emit a warning message.
+			""",
+
+			"nodule:type", "",
+
+		],
+
+		"zeroValue" : [
+
+			"description",
+			"""
+			Defines a value that will cause no displacement to
+			occur. For instance, if the displacement map contains
+			a greyscale noise between 0 and 1, a zero value of 0.5
+			will mean that the displacement pushes into the object
+			in some places and out in others.
+			""",
+
+			"nodule:type", "",
+
+		],
+
+		"autoBump" : [
+
+			"description",
+			"""
+			Automatically turns the details of the displacement map
+			into bump, wherever the mesh is not subdivided enough
+			to properly capture them.
+			""",
+
+			"nodule:type", "",
+
+		],
+
+	}
+
+)

--- a/python/GafferArnoldUI/__init__.py
+++ b/python/GafferArnoldUI/__init__.py
@@ -42,5 +42,6 @@ import ArnoldAttributesUI
 import ArnoldLightUI
 import ArnoldVDBUI
 import InteractiveArnoldRenderUI
+import ArnoldDisplacementUI
 
 __import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", {}, subdirectory = "GafferArnoldUI" )

--- a/python/GafferOSLTest/OSLShaderTest.py
+++ b/python/GafferOSLTest/OSLShaderTest.py
@@ -71,14 +71,14 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 
 		self.assertEqual( n["out"].typeId(), Gaffer.Plug.staticTypeId() )
 
-		state = n.state()
-		self.assertEqual( len( state ), 1 )
-		self.assertEqual( state[0].name, s )
-		self.assertEqual( state[0].type, "osl:surface" )
-		self.assertEqual( state[0].parameters["i"], IECore.IntData( 10 ) )
-		self.assertEqual( state[0].parameters["f"], IECore.FloatData( 1 ) )
-		self.assertEqual( state[0].parameters["c"], IECore.Color3fData( IECore.Color3f( 1, 2, 3 ) ) )
-		self.assertEqual( state[0].parameters["s"], IECore.StringData( "s" ) )
+		network = n.attributes()["osl:surface"]
+		self.assertEqual( len( network ), 1 )
+		self.assertEqual( network[0].name, s )
+		self.assertEqual( network[0].type, "osl:surface" )
+		self.assertEqual( network[0].parameters["i"], IECore.IntData( 10 ) )
+		self.assertEqual( network[0].parameters["f"], IECore.FloatData( 1 ) )
+		self.assertEqual( network[0].parameters["c"], IECore.Color3fData( IECore.Color3f( 1, 2, 3 ) ) )
+		self.assertEqual( network[0].parameters["s"], IECore.StringData( "s" ) )
 
 	def testOutputTypes( self ) :
 
@@ -111,19 +111,19 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 
 		self.assertEqual( typesNode["parameters"]["i"].getValue(), 10 )
 
-		state = typesNode.state()
+		network = typesNode.attributes()["osl:surface"]
 
-		self.assertEqual( len( state ), 2 )
+		self.assertEqual( len( network ), 2 )
 
-		self.assertEqual( state[1].name, typesShader )
-		self.assertEqual( state[1].type, "osl:surface" )
-		self.assertEqual( state[1].parameters["i"], IECore.StringData( "link:" + state[0].parameters["__handle"].value + ".i" ) )
-		self.assertEqual( state[1].parameters["f"], IECore.FloatData( 1 ) )
-		self.assertEqual( state[1].parameters["c"], IECore.Color3fData( IECore.Color3f( 1, 2, 3 ) ) )
-		self.assertEqual( state[1].parameters["s"], IECore.StringData( "s" ) )
-		self.assertEqual( state[0].name, outputTypesShader )
-		self.assertEqual( state[0].type, "osl:shader" )
-		self.assertEqual( state[0].parameters["input"], IECore.FloatData( 1 ) )
+		self.assertEqual( network[1].name, typesShader )
+		self.assertEqual( network[1].type, "osl:surface" )
+		self.assertEqual( network[1].parameters["i"], IECore.StringData( "link:" + network[0].parameters["__handle"].value + ".i" ) )
+		self.assertEqual( network[1].parameters["f"], IECore.FloatData( 1 ) )
+		self.assertEqual( network[1].parameters["c"], IECore.Color3fData( IECore.Color3f( 1, 2, 3 ) ) )
+		self.assertEqual( network[1].parameters["s"], IECore.StringData( "s" ) )
+		self.assertEqual( network[0].name, outputTypesShader )
+		self.assertEqual( network[0].type, "osl:shader" )
+		self.assertEqual( network[0].parameters["input"], IECore.FloatData( 1 ) )
 
 	def testSerialiation( self ) :
 
@@ -195,20 +195,20 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		n["parameters"]["s"]["c"].setValue( IECore.Color3f( 3, 4, 5 ) )
 		n["parameters"]["s"]["s"].setValue( "ttt" )
 
-		state = n.state()
-		self.assertEqual( len( state[0].parameters ), 7 )
-		self.assertTrue( state[0].parameters["i"], IECore.IntData( 2 ) )
-		self.assertTrue( state[0].parameters["f"], IECore.FloatData( 3 ) )
-		self.assertTrue( state[0].parameters["s.i"], IECore.IntData( 10 ) )
-		self.assertTrue( state[0].parameters["s.f"], IECore.FloatData( 21 ) )
-		self.assertTrue( state[0].parameters["s.c"], IECore.Color3fData( IECore.Color3f( 3, 4, 5 ) ) )
-		self.assertTrue( state[0].parameters["s.s"], IECore.StringData( "ttt" ) )
-		self.assertTrue( state[0].parameters["ss"], IECore.StringData( "ss" ) )
+		network = n.attributes()["osl:shader"]
+		self.assertEqual( len( network[0].parameters ), 7 )
+		self.assertTrue( network[0].parameters["i"], IECore.IntData( 2 ) )
+		self.assertTrue( network[0].parameters["f"], IECore.FloatData( 3 ) )
+		self.assertTrue( network[0].parameters["s.i"], IECore.IntData( 10 ) )
+		self.assertTrue( network[0].parameters["s.f"], IECore.FloatData( 21 ) )
+		self.assertTrue( network[0].parameters["s.c"], IECore.Color3fData( IECore.Color3f( 3, 4, 5 ) ) )
+		self.assertTrue( network[0].parameters["s.s"], IECore.StringData( "ttt" ) )
+		self.assertTrue( network[0].parameters["ss"], IECore.StringData( "ss" ) )
 
-		h1 = n.stateHash()
+		h1 = n.attributesHash()
 
 		n["parameters"]["s"]["i"].setValue( 100 )
-		h2 = n.stateHash()
+		h2 = n.attributesHash()
 		self.assertNotEqual( h1, h2 )
 
 		s2 = self.compileShader( os.path.dirname( __file__ ) + "/shaders/outputTypes.osl" )
@@ -216,7 +216,7 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		g.loadShader( s2 )
 
 		n["parameters"]["s"]["i"].setInput( g["out"]["i"] )
-		h3 = n.stateHash()
+		h3 = n.attributesHash()
 		self.assertNotEqual( h1, h3 )
 		self.assertNotEqual( h2, h3 )
 
@@ -229,10 +229,10 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		buildColor.loadShader( "Utility/BuildColor" )
 
 		buildColor["parameters"]["r"].setInput( globals["out"]["globalU"] )
-		h1 = buildColor.stateHash()
+		h1 = buildColor.attributesHash()
 
 		buildColor["parameters"]["r"].setInput( globals["out"]["globalV"] )
-		h2 = buildColor.stateHash()
+		h2 = buildColor.attributesHash()
 
 		self.assertNotEqual( h1, h2 )
 
@@ -261,7 +261,7 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 
 		inputClosure["parameters"]["i"].setInput( outputClosure["out"]["c"] )
 
-		s = inputClosure.state()
+		s = inputClosure.attributes()["osl:surface"]
 		self.assertEqual( len( s ), 2 )
 		self.assertEqual( s[1].parameters["i"].value, "link:" + s[0].parameters["__handle"].value + ".c" )
 
@@ -315,8 +315,8 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 
 		sn2["parameters"]["i"].setInput( sn1["out"]["i"] )
 
-		self.assertEqual( sn2.stateHash(), sn2.stateHash() )
-		self.assertEqual( sn2.state(), sn2.state() )
+		self.assertEqual( sn2.attributesHash(), sn2.attributesHash() )
+		self.assertEqual( sn2.attributes(), sn2.attributes() )
 
 	def testHandlesAreHumanReadable( self ) :
 
@@ -331,8 +331,8 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 
 		sn2["parameters"]["i"].setInput( sn1["out"]["i"] )
 
-		state = sn2.state()
-		self.assertTrue( "Shader1" in state[0].parameters["__handle"].value )
+		network = sn2.attributes()["osl:surface"]
+		self.assertTrue( "Shader1" in network[0].parameters["__handle"].value )
 
 	def testHandlesAreUniqueEvenIfNodeNamesArent( self ) :
 
@@ -359,8 +359,8 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		box["in1"].setName( "notUnique" )
 		script["in2"].setName( "notUnique" )
 
-		state = script["shader"].state()
-		self.assertNotEqual( state[0].parameters["__handle"], state[1].parameters["__handle"] )
+		network = script["shader"].attributes()["osl:surface"]
+		self.assertNotEqual( network[0].parameters["__handle"], network[1].parameters["__handle"] )
 
 	def testShaderMetadata( self ) :
 
@@ -450,8 +450,8 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		color["parameters"]["g"].setInput( noise["out"]["n"] )
 
 		# Should not throw - there are no cycles above.
-		color.stateHash()
-		color.state()
+		color.attributesHash()
+		color.attributes()
 
 	def testLoadNetworkFromVersion0_23( self ) :
 

--- a/python/GafferRenderManTest/RenderManShaderTest.py
+++ b/python/GafferRenderManTest/RenderManShaderTest.py
@@ -82,7 +82,7 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 		s = Gaffer.ScriptNode()
 		s.execute( ss )
 
-		st = s["n"].state()
+		st = s["n"].attributes()["ri:surface"]
 		self.assertEqual( len( st ), 1 )
 
 		self.assertEqual( st[0].type, "ri:surface" )
@@ -101,7 +101,7 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 		n = GafferRenderMan.RenderManShader()
 		n.loadShader( "plastic" )
 
-		s = n.state()
+		s = n.attributes()["ri:surface"]
 		self.assertEqual( len( s ), 1 )
 
 		self.assertEqual( s[0].type, "ri:surface" )
@@ -117,10 +117,10 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		n = GafferRenderMan.RenderManShader()
 		n.loadShader( "matte" )
-		h1 = n.stateHash()
+		h1 = n.attributesHash()
 
 		n["parameters"]["Kd"].setValue( 0.25 )
-		self.assertNotEqual( n.stateHash(), h1 )
+		self.assertNotEqual( n.attributesHash(), h1 )
 
 	def testCoshaderHash( self ) :
 
@@ -139,11 +139,11 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		shaderNode["parameters"]["coshaderParameter"].setInput( coshaderNode["out"] )
 
-		h1 = shaderNode.stateHash()
+		h1 = shaderNode.attributesHash()
 
 		coshaderNode["parameters"]["floatParameter"].setValue( 0.25 )
 
-		self.assertNotEqual( shaderNode.stateHash(), h1 )
+		self.assertNotEqual( shaderNode.attributesHash(), h1 )
 
 	def testParameterOrdering( self ) :
 
@@ -179,7 +179,7 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		shaderNode["parameters"]["coshaderParameter"].setInput( coshaderNode["out"] )
 
-		s = shaderNode.state()
+		s = shaderNode.attributes()["ri:surface"]
 		self.assertEqual( len( s ), 2 )
 
 		self.assertEqual( s[0].name, coshader )
@@ -448,7 +448,7 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 			self.assertEqual( n["parameters"][name].defaultValue(), value )
 			self.assertEqual( n["parameters"][name].getValue(), value )
 
-		s = n.state()[0]
+		s = n.attributes()["ri:surface"][0]
 
 		for name, value in expected.items() :
 
@@ -470,9 +470,9 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 		self.assertTrue( isinstance( n["parameters"]["fixedShaderArray"]["fixedShaderArray2"], Gaffer.Plug ) )
 		self.assertTrue( isinstance( n["parameters"]["fixedShaderArray"]["fixedShaderArray3"], Gaffer.Plug ) )
 
-		state = n.state()
+		network = n.attributes()["ri:surface"]
 
-		self.assertEqual( state[0].parameters["fixedShaderArray"], IECore.StringVectorData( [ "" ] * 4 ) )
+		self.assertEqual( network[0].parameters["fixedShaderArray"], IECore.StringVectorData( [ "" ] * 4 ) )
 
 		coshader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/coshader.sl" )
 
@@ -481,9 +481,9 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		n["parameters"]["fixedShaderArray"]["fixedShaderArray0"].setInput( coshaderNode["out"] )
 
-		state = n.state()
+		network = n.attributes()["ri:surface"]
 
-		self.assertEqual( state[1].parameters["fixedShaderArray"], IECore.StringVectorData( [ state[0].parameters["__handle"].value, "", "", "" ] ) )
+		self.assertEqual( network[1].parameters["fixedShaderArray"], IECore.StringVectorData( [ network[0].parameters["__handle"].value, "", "", "" ] ) )
 
 	def testCoshaderType( self ) :
 
@@ -491,7 +491,7 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 		coshaderNode = GafferRenderMan.RenderManShader()
 		coshaderNode.loadShader( coshader )
 
-		self.assertEqual( coshaderNode.state()[0].type, "ri:shader" )
+		self.assertEqual( coshaderNode.attributes()["ri:shader"][0].type, "ri:shader" )
 
 	def testCantConnectSurfaceShaderIntoCoshaderInput( self ) :
 
@@ -525,7 +525,7 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 		s["parameters"]["Kd"].setValue( 0.25 )
 		s["parameters"]["Ks"].setInput( s["parameters"]["Kd"] )
 
-		shader = s.state()[0]
+		shader = s.attributes()["ri:surface"][0]
 
 		self.assertEqual( shader.parameters["Kd"].value, 0.25 )
 		self.assertEqual( shader.parameters["Ks"].value, 0.25 )
@@ -536,7 +536,7 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 		n = GafferRenderMan.RenderManShader()
 		n.loadShader( shader )
 
-		h1 = n.stateHash()
+		h1 = n.attributesHash()
 
 		coshader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/coshader.sl" )
 		coshaderNode = GafferRenderMan.RenderManShader()
@@ -544,19 +544,19 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		n["parameters"]["fixedShaderArray"]["fixedShaderArray0"].setInput( coshaderNode["out"] )
 
-		h2 = n.stateHash()
+		h2 = n.attributesHash()
 		self.assertNotEqual( h2, h1 )
 
 		n["parameters"]["fixedShaderArray"]["fixedShaderArray1"].setInput( coshaderNode["out"] )
 
-		h3 = n.stateHash()
+		h3 = n.attributesHash()
 		self.assertNotEqual( h3, h2 )
 		self.assertNotEqual( h3, h1 )
 
 		n["parameters"]["fixedShaderArray"]["fixedShaderArray1"].setInput( None )
 		n["parameters"]["fixedShaderArray"]["fixedShaderArray2"].setInput( coshaderNode["out"] )
 
-		h4 = n.stateHash()
+		h4 = n.attributesHash()
 		self.assertNotEqual( h4, h3 )
 		self.assertNotEqual( h4, h2 )
 		self.assertNotEqual( h4, h1 )
@@ -566,20 +566,21 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 		s = GafferRenderMan.RenderManShader()
 		s.loadShader( "plastic" )
 
-		stateHash = s.stateHash()
-		state = s.state()
-		self.assertEqual( len( state ), 1 )
-		self.assertEqual( state[0].name, "plastic" )
+		attributesHash = s.attributesHash()
+		attributes = s.attributes()
+		self.assertEqual( len( attributes ), 1 )
+		self.assertEqual( len( attributes["ri:surface"] ), 1 )
+		self.assertEqual( attributes["ri:surface"][0].name, "plastic" )
 
 		self.assertTrue( s["enabled"].isSame( s.enabledPlug() ) )
 
 		s["enabled"].setValue( False )
 
-		stateHash2 = s.stateHash()
-		self.assertNotEqual( stateHash2, stateHash )
+		attributesHash2 = s.attributesHash()
+		self.assertNotEqual( attributesHash2, attributesHash )
 
-		state2 = s.state()
-		self.assertEqual( len( state2 ), 0 )
+		attributes2 = s.attributes()
+		self.assertEqual( len( attributes2 ), 0 )
 
 	def testDisablingCoshaders( self ) :
 
@@ -595,23 +596,23 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		shaderNode["parameters"]["coshaderParameter"].setInput( coshaderNode["out"] )
 
-		s = shaderNode.state()
+		s = shaderNode.attributes()["ri:surface"]
 		self.assertEqual( len( s ), 2 )
 
 		self.assertEqual( s[0].name, coshader )
 		self.assertEqual( s[1].name, shader )
 
-		h = shaderNode.stateHash()
+		h = shaderNode.attributesHash()
 
 		coshaderNode["enabled"].setValue( False )
 
-		s2 = shaderNode.state()
+		s2 = shaderNode.attributes()["ri:surface"]
 		self.assertEqual( len( s2 ), 1 )
 
 		self.assertEqual( s2[0].name, shader )
 		self.assertTrue( "coshaderParameter" not in s2[0].parameters )
 
-		self.assertNotEqual( shaderNode.stateHash(), h )
+		self.assertNotEqual( shaderNode.attributesHash(), h )
 
 	def testDisablingCoshaderArrayInputs( self ) :
 
@@ -630,42 +631,42 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 		n["parameters"]["fixedShaderArray"][0].setInput( coshaderNode1["out"] )
 		n["parameters"]["fixedShaderArray"][2].setInput( coshaderNode2["out"] )
 
-		state = n.state()
-		h1 = n.stateHash()
+		s = n.attributes()["ri:surface"]
+		h1 = n.attributesHash()
 
 		self.assertEqual(
-			state[2].parameters["fixedShaderArray"],
+			s[2].parameters["fixedShaderArray"],
 			IECore.StringVectorData( [
-				state[0].parameters["__handle"].value,
+				s[0].parameters["__handle"].value,
 				"",
-				state[1].parameters["__handle"].value,
+				s[1].parameters["__handle"].value,
 				""
 			] )
 		)
 
 		coshaderNode1["enabled"].setValue( False )
 
-		state = n.state()
+		s = n.attributes()["ri:surface"]
 
 		self.assertEqual(
-			state[1].parameters["fixedShaderArray"],
+			s[1].parameters["fixedShaderArray"],
 			IECore.StringVectorData( [
 				"",
 				"",
-				state[0].parameters["__handle"].value,
+				s[0].parameters["__handle"].value,
 				""
 			] )
 		)
 
-		h2 = n.stateHash()
+		h2 = n.attributesHash()
 		self.assertNotEqual( h2, h1 )
 
 		coshaderNode2["enabled"].setValue( False )
 
-		state = n.state()
+		s = n.attributes()["ri:surface"]
 
 		self.assertEqual(
-			state[0].parameters["fixedShaderArray"],
+			s[0].parameters["fixedShaderArray"],
 			IECore.StringVectorData( [
 				"",
 				"",
@@ -674,8 +675,8 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 			] )
 		)
 
-		self.assertNotEqual( n.stateHash(), h1 )
-		self.assertNotEqual( n.stateHash(), h2 )
+		self.assertNotEqual( n.attributesHash(), h1 )
+		self.assertNotEqual( n.attributesHash(), h2 )
 
 	def testCorrespondingInput( self ) :
 
@@ -706,8 +707,8 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 		shaderNode["parameters"]["coshaderParameter"].setInput( passThroughCoshaderNode["out"] )
 		passThroughCoshaderNode["parameters"]["aColorIWillTint"].setInput( coshaderNode["out"] )
 
-		h = shaderNode.stateHash()
-		s = shaderNode.state()
+		h = shaderNode.attributesHash()
+		s = shaderNode.attributes()["ri:surface"]
 
 		self.assertEqual( len( s ), 3 )
 		self.assertEqual( s[2].parameters["coshaderParameter"], s[1].parameters["__handle"] )
@@ -717,7 +718,7 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		passThroughCoshaderNode["enabled"].setValue( False )
 
-		s = shaderNode.state()
+		s = shaderNode.attributes()["ri:surface"]
 
 		self.assertEqual( len( s ), 2 )
 		self.assertEqual( s[1].parameters["coshaderParameter"], s[0].parameters["__handle"] )
@@ -789,7 +790,7 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 		n["parameters"]["floatSpline"].setValue( floatValue )
 		n["parameters"]["colorSpline"].setValue( colorValue )
 
-		s = n.state()[0]
+		s = n.attributes()["ri:surface"][0]
 
 		self.assertEqual( s.parameters["floatSpline"].value, floatValue )
 		self.assertEqual( s.parameters["colorSpline"].value, colorValue )
@@ -888,7 +889,7 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		self.assertTrue( s["shader"]["parameters"]["coshaderParameter"].getInput().parent().isSame( b ) )
 
-		s = s["shader"].state()
+		s = s["shader"].attributes()["ri:surface"]
 
 		self.assertEqual( len( s ), 2 )
 		self.assertEqual( s[1].parameters["coshaderParameter"], s[0].parameters["__handle"] )
@@ -912,7 +913,7 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		self.assertTrue( b["shader"]["parameters"]["coshaderParameter"].getInput().parent().isSame( b ) )
 
-		s = b["shader"].state()
+		s = b["shader"].attributes()["ri:surface"]
 
 		self.assertEqual( len( s ), 2 )
 		self.assertEqual( s[1].parameters["coshaderParameter"], s[0].parameters["__handle"] )
@@ -1020,8 +1021,8 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 		S["parameters"]["fixedShaderArray"][1].setInput( D["out"] )
 		D["parameters"]["aColorIWillTint"].setInput( C["out"] )
 
-		h = S.stateHash()
-		s = S.state()
+		h = S.attributesHash()
+		s = S.attributes()["ri:surface"]
 
 		self.assertEqual( len( s ), 3 )
 		self.assertEqual( s[2].parameters["fixedShaderArray"], IECore.StringVectorData( [ s[0].parameters["__handle"].value, s[1].parameters["__handle"].value, "", "" ] ) )
@@ -1031,9 +1032,9 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		D["enabled"].setValue( False )
 
-		self.assertNotEqual( S.stateHash(), h )
+		self.assertNotEqual( S.attributesHash(), h )
 
-		s = S.state()
+		s = S.attributes()["ri:surface"]
 
 		self.assertEqual( len( s ), 2 )
 		self.assertEqual( s[1].parameters["fixedShaderArray"], IECore.StringVectorData( [ s[0].parameters["__handle"].value, s[0].parameters["__handle"].value, "", "" ] ) )
@@ -1061,8 +1062,8 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 		D2["parameters"]["aColorIWillTint"].setInput( D1["out"] )
 		D1["parameters"]["aColorIWillTint"].setInput( C["out"] )
 
-		h1 = S.stateHash()
-		s = S.state()
+		h1 = S.attributesHash()
+		s = S.attributes()["ri:surface"]
 
 		self.assertEqual( len( s ), 4 )
 		self.assertEqual( s[0].name, coshader )
@@ -1076,10 +1077,10 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		D2["enabled"].setValue( False )
 
-		h2 = S.stateHash()
+		h2 = S.attributesHash()
 		self.assertNotEqual( h1, h2 )
 
-		s = S.state()
+		s = S.attributes()["ri:surface"]
 
 		self.assertEqual( len( s ), 3 )
 		self.assertEqual( s[0].name, coshader )
@@ -1091,11 +1092,11 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		D1["enabled"].setValue( False )
 
-		h3 = S.stateHash()
+		h3 = S.attributesHash()
 		self.assertNotEqual( h3, h2 )
 		self.assertNotEqual( h3, h1 )
 
-		s = S.state()
+		s = S.attributes()["ri:surface"]
 
 		self.assertEqual( len( s ), 2 )
 		self.assertEqual( s[0].name, coshader )
@@ -1278,11 +1279,11 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 		b["out"].setInput( intermediateCoshaderNode["out"] )
 		shaderNode["parameters"]["coshaderParameter"].setInput( b["out"] )
 
-		h1 = shaderNode.stateHash()
+		h1 = shaderNode.attributesHash()
 
 		coshaderNode["parameters"]["floatParameter"].setValue( 0.25 )
 
-		self.assertNotEqual( shaderNode.stateHash(), h1 )
+		self.assertNotEqual( shaderNode.attributesHash(), h1 )
 
 	def testDanglingBoxConnection( self ):
 
@@ -1326,7 +1327,7 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 		b["in"] = b["s"]["parameters"]["coshaderParameter"].createCounterpart( "in", Gaffer.Plug.Direction.In )
 
 		b["s"]["parameters"]["coshaderParameter"].setInput( b["in"] )
-		s = b["s"].state()
+		s = b["s"].attributes()["ri:surface"]
 		self.assertEqual( len( s ), 1 )
 		self.assertEqual( s[0].name, shader )
 
@@ -1342,7 +1343,7 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 		self.assertTrue( b["in"].acceptsInput( c["out"] ) )
 		b["in"].setInput( c["out"] )
 
-		s = b["s"].state()
+		s = b["s"].attributes()["ri:surface"]
 		self.assertEqual( len( s ), 2 )
 		self.assertEqual( s[1].parameters["coshaderParameter"], s[0].parameters["__handle"] )
 
@@ -1391,13 +1392,13 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 		switch["in1"].setInput( coshaderNode1["out"] )
 
 		shaderNode["parameters"]["coshaderParameter"].setInput( switch["out"] )
-		self.assertEqual( shaderNode.state()[0].parameters["floatParameter"].value, 0 )
+		self.assertEqual( shaderNode.attributes()["ri:surface"][0].parameters["floatParameter"].value, 0 )
 
 		switch["index"].setValue( 1 )
-		self.assertEqual( shaderNode.state()[0].parameters["floatParameter"].value, 1 )
+		self.assertEqual( shaderNode.attributes()["ri:surface"][0].parameters["floatParameter"].value, 1 )
 
 		switch["enabled"].setValue( False )
-		self.assertEqual( shaderNode.state()[0].parameters["floatParameter"].value, 0 )
+		self.assertEqual( shaderNode.attributes()["ri:surface"][0].parameters["floatParameter"].value, 0 )
 
 	def testCoshaderTypingPreventsNewInvalidSwitchInputs( self ) :
 
@@ -1456,16 +1457,16 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		script["shaderNode"]["parameters"]["coshaderParameter"].setInput( script["switch"]["out"] )
 
-		self.assertEqual( script["shaderNode"].state()[0].parameters["floatParameter"].value, 0 )
+		self.assertEqual( script["shaderNode"].attributes()["ri:surface"][0].parameters["floatParameter"].value, 0 )
 
 		box = Gaffer.Box.create( script, Gaffer.StandardSet( script.children( Gaffer.Node ) ) )
-		self.assertEqual( box["shaderNode"].state()[0].parameters["floatParameter"].value, 0 )
+		self.assertEqual( box["shaderNode"].attributes()["ri:surface"][0].parameters["floatParameter"].value, 0 )
 
 		promotedIndex = box.promotePlug( box["switch"]["index"] )
-		self.assertEqual( box["shaderNode"].state()[0].parameters["floatParameter"].value, 0 )
+		self.assertEqual( box["shaderNode"].attributes()["ri:surface"][0].parameters["floatParameter"].value, 0 )
 
 		promotedIndex.setValue( 1 )
-		self.assertEqual( box["shaderNode"].state()[0].parameters["floatParameter"].value, 1 )
+		self.assertEqual( box["shaderNode"].attributes()["ri:surface"][0].parameters["floatParameter"].value, 1 )
 
 	def testRepeatability( self ) :
 
@@ -1479,8 +1480,8 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		sn2["parameters"]["coshaderParameter"].setInput( sn1["out"] )
 
-		self.assertEqual( sn2.stateHash(), sn2.stateHash() )
-		self.assertEqual( sn2.state(), sn2.state() )
+		self.assertEqual( sn2.attributesHash(), sn2.attributesHash() )
+		self.assertEqual( sn2.attributes(), sn2.attributes() )
 
 	def testHandlesAreHumanReadable( self ) :
 
@@ -1494,8 +1495,8 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		sn2["parameters"]["coshaderParameter"].setInput( sn1["out"] )
 
-		state = sn2.state()
-		self.assertTrue( "Shader1" in state[0].parameters["__handle"].value )
+		network = sn2.attributes()["ri:surface"]
+		self.assertTrue( "Shader1" in network[0].parameters["__handle"].value )
 
 	def testHandlesAreUniqueEvenIfNodeNamesArent( self ) :
 
@@ -1522,10 +1523,10 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 		box["in1"].setName( "notUnique" )
 		script["in2"].setName( "notUnique" )
 
-		state = script["shader"].state()
-		self.assertNotEqual( state[0].parameters["__handle"], state[1].parameters["__handle"] )
+		network = script["shader"].attributes()["ri:surface"]
+		self.assertNotEqual( network[0].parameters["__handle"], network[1].parameters["__handle"] )
 
-	def testShaderTypesInState( self ) :
+	def testShaderTypesInNetwork( self ) :
 
 		shader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/coshaderParameter.sl" )
 
@@ -1539,9 +1540,9 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		shaderNode["parameters"]["coshaderParameter"].setInput( coshaderNode["out"] )
 
-		state = shaderNode.state()
-		self.assertEqual( state[0].type, "ri:shader" )
-		self.assertEqual( state[1].type, "ri:surface" )
+		network = shaderNode.attributes()["ri:surface"]
+		self.assertEqual( network[0].type, "ri:shader" )
+		self.assertEqual( network[1].type, "ri:surface" )
 
 	def testAssignmentAttributeName( self ) :
 

--- a/python/GafferSceneTest/OpenGLShaderTest.py
+++ b/python/GafferSceneTest/OpenGLShaderTest.py
@@ -67,18 +67,18 @@ class OpenGLShaderTest( GafferSceneTest.SceneTestCase ) :
 		i["fileName"].setValue( os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checker.exr" ) )
 		s["parameters"]["texture"].setInput( i["out"] )
 
-		ss = s.state()
-		self.assertEqual( len( ss ), 1 )
-		self.failUnless( isinstance( ss[0], IECore.Shader ) )
+		a = s.attributes()
+		self.assertEqual( a.keys(), [ "gl:surface"] )
+		self.failUnless( isinstance( a["gl:surface"][0], IECore.Shader ) )
 
-		self.assertEqual( ss[0].name, "Texture" )
-		self.assertEqual( ss[0].type, "gl:surface" )
-		self.assertEqual( ss[0].parameters["mult"], IECore.FloatData( 0.5 ) )
-		self.assertEqual( ss[0].parameters["tint"].value, IECore.Color4f( 1, 0.5, 0.25, 1 ) )
-		self.assertTrue( isinstance( ss[0].parameters["texture"], IECore.CompoundData ) )
-		self.failUnless( "displayWindow" in ss[0].parameters["texture"] )
-		self.failUnless( "dataWindow" in ss[0].parameters["texture"] )
-		self.failUnless( "channels" in ss[0].parameters["texture"] )
+		self.assertEqual( a["gl:surface"][0].name, "Texture" )
+		self.assertEqual( a["gl:surface"][0].type, "gl:surface" )
+		self.assertEqual( a["gl:surface"][0].parameters["mult"], IECore.FloatData( 0.5 ) )
+		self.assertEqual( a["gl:surface"][0].parameters["tint"].value, IECore.Color4f( 1, 0.5, 0.25, 1 ) )
+		self.assertTrue( isinstance( a["gl:surface"][0].parameters["texture"], IECore.CompoundData ) )
+		self.failUnless( "displayWindow" in a["gl:surface"][0].parameters["texture"] )
+		self.failUnless( "dataWindow" in a["gl:surface"][0].parameters["texture"] )
+		self.failUnless( "channels" in a["gl:surface"][0].parameters["texture"] )
 
 	def testDirtyPropagation( self ) :
 
@@ -99,18 +99,18 @@ class OpenGLShaderTest( GafferSceneTest.SceneTestCase ) :
 		s = GafferScene.OpenGLShader()
 		s.loadShader( "Texture" )
 
-		h1 = s.stateHash()
+		h1 = s.attributesHash()
 
 		i = GafferImage.Constant()
 		i["format"].setValue( GafferImage.Format( 100, 100, 1 ) )
 		s["parameters"]["texture"].setInput( i["out"] )
 
-		h2 = s.stateHash()
+		h2 = s.attributesHash()
 		self.assertNotEqual( h2, h1 )
 
 		i["color"].setValue( IECore.Color4f( 1, 0, 1, 0 ) )
 
-		h3 = s.stateHash()
+		h3 = s.attributesHash()
 		self.assertNotEqual( h3, h2 )
 		self.assertNotEqual( h3, h1 )
 

--- a/python/GafferSceneTest/ShaderTest.py
+++ b/python/GafferSceneTest/ShaderTest.py
@@ -67,30 +67,30 @@ class ShaderTest( GafferSceneTest.SceneTestCase ) :
 		self.assertTrue( s["enabled"].isSame( s.enabledPlug() ) )
 		self.assertEqual( s.correspondingInput( s["out"] ), None )
 
-		h = s.stateHash()
-		self.assertEqual( len( s.state() ), 1 )
+		h = s.attributesHash()
+		self.assertEqual( len( s.attributes() ), 1 )
 
 		s["enabled"].setValue( False )
 
-		self.assertEqual( len( s.state() ), 0 )
-		self.assertNotEqual( s.stateHash(), h )
+		self.assertEqual( len( s.attributes() ), 0 )
+		self.assertNotEqual( s.attributesHash(), h )
 
 	def testNodeNameBlindData( self ) :
 
 		s = GafferSceneTest.TestShader( "node1" )
+		s["type"].setValue( "test:surface" )
 
-		h1 = s.stateHash()
-		s1 = s.state()
-
+		h1 = s.attributesHash()
+		s1 = s.attributes()["test:surface"]
 		cs = GafferTest.CapturingSlot( s.plugDirtiedSignal() )
 
 		s.setName( "node2" )
 
 		self.assertTrue( s["out"] in [ x[0] for x in cs ] )
 
-		self.assertNotEqual( s.stateHash(), h1 )
+		self.assertNotEqual( s.attributesHash(), h1 )
 
-		s2 = s.state()
+		s2 = s.attributes()["test:surface"]
 		self.assertNotEqual( s2, s1 )
 
 		self.assertEqual( s1[0].blindData()["gaffer:nodeName"], IECore.StringData( "node1" ) )
@@ -99,9 +99,10 @@ class ShaderTest( GafferSceneTest.SceneTestCase ) :
 	def testNodeColorBlindData( self ) :
 
 		s = GafferSceneTest.TestShader()
+		s["type"].setValue( "test:surface" )
 
-		h1 = s.stateHash()
-		s1 = s.state()
+		h1 = s.attributesHash()
+		s1 = s.attributes()["test:surface"]
 
 		cs = GafferTest.CapturingSlot( s.plugDirtiedSignal() )
 
@@ -109,15 +110,15 @@ class ShaderTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertTrue( s["out"] in [ x[0] for x in cs ] )
 
-		self.assertNotEqual( s.stateHash(), h1 )
+		self.assertNotEqual( s.attributesHash(), h1 )
 
-		s2 = s.state()
+		s2 = s.attributes()["test:surface"]
 		self.assertNotEqual( s2, s1 )
 
 		self.assertEqual( s1[0].blindData()["gaffer:nodeColor"], IECore.Color3fData( IECore.Color3f( 0 ) ) )
 		self.assertEqual( s2[0].blindData()["gaffer:nodeColor"], IECore.Color3fData( IECore.Color3f( 1, 0, 0 ) ) )
 
-	def testShaderTypesInState( self ) :
+	def testShaderTypesInAttributes( self ) :
 
 		surface = GafferSceneTest.TestShader( "surface" )
 		surface["name"].setValue( "testSurface" )
@@ -130,9 +131,9 @@ class ShaderTest( GafferSceneTest.SceneTestCase ) :
 
 		surface["parameters"]["t"].setInput( texture["out"] )
 
-		state = surface.state()
-		self.assertEqual( state[0].type, "test:shader" )
-		self.assertEqual( state[1].type, "test:surface" )
+		network = surface.attributes()["test:surface"]
+		self.assertEqual( network[0].type, "test:shader" )
+		self.assertEqual( network[1].type, "test:surface" )
 
 	def testDirtyPropagationThroughShaderAssignment( self ) :
 
@@ -176,8 +177,8 @@ class ShaderTest( GafferSceneTest.SceneTestCase ) :
 		# And a hard error when we attempt to actually generate
 		# the shader network.
 		for node in ( n1, n2, n3 ) :
-			self.assertRaisesRegexp( RuntimeError, "cycle", node.stateHash )
-			self.assertRaisesRegexp( RuntimeError, "cycle", node.state )
+			self.assertRaisesRegexp( RuntimeError, "cycle", node.attributesHash )
+			self.assertRaisesRegexp( RuntimeError, "cycle", node.attributes )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferArnold/ArnoldAttributes.cpp
+++ b/src/GafferArnold/ArnoldAttributes.cpp
@@ -68,6 +68,7 @@ ArnoldAttributes::ArnoldAttributes( const std::string &name )
 
 	// Subdivision parameters
 
+	attributes->addOptionalMember( "ai:polymesh:subdiv_type", new StringPlug( "value", Plug::In, "none" ), "subdivType", false );
 	attributes->addOptionalMember( "ai:polymesh:subdiv_iterations", new IntPlug( "value", Plug::In, 1, 1 ), "subdivIterations", false );
 	attributes->addOptionalMember( "ai:polymesh:subdiv_adaptive_error", new FloatPlug( "value", Plug::In, 0.0f, 0.0f ), "subdivAdaptiveError", false );
 	attributes->addOptionalMember( "ai:polymesh:subdiv_adaptive_metric", new StringPlug( "value", Plug::In, "auto" ), "subdivAdaptiveMetric", false );

--- a/src/GafferArnold/ArnoldAttributes.cpp
+++ b/src/GafferArnold/ArnoldAttributes.cpp
@@ -68,7 +68,7 @@ ArnoldAttributes::ArnoldAttributes( const std::string &name )
 
 	// Subdivision parameters
 
-	attributes->addOptionalMember( "ai:polymesh:subdiv_type", new StringPlug( "value", Plug::In, "none" ), "subdivType", false );
+	attributes->addOptionalMember( "ai:polymesh:subdividePolygons", new BoolPlug( "value" ), "subdividePolygons", false );
 	attributes->addOptionalMember( "ai:polymesh:subdiv_iterations", new IntPlug( "value", Plug::In, 1, 1 ), "subdivIterations", false );
 	attributes->addOptionalMember( "ai:polymesh:subdiv_adaptive_error", new FloatPlug( "value", Plug::In, 0.0f, 0.0f ), "subdivAdaptiveError", false );
 	attributes->addOptionalMember( "ai:polymesh:subdiv_adaptive_metric", new StringPlug( "value", Plug::In, "auto" ), "subdivAdaptiveMetric", false );

--- a/src/GafferArnold/ArnoldDisplacement.cpp
+++ b/src/GafferArnold/ArnoldDisplacement.cpp
@@ -1,0 +1,210 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Gaffer/Dot.h"
+#include "Gaffer/SubGraph.h"
+
+#include "GafferScene/ShaderSwitch.h"
+
+#include "GafferArnold/ArnoldDisplacement.h"
+#include "GafferArnold/ArnoldShader.h"
+
+using namespace IECore;
+using namespace Gaffer;
+using namespace GafferScene;
+using namespace GafferArnold;
+
+IE_CORE_DEFINERUNTIMETYPED( ArnoldDisplacement );
+
+size_t ArnoldDisplacement::g_firstPlugIndex = 0;
+static IECore::InternedString g_surfaceAttributeName = "ai:surface";
+static IECore::InternedString g_mapAttributeName = "ai:disp_map";
+static IECore::InternedString g_paddingAttributeName = "ai:disp_padding";
+static IECore::InternedString g_heightAttributeName = "ai:disp_height";
+static IECore::InternedString g_zeroValueAttributeName = "ai:disp_zero_value";
+static IECore::InternedString g_autoBumpAttributeName = "ai:disp_autobump";
+
+ArnoldDisplacement::ArnoldDisplacement( const std::string &name )
+	:	Shader( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+	addChild( new Plug( "map" ) );
+	addChild( new FloatPlug( "height", Plug::In, 1.0f ) );
+	addChild( new FloatPlug( "padding", Plug::In, 0.0f, 0.0f ) );
+	addChild( new FloatPlug( "zeroValue" ) );
+	addChild( new BoolPlug( "autoBump" ) );
+	addChild( new Plug( "out", Plug::Out ) );
+}
+
+ArnoldDisplacement::~ArnoldDisplacement()
+{
+}
+
+Gaffer::Plug *ArnoldDisplacement::mapPlug()
+{
+	return getChild<Plug>( g_firstPlugIndex );
+}
+
+const Gaffer::Plug *ArnoldDisplacement::mapPlug() const
+{
+	return getChild<Plug>( g_firstPlugIndex );
+}
+
+Gaffer::FloatPlug *ArnoldDisplacement::heightPlug()
+{
+	return getChild<FloatPlug>( g_firstPlugIndex + 1 );
+}
+
+const Gaffer::FloatPlug *ArnoldDisplacement::heightPlug() const
+{
+	return getChild<FloatPlug>( g_firstPlugIndex + 1 );
+}
+
+Gaffer::FloatPlug *ArnoldDisplacement::paddingPlug()
+{
+	return getChild<FloatPlug>( g_firstPlugIndex + 2 );
+}
+
+const Gaffer::FloatPlug *ArnoldDisplacement::paddingPlug() const
+{
+	return getChild<FloatPlug>( g_firstPlugIndex + 2 );
+}
+
+Gaffer::FloatPlug *ArnoldDisplacement::zeroValuePlug()
+{
+	return getChild<FloatPlug>( g_firstPlugIndex + 3 );
+}
+
+const Gaffer::FloatPlug *ArnoldDisplacement::zeroValuePlug() const
+{
+	return getChild<FloatPlug>( g_firstPlugIndex + 3 );
+}
+
+Gaffer::BoolPlug *ArnoldDisplacement::autoBumpPlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 4 );
+}
+
+const Gaffer::BoolPlug *ArnoldDisplacement::autoBumpPlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 4 );
+}
+
+Gaffer::Plug *ArnoldDisplacement::outPlug()
+{
+	return getChild<Plug>( g_firstPlugIndex + 5 );
+}
+
+const Gaffer::Plug *ArnoldDisplacement::outPlug() const
+{
+	return getChild<Plug>( g_firstPlugIndex + 5 );
+}
+
+void ArnoldDisplacement::attributesHash( IECore::MurmurHash &h ) const
+{
+	h.append( typeId() );
+	if( !enabledPlug()->getValue() )
+	{
+		return;
+	}
+
+	if( const ArnoldShader *arnoldShader = runTimeCast<const ArnoldShader>( mapPlug()->source<Plug>()->node() ) )
+	{
+		arnoldShader->attributesHash( h );
+	}
+	heightPlug()->hash( h );
+	paddingPlug()->hash( h );
+	zeroValuePlug()->hash( h );
+	autoBumpPlug()->hash( h );
+}
+
+IECore::ConstCompoundObjectPtr ArnoldDisplacement::attributes() const
+{
+	CompoundObjectPtr result = new CompoundObject;
+	if( !enabledPlug()->getValue() )
+	{
+		return result;
+	}
+
+	CompoundObject::ObjectMap &m = result->members();
+	if( const ArnoldShader *arnoldShader = runTimeCast<const ArnoldShader>( mapPlug()->source<Plug>()->node() ) )
+	{
+		m = arnoldShader->attributes()->members();
+		CompoundObject::ObjectMap::iterator it = m.find( g_surfaceAttributeName );
+		if( it != m.end() )
+		{
+			m[g_mapAttributeName] = it->second;
+			m.erase( it );
+		}
+	}
+
+	m[g_heightAttributeName] = new FloatData( heightPlug()->getValue() );
+	m[g_paddingAttributeName] = new FloatData( paddingPlug()->getValue() );
+	m[g_zeroValueAttributeName] = new FloatData( zeroValuePlug()->getValue() );
+	m[g_autoBumpAttributeName] = new BoolData( autoBumpPlug()->getValue() );
+
+	return result;
+}
+
+bool ArnoldDisplacement::acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const
+{
+	if( !Shader::acceptsInput( plug, inputPlug ) )
+	{
+		return false;
+	}
+
+	if( !inputPlug )
+	{
+		return true;
+	}
+
+	if( plug == mapPlug() )
+	{
+		const Node *sourceNode = inputPlug->source<Plug>()->node();
+		if(
+			runTimeCast<const ArnoldShader>( sourceNode ) ||
+			runTimeCast<const SubGraph>( sourceNode ) ||
+			runTimeCast<const ShaderSwitch>( sourceNode ) ||
+			runTimeCast<const Dot>( sourceNode )
+		)
+		{
+			return true;
+		}
+		return false;
+	}
+
+	return true;
+}

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -358,7 +358,7 @@ IECore::InternedString g_polyMeshSubdivIterationsAttributeName( "ai:polymesh:sub
 IECore::InternedString g_polyMeshSubdivAdaptiveErrorAttributeName( "ai:polymesh:subdiv_adaptive_error" );
 IECore::InternedString g_polyMeshSubdivAdaptiveMetricAttributeName( "ai:polymesh:subdiv_adaptive_metric" );
 IECore::InternedString g_polyMeshSubdivAdaptiveSpaceAttributeName( "ai:polymesh:subdiv_adaptive_space" );
-IECore::InternedString g_polyMeshSubdivTypeAttributeName( "ai:polymesh:subdiv_type" );
+IECore::InternedString g_polyMeshSubdividePolygonsAttributeName( "ai:polymesh:subdividePolygons" );
 IECore::InternedString g_objectSpace( "object" );
 
 IECore::InternedString g_dispMapAttributeName( "ai:disp_map" );
@@ -381,38 +381,38 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 				subdivAdaptiveError = attributeValue<float>( g_polyMeshSubdivAdaptiveErrorAttributeName, attributes, 0.0f );
 				subdivAdaptiveMetric = attributeValue<string>( g_polyMeshSubdivAdaptiveMetricAttributeName, attributes, "auto" );
 				subdivAdaptiveSpace = attributeValue<string>( g_polyMeshSubdivAdaptiveSpaceAttributeName, attributes, "raster" );
-				subdivType = attributeValue<string>( g_polyMeshSubdivTypeAttributeName, attributes, "" );
+				subdividePolygons = attributeValue<bool>( g_polyMeshSubdividePolygonsAttributeName, attributes, false );
 			}
 
 			int subdivIterations;
 			float subdivAdaptiveError;
 			IECore::InternedString subdivAdaptiveMetric;
 			IECore::InternedString subdivAdaptiveSpace;
-			IECore::InternedString subdivType;
+			bool subdividePolygons;
 
 			void hash( const IECore::MeshPrimitive *mesh, IECore::MurmurHash &h ) const
 			{
-				if( mesh->interpolation() != "linear" || subdivType != "" )
+				if( mesh->interpolation() != "linear" || subdividePolygons )
 				{
 					h.append( subdivIterations );
 					h.append( subdivAdaptiveError );
 					h.append( subdivAdaptiveMetric );
 					h.append( subdivAdaptiveSpace );
-					h.append( subdivType );
+					h.append( subdividePolygons );
 				}
 			}
 
 			void apply( const IECore::MeshPrimitive *mesh, AtNode *node ) const
 			{
-				if( mesh->interpolation() != "linear" || subdivType != "" )
+				if( mesh->interpolation() != "linear" || subdividePolygons )
 				{
 					AiNodeSetByte( node, "subdiv_iterations", subdivIterations );
 					AiNodeSetFlt( node, "subdiv_adaptive_error", subdivAdaptiveError );
 					AiNodeSetStr( node, "subdiv_adaptive_metric", subdivAdaptiveMetric.c_str() );
 					AiNodeSetStr( node, "subdiv_adaptive_space", subdivAdaptiveSpace.c_str() );
-					if( subdivType != "" )
+					if( mesh->interpolation() == "linear" )
 					{
-						AiNodeSetStr( node, "subdiv_type", subdivType.c_str() );
+						AiNodeSetStr( node, "subdiv_type", "linear" );
 					}
 				}
 			}

--- a/src/GafferArnoldModule/GafferArnoldModule.cpp
+++ b/src/GafferArnoldModule/GafferArnoldModule.cpp
@@ -46,6 +46,7 @@
 #include "GafferArnold/ArnoldVDB.h"
 #include "GafferArnold/InteractiveArnoldRender.h"
 #include "GafferArnold/ArnoldRender.h"
+#include "GafferArnold/ArnoldDisplacement.h"
 
 using namespace boost::python;
 using namespace GafferArnold;
@@ -64,6 +65,7 @@ BOOST_PYTHON_MODULE( _GafferArnold )
 	GafferBindings::DependencyNodeClass<ArnoldOptions>();
 	GafferBindings::DependencyNodeClass<ArnoldAttributes>();
 	GafferBindings::DependencyNodeClass<ArnoldVDB>();
+	GafferBindings::DependencyNodeClass<ArnoldDisplacement>();
 	GafferBindings::NodeClass<InteractiveArnoldRender>();
 	GafferDispatchBindings::TaskNodeClass<ArnoldRender>();
 

--- a/src/GafferOSL/OSLImage.cpp
+++ b/src/GafferOSL/OSLImage.cpp
@@ -283,7 +283,7 @@ void OSLImage::hashShading( const Gaffer::Context *context, IECore::MurmurHash &
 	const OSLShader *shader = runTimeCast<const OSLShader>( shaderPlug()->source<Plug>()->node() );
 	if( shader )
 	{
-		shader->stateHash( h );
+		shader->attributesHash( h );
 	}
 }
 

--- a/src/GafferOSL/OSLObject.cpp
+++ b/src/GafferOSL/OSLObject.cpp
@@ -163,7 +163,7 @@ void OSLObject::hashProcessedObject( const ScenePath &path, const Gaffer::Contex
 	const OSLShader *shader = runTimeCast<const OSLShader>( shaderPlug()->source<Plug>()->node() );
 	if( shader )
 	{
-		shader->stateHash( h );
+		shader->attributesHash( h );
 	}
 }
 

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -156,6 +156,32 @@ const Gaffer::Color3fPlug *Shader::nodeColorPlug() const
 	return getChild<Color3fPlug>( g_firstPlugIndex + 5 );
 }
 
+IECore::MurmurHash Shader::attributesHash() const
+{
+	IECore::MurmurHash h;
+	attributesHash( h );
+	return h;
+}
+
+void Shader::attributesHash( IECore::MurmurHash &h ) const
+{
+	NetworkBuilder networkBuilder( this );
+	h.append( networkBuilder.stateHash() );
+}
+
+IECore::ConstCompoundObjectPtr Shader::attributes() const
+{
+	IECore::CompoundObjectPtr result = new IECore::CompoundObject;
+	NetworkBuilder networkBuilder( this );
+	if( !networkBuilder.state()->members().empty() )
+	{
+		result->members()[typePlug()->getValue()] = boost::const_pointer_cast<IECore::ObjectVector>(
+			networkBuilder.state()
+		);
+	}
+	return result;
+}
+
 IECore::MurmurHash Shader::stateHash() const
 {
 	NetworkBuilder networkBuilder( this );

--- a/src/GafferScene/ShaderAssignment.cpp
+++ b/src/GafferScene/ShaderAssignment.cpp
@@ -141,7 +141,7 @@ void ShaderAssignment::hashProcessedAttributes( const ScenePath &path, const Gaf
 	const Shader *shader = shaderPlug()->source<Plug>()->ancestor<Shader>();
 	if( shader )
 	{
-		shader->stateHash( h );
+		shader->attributesHash( h );
 	}
 }
 
@@ -153,14 +153,8 @@ IECore::ConstCompoundObjectPtr ShaderAssignment::computeProcessedAttributes( con
 		return inputAttributes;
 	}
 
-	ConstObjectVectorPtr state = shader->state();
-	if( !state->members().size() )
-	{
-		return inputAttributes;
-	}
-
-	const IECore::Shader *primaryShader = runTimeCast<IECore::Shader>( state->members().back().get() );
-	if( !primaryShader || !primaryShader->getType().size() )
+	ConstCompoundObjectPtr attributes = shader->attributes();
+	if( attributes->members().empty() )
 	{
 		return inputAttributes;
 	}
@@ -171,12 +165,10 @@ IECore::ConstCompoundObjectPtr ShaderAssignment::computeProcessedAttributes( con
 	// the input members in our result without copying. Be careful not to modify
 	// them though!
 	result->members() = inputAttributes->members();
-	// Shader::state() returns a const object, so that in the future it may
-	// come from a cached value. we're putting it into our result which, once
-	// returned, will also be treated as const and cached. for that reason the
-	// temporary const_cast needed to put it into the result is justified -
-	// we never change the object and nor can anyone after it is returned.
-	result->members()[primaryShader->getType()] = boost::const_pointer_cast<ObjectVector>( state );
+	for( CompoundObject::ObjectMap::const_iterator it = attributes->members().begin(), eIt = attributes->members().end(); it != eIt; ++it )
+	{
+		result->members()[it->first] = it->second;
+	}
 
 	return result;
 }

--- a/src/GafferSceneBindings/ShaderBinding.cpp
+++ b/src/GafferSceneBindings/ShaderBinding.cpp
@@ -49,7 +49,23 @@ using namespace Gaffer;
 using namespace GafferBindings;
 using namespace GafferScene;
 
-static IECore::ObjectVectorPtr state( const Shader &s, bool copy=true )
+namespace
+{
+
+IECore::CompoundObjectPtr attributes( const Shader &s, bool copy=true )
+{
+	IECore::ConstCompoundObjectPtr o = s.attributes();
+	if( copy )
+	{
+		return o->copy();
+	}
+	else
+	{
+		return boost::const_pointer_cast<IECore::CompoundObject>( o );
+	}
+}
+
+IECore::ObjectVectorPtr state( const Shader &s, bool copy=true )
 {
 	IECore::ConstObjectVectorPtr o = s.state();
 	if( copy )
@@ -62,10 +78,15 @@ static IECore::ObjectVectorPtr state( const Shader &s, bool copy=true )
 	}
 }
 
+} // namespace
+
 void GafferSceneBindings::bindShader()
 {
 
 	GafferBindings::DependencyNodeClass<Shader>()
+		.def( "attributesHash", (IECore::MurmurHash (Shader::*)() const )&Shader::attributesHash )
+		.def( "attributesHash", (void (Shader::*)( IECore::MurmurHash &h ) const )&Shader::attributesHash )
+		.def( "attributes", &attributes, ( boost::python::arg_( "_copy" ) = true ) )
 		.def( "stateHash", (IECore::MurmurHash (Shader::*)() const )&Shader::stateHash )
 		.def( "stateHash", (void (Shader::*)( IECore::MurmurHash &h ) const )&Shader::stateHash )
 		.def( "state", &state, ( boost::python::arg_( "_copy" ) = true ) )

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -101,6 +101,7 @@ if moduleSearchPath.find( "arnold" ) :
 
 		GafferArnoldUI.ShaderMenu.appendShaders( nodeMenu.definition() )
 
+		nodeMenu.append( "/Arnold/Displacement", GafferArnold.ArnoldDisplacement, searchText = "ArnoldDisplacement"  )
 		nodeMenu.append( "/Arnold/VDB", GafferArnold.ArnoldVDB, searchText = "ArnoldVDB"  )
 		nodeMenu.append( "/Arnold/Options", GafferArnold.ArnoldOptions, searchText = "ArnoldOptions" )
 		nodeMenu.append( "/Arnold/Attributes", GafferArnold.ArnoldAttributes, searchText = "ArnoldAttributes" )


### PR DESCRIPTION
This adds support for assigning displacement shaders in Arnold, by combining an input displacement map (any Arnold shader) with attributes such as disp_height, disp_padding. That can then be assigned in the usual way using a regular ShaderAssignment node.

Arnold doesn't support changing displacement or subdivision in interactive renders, but this _could_ be dealt with by deleting and recreating the polymesh node. It was my plan to implement that for this PR, but since SG#9168 seems more urgent, I thought it best to get the already-done displacement functionality merged first, and then come back later to add the bells and whistles for the interactive rendering. Let me know if that doesn't sound right...