### PR TITLE
Arnold Renderer : Fix camera threading bug.

### DIFF
--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -473,6 +473,22 @@ class ArnoldRenderTest( GafferTest.TestCase ) :
 
 		self.assertRaisesRegexp( RuntimeError, "/i/dont/exist", s["render"]["task"].execute )
 
+	def testManyCameras( self ) :
+
+		camera = GafferScene.Camera()
+
+		duplicate = GafferScene.Duplicate()
+		duplicate["in"].setInput( camera["out"] )
+		duplicate["target"].setValue( "/camera" )
+		duplicate["copies"].setValue( 1000 )
+
+		render = GafferArnold.ArnoldRender()
+		render["in"].setInput( duplicate["out"] )
+		render["mode"].setValue( render.Mode.SceneDescriptionMode )
+		render["fileName"].setValue( self.temporaryDirectory() + "/test.ass" )
+
+		render["task"].execute()
+
 	def __assertStructsEqual( self, a, b ) :
 
 		for field in a._fields_ :

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -36,6 +36,7 @@
 
 #include "tbb/compat/thread"
 #include "tbb/concurrent_vector.h"
+#include "tbb/concurrent_unordered_map.h"
 
 #include "boost/make_shared.hpp"
 #include "boost/format.hpp"
@@ -1222,7 +1223,7 @@ class ArnoldRenderer : public IECoreScenePreview::Renderer
 		OutputMap m_outputs;
 
 		std::string m_cameraName;
-		typedef std::map<std::string, IECore::ConstCameraPtr> CameraMap;
+		typedef tbb::concurrent_unordered_map<std::string, IECore::ConstCameraPtr> CameraMap;
 		CameraMap m_cameras;
 		ObjectInterfacePtr m_defaultCamera;
 


### PR DESCRIPTION
The `camera()` method can be called concurrently, so `m_cameras` needs to be a container that can handle concurrent inserts.