### PR TITLE
OSL spline support

### DIFF
--- a/python/GafferOSLTest/OSLShaderTest.py
+++ b/python/GafferOSLTest/OSLShaderTest.py
@@ -600,5 +600,69 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 			if isinstance( plug, Gaffer.ValuePlug ) :
 				self.assertTrue( plug.isSetToDefault() )
 
+	def testSplineParameters( self ) :
+
+		s = self.compileShader( os.path.dirname( __file__ ) + "/shaders/splineParameters.osl" )
+		n = GafferOSL.OSLShader()
+		n.loadShader( s )
+
+		self.assertEqual( n["parameters"].keys(), [ "floatSpline", "colorSpline" ] )
+
+		self.assertTrue( isinstance( n["parameters"]["floatSpline"], Gaffer.SplineffPlug ) )
+		self.assertEqual(
+			n["parameters"]["floatSpline"].getValue(),
+			IECore.Splineff(
+				IECore.CubicBasisf.catmullRom(),
+				[
+					( 0, 0 ),
+					( 0, 0 ),
+					( 1, 1 ),
+					( 1, 1 ),
+				]
+			)
+		)
+
+		self.assertTrue( isinstance( n["parameters"]["colorSpline"], Gaffer.SplinefColor3fPlug ) )
+		self.assertEqual(
+			n["parameters"]["colorSpline"].getValue(),
+			IECore.SplinefColor3f(
+				IECore.CubicBasisf.bSpline(),
+				[
+					( 0, IECore.Color3f( 0 ) ),
+					( 0, IECore.Color3f( 0 ) ),
+					( 1, IECore.Color3f( 1 ) ),
+					( 1, IECore.Color3f( 1 ) ),
+				]
+			)
+		)
+
+		shader = n.attributes()["osl:surface"][0]
+
+		self.assertEqual(
+			shader.parameters["floatSpline"].value,
+			IECore.Splineff(
+				IECore.CubicBasisf.catmullRom(),
+				[
+					( 0, 0 ),
+					( 0, 0 ),
+					( 1, 1 ),
+					( 1, 1 ),
+				]
+			)
+		)
+
+		self.assertEqual(
+			shader.parameters["colorSpline"].value,
+			IECore.SplinefColor3f(
+				IECore.CubicBasisf.bSpline(),
+				[
+					( 0, IECore.Color3f( 0 ) ),
+					( 0, IECore.Color3f( 0 ) ),
+					( 1, IECore.Color3f( 1 ) ),
+					( 1, IECore.Color3f( 1 ) ),
+				]
+			)
+		)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferOSLTest/ShadingEngineTest.py
+++ b/python/GafferOSLTest/ShadingEngineTest.py
@@ -289,5 +289,27 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 			self.assertEqual( shading["n"][i], IECore.V3f( 0 ) )
 			self.assertEqual( shading["c"][i], IECore.Color3f( 0 ) )
 
