### PR TITLE
IECoreArnoldPreview : Added some debug info when an invalid camera reaches updateCamera()

### DIFF
--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -1167,6 +1167,16 @@ class ArnoldRenderer : public IECoreScenePreview::Renderer
 				}
 				cortexCamera = m_cameras["ieCoreArnold:defaultCamera"].get();
 				AiNodeSetPtr( options, "camera", AiNodeLookUpByName( "ieCoreArnold:defaultCamera" ) );
+
+				IECore::msg( IECore::Msg::Warning, "IECoreArnold::Renderer::updateCamera", "Failed to find camera: " + m_cameraName );
+				IECore::msg( IECore::Msg::Warning, "IECoreArnold::Renderer::updateCamera", "Falling back to default camera" );
+
+				std::string candidateCameras = "";
+				for(CameraMap::iterator iter = m_cameras.begin(); iter != m_cameras.end(); ++iter)
+				{
+					candidateCameras += iter->first + " ";
+				}
+				IECore::msg( IECore::Msg::Warning, "IECoreArnold::Renderer::updateCamera", "Candidate cameras were: " + candidateCameras );
 			}
 
 			const IECore::V2iData *resolution = cortexCamera->parametersData()->member<IECore::V2iData>( "resolution" );


### PR DESCRIPTION
It shouldn't be necessary to output warnings here, because this should never happen - invalid cameras should be caught earlier.

But we've got a nasty non-deterministic error currently where 1 in 500 times some scenes will fail to find the camera and render with a default 640x480 camera without outputting any errors.

My best guess is that somehow the parallelProcessLocations in RendererAlgo::outputCameras sometimes fails to add the camera to m_cameras, but I can't think of any real mechanism for this to happen.

Unless you have any brilliant ideas, getting this debug info rolled out to production might help narrow things down a bit next time we see one of these failures.