+	def testSpline( self ) :
+
+		shader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/splineParameters.osl" )
+		spline =  IECore.SplinefColor3f(
+			IECore.CubicBasisf.bSpline(),
+			[
+				( 0, IECore.Color3f( 1 ) ),
+				( 0, IECore.Color3f( 1 ) ),
+				( 1, IECore.Color3f( 0 ) ),
+				( 1, IECore.Color3f( 0 ) ),
+			]
+		)
+
+		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
+			IECore.Shader( shader, "surface", { "colorSpline" : spline } )
+		] ) )
+
+		rp = self.rectanglePoints()
+		p = e.shade( rp )
+		for i in range( 0, len( p["Ci"] ) ) :
+			self.assertTrue( p["Ci"][i].equalWithAbsError( spline( rp["v"][i] ), 0.001 ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferOSLTest/shaders/splineParameters.osl
+++ b/python/GafferOSLTest/shaders/splineParameters.osl
@@ -1,0 +1,53 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+surface splineParameters
+(
+
+	float floatSplinePositions[] = { 0, 0, 1, 1 },
+	float floatSplineValues[] = { 0, 0, 1, 1 },
+	string floatSplineBasis = "catmull-rom",
+
+	color colorSplineValues[] = { 0, 0, 1, 1 },
+	float colorSplinePositions[] = { 0, 0, 1, 1 },
+	string colorSplineBasis = "bspline",
+
+)
+{
+	float t = splineinverse( colorSplineBasis, v, colorSplinePositions  );
+	color c = spline( colorSplineBasis, t, colorSplineValues );
+	Ci = c * emission();
+}

--- a/python/GafferOSLTest/shaders/version1.osl
+++ b/python/GafferOSLTest/shaders/version1.osl
@@ -1,0 +1,90 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+struct TestStruct
+{
+
+	// Fields shared with version 1
+	int commonI;
+	float commonF;
+	color commonColor;
+	string commonString;
+
+	// Fields removed in version 2
+	int removedI;
+	float removedF;
+	color removedColor;
+	string removedString;
+
+	// Fields which change type in version 2
+	int typeChanged1;
+	float typeChanged2;
+	color typeChanged3;
+	string typeChanged4;
+
+};
+
+shader version1
+(
+
+	// Parameters shared with version 1
+
+	int commonI = 2,
+	float commonF = 3,
+	color commonColor = 1,
+	string commonString = "ss",
+	TestStruct commonStruct = { 1, 2, color( 1, 2, 3 ), "s", 2, 4, color( 2, 3, 4 ), "t", 1, 2, 3, "four" },
+
+	// Parameters added in version 2
+
+	int removedI = 3,
+	float removedF = 4,
+	color removedColor = 5,
+	string removedString = "tt",
+	TestStruct removedStruct = { 1, 2, color( 1, 2, 3 ), "s", 2, 4, color( 2, 3, 4 ), "t", 1, 2, 3, "four" },
+
+	// Parameters which change type in version 2
+
+	int typeChanged1 = 1,
+	float typeChanged2 = 2,
+	color typeChanged3 = 3,
+	string typeChanged4 = "four",
+
+	output color c = 0
+
+)
+{
+}

--- a/python/GafferOSLTest/shaders/version2.osl
+++ b/python/GafferOSLTest/shaders/version2.osl
@@ -1,0 +1,88 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+struct TestStruct
+{
+	// Fields shared with version 1
+	int commonI;
+	float commonF;
+	color commonColor;
+	string commonString;
+
+	// Fields which change type in version 2
+	float typeChanged1;
+	int typeChanged2;
+	string typeChanged3;
+	color typeChanged4;
+
+	// Fields added in version 2
+	int addedI;
+	float addedF;
+	color addedColor;
+	string addedString;
+};
+
+shader version2
+(
+
+	// Parameters shared with version 1
+
+	int commonI = 2,
+	float commonF = 3,
+	color commonColor = 1,
+	string commonString = "ss",
+	TestStruct commonStruct = { 1, 2, color( 1, 2, 3 ), "s", 1, 2, "three", 4, 2, 4, color( 2, 3, 4 ), "t" },
+
+	// Parameters which change type in version 2
+
+	string typeChanged1 = "one",
+	color typeChanged2 = 2,
+	float typeChanged3 = 3,
+	int typeChanged4 = 4,
+
+	// Parameters added in version 2
+
+	int addedI = 2,
+	float addedF = 3,
+	color addedColor = 1,
+	string addedString = "ss",
+	TestStruct addedStruct = { 1, 2, color( 1, 2, 3 ), "s", 1, 2, "three", 4, 2, 4, color( 2, 3, 4 ), "t" },
+
+	output color c = 0
+
+)
+{
+}

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -174,7 +174,8 @@ class _ShaderNamePlugValueWidget( GafferUI.PlugValueWidget ) :
 	def __buttonClicked( self, button ) :
 
 		node = self.getPlug().node()
-		node.shaderLoader().clear()
+		if hasattr( node, "shaderLoader" ) :
+			node.shaderLoader().clear()
 
 		with Gaffer.UndoContext( node.ancestor( Gaffer.ScriptNode ) ) :
 			node.loadShader( node["name"].getValue(), keepExistingValues = True )

--- a/shaders/Pattern/ColorSpline.osl
+++ b/shaders/Pattern/ColorSpline.osl
@@ -1,0 +1,52 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+shader ColorSpline
+(
+
+	float splinePositions[] = { 0, 0, 1, 1 },
+	color splineValues[] = { 0, 0, 1, 1 },
+	string splineBasis = "catmull-rom",
+
+	float x = 0,
+
+	output color c = 0
+
+)
+{
+	float t = splineinverse( splineBasis, x, splinePositions  );
+	c = spline( splineBasis, t, splineValues );
+}


### PR DESCRIPTION
This adds support for spline parameters in OSL shaders, following similar conventions as we use for RSL shaders. Only the last 4 commits are unique to this PR - the rest are from #1776, which I build on top of to avoid conflicts later. I could tease the two apart if necessary, but I'm hoping we'll just forge ahead and merge the Arnold PRs that have been waiting patiently for a while now.