### PR TITLE
FilterPlug

### DIFF
--- a/include/GafferScene/Filter.h
+++ b/include/GafferScene/Filter.h
@@ -72,6 +72,7 @@ class Filter : public Gaffer::ComputeNode
 		virtual Gaffer::BoolPlug *enabledPlug();
 		virtual const Gaffer::BoolPlug *enabledPlug() const;
 
+		/// \todo Change return type to FilterPlug.
 		Gaffer::IntPlug *outPlug();
 		const Gaffer::IntPlug *outPlug() const;
 

--- a/include/GafferScene/FilterPlug.h
+++ b/include/GafferScene/FilterPlug.h
@@ -1,0 +1,94 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENE_FILTERPLUG_H
+#define GAFFERSCENE_FILTERPLUG_H
+
+#include "Gaffer/NumericPlug.h"
+
+#include "GafferScene/Filter.h"
+
+namespace GafferScene
+{
+
+/// Plug type to provide the output from Filter nodes, and
+/// an input for nodes which wish to use Filters.
+/// \todo This derives from IntPlug for backwards compatibility
+/// reasons, but it may be preferable to derive straight from
+/// ValuePlug for version 1.0.0.0.
+class FilterPlug : public Gaffer::IntPlug
+{
+
+	public :
+
+		FilterPlug(
+			const std::string &name = defaultName<FilterPlug>(),
+			Direction direction = In,
+			unsigned flags = Default
+		);
+
+		/// \deprecated
+		FilterPlug(
+			const std::string &name,
+			Direction direction ,
+			int defaultValue,
+			int minValue,
+			int maxValue,
+			unsigned flags
+		);
+
+		virtual ~FilterPlug();
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::FilterPlug, FilterPlugTypeId, Gaffer::IntPlug );
+
+		virtual bool acceptsInput( const Gaffer::Plug *input ) const;
+		virtual Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
+
+};
+
+IE_CORE_DECLAREPTR( FilterPlug );
+
+typedef Gaffer::FilteredChildIterator<Gaffer::PlugPredicate<Gaffer::Plug::Invalid, FilterPlug> > FilterPlugIterator;
+typedef Gaffer::FilteredChildIterator<Gaffer::PlugPredicate<Gaffer::Plug::In, FilterPlug> > InputFilterPlugIterator;
+typedef Gaffer::FilteredChildIterator<Gaffer::PlugPredicate<Gaffer::Plug::Out, FilterPlug> > OutputFilterPlugIterator;
+
+typedef Gaffer::FilteredRecursiveChildIterator<Gaffer::PlugPredicate<Gaffer::Plug::Invalid, FilterPlug>, Gaffer::PlugPredicate<> > RecursiveFilterPlugIterator;
+typedef Gaffer::FilteredRecursiveChildIterator<Gaffer::PlugPredicate<Gaffer::Plug::In, FilterPlug>, Gaffer::PlugPredicate<> > RecursiveInputFilterPlugIterator;
+typedef Gaffer::FilteredRecursiveChildIterator<Gaffer::PlugPredicate<Gaffer::Plug::Out, FilterPlug>, Gaffer::PlugPredicate<> > RecursiveOutputFilterPlugIterator;
+
+} // namespace GafferScene
+
+#endif // GAFFERSCENE_FILTERPLUG_H

--- a/include/GafferScene/FilterProcessor.h
+++ b/include/GafferScene/FilterProcessor.h
@@ -73,6 +73,7 @@ class FilterProcessor : public Filter
 		/// with a single input, it will be a plug parented directly to the
 		/// node. If the node is disabled via enabledPlug(), then the inPlug()
 		/// is automatically passed through directly to the outPlug().
+		/// \todo Change return type to FilterPlug.
 		Gaffer::IntPlug *inPlug();
 		const Gaffer::IntPlug *inPlug() const;
 
@@ -88,8 +89,6 @@ class FilterProcessor : public Filter
 		virtual const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const;
 
 	protected :
-
-		virtual bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const;
 
 		/// Reimplemented to pass through the inPlug() hash when the node is disabled.
 		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;

--- a/include/GafferScene/FilteredSceneProcessor.h
+++ b/include/GafferScene/FilteredSceneProcessor.h
@@ -40,6 +40,7 @@
 
 #include "GafferScene/SceneProcessor.h"
 #include "GafferScene/Filter.h"
+#include "GafferScene/FilterPlug.h"
 
 namespace GafferScene
 {
@@ -56,15 +57,13 @@ class FilteredSceneProcessor : public SceneProcessor
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::FilteredSceneProcessor, FilteredSceneProcessorTypeId, SceneProcessor );
 
+		/// \todo Change return type to FilterPlug.
 		Gaffer::IntPlug *filterPlug();
 		const Gaffer::IntPlug *filterPlug() const;
 
 		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
 
 	protected :
-
-		/// Implemented to prevent non-Filter nodes being connected to the filter plug.
-		virtual bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const;
 
 		/// Convenience method which creates a temporary context for use in
 		/// passing the input scene to the filter. Such a context must be current

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -128,6 +128,7 @@ enum TypeId
 	AttributeVisualiserTypeId = 110583,
 	SceneLoopTypeId = 110584,
 	RenderTypeId = 110585,
+	FilterPlugTypeId = 110586,
 
 	PreviewInteractiveRenderTypeId = 110649,
 

--- a/include/GafferSceneBindings/FilterPlugBinding.h
+++ b/include/GafferSceneBindings/FilterPlugBinding.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENEBINDINGS_FILTERPLUGBINDING_H
+#define GAFFERSCENEBINDINGS_FILTERPLUGBINDING_H
+
+namespace GafferSceneBindings
+{
+
+void bindFilterPlug();
+
+} // namespace GafferSceneBindings
+
+#endif // GAFFERSCENEBINDINGS_FILTERPLUGBINDING_H

--- a/python/GafferSceneTest/FilterSwitchTest.py
+++ b/python/GafferSceneTest/FilterSwitchTest.py
@@ -199,5 +199,18 @@ class FilterSwitchTest( GafferSceneTest.SceneTestCase ) :
 		# should still be correctly connected internally:
 		self.assertEqual( fs["out"].getInput(), fs["in"]["in1"] )
 
+	def testConnectWithoutInputs( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["i"] = GafferScene.Isolate()
+		s["p"] = GafferScene.PathFilter()
+
+		s["s"] = GafferScene.FilterSwitch()
+		s["s"]["in"][0].setInput( s["p"]["out"] )
+		s["s"]["in"][0].setInput( None )
+
+		s["i"]["filter"].setInput( s["s"]["out"] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/ShaderAssignmentTest.py
+++ b/python/GafferSceneTest/ShaderAssignmentTest.py
@@ -91,11 +91,6 @@ class ShaderAssignmentTest( GafferSceneTest.SceneTestCase ) :
 		n = GafferTest.AddNode()
 		self.assertFalse( a["filter"].acceptsInput( n["sum"] ) )
 
-		p = Gaffer.IntPlug()
-		p.setInput( f["out"] )
-
-		self.assertTrue( a["filter"].acceptsInput( p ) )
-
 	def testAssignShaderFromOutsideBox( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/python/GafferSceneTest/UnionFilterTest.py
+++ b/python/GafferSceneTest/UnionFilterTest.py
@@ -127,7 +127,7 @@ class UnionFilterTest( GafferSceneTest.SceneTestCase ) :
 		n["out"] = f["out"].createCounterpart( "out", Gaffer.Plug.Direction.Out )
 
 		u = GafferScene.UnionFilter()
-		self.assertFalse( u["in"][0].acceptsInput( n["out"] ) )
+		self.assertTrue( u["in"][0].acceptsInput( n["out"] ) )
 
 	def testSceneAffects( self ) :
 

--- a/src/Gaffer/ArrayPlug.cpp
+++ b/src/Gaffer/ArrayPlug.cpp
@@ -98,6 +98,12 @@ bool ArrayPlug::acceptsChild( const GraphComponent *potentialChild ) const
 	{
 		return true;
 	}
+	// Likewise, we must do the same for old FilterProcessor nodes, which used to
+	// use IntPlugs nd now use FilterPlugs.
+	if( children()[0]->isInstanceOf( "GafferScene::FilterPlug" ) && potentialChild->typeId() == (IECore::TypeId)IntPlugTypeId )
+	{
+		return true;
+	}
 
 	return false;
 }

--- a/src/Gaffer/NumericPlug.cpp
+++ b/src/Gaffer/NumericPlug.cpp
@@ -149,19 +149,21 @@ T NumericPlug<T>::getValue( const IECore::MurmurHash *precomputedHash ) const
 template<class T>
 void NumericPlug<T>::setFrom( const ValuePlug *other )
 {
-	switch( static_cast<Gaffer::TypeId>(other->typeId()) )
+	if( const FloatPlug *p = runTimeCast<const FloatPlug>( other ) )
 	{
-		case FloatPlugTypeId :
-			setValue( (T)static_cast<const FloatPlug *>( other )->getValue() );
-			break;
-		case IntPlugTypeId :
-			setValue( (T)static_cast<const IntPlug *>( other )->getValue() );
-			break;
-		case BoolPlugTypeId :
-			setValue( (T)static_cast<const BoolPlug *>( other )->getValue() );
-			break;
-		default :
-			throw IECore::Exception( "Unsupported plug type" );
+		setValue( static_cast<T>( p->getValue() ) );
+	}
+	else if( const IntPlug *p = runTimeCast<const IntPlug>( other ) )
+	{
+		setValue( static_cast<T>( p->getValue() ) );
+	}
+	else if( const BoolPlug *p = runTimeCast<const BoolPlug>( other ) )
+	{
+		setValue( static_cast<T>( p->getValue() ) );
+	}
+	else
+	{
+		throw IECore::Exception( "Unsupported plug type" );
 	}
 }
 

--- a/src/GafferScene/Filter.cpp
+++ b/src/GafferScene/Filter.cpp
@@ -37,6 +37,7 @@
 #include "Gaffer/Context.h"
 
 #include "GafferScene/Filter.h"
+#include "GafferScene/FilterPlug.h"
 
 using namespace GafferScene;
 using namespace Gaffer;
@@ -51,7 +52,7 @@ Filter::Filter( const std::string &name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new BoolPlug( "enabled", Gaffer::Plug::In, true ) );
-	addChild( new IntPlug( "out", Gaffer::Plug::Out, NoMatch, NoMatch, EveryMatch, Plug::Default & ( ~Plug::Cacheable ) ) );
+	addChild( new FilterPlug( "out", Gaffer::Plug::Out, Plug::Default & ( ~Plug::Cacheable ) ) );
 }
 
 Filter::~Filter()
@@ -132,7 +133,7 @@ void Filter::compute( ValuePlug *output, const Context *context ) const
 		{
 			match = computeMatch( getInputScene( context ), context );
 		}
-		static_cast<IntPlug *>( output )->setValue( match );
+		static_cast<FilterPlug *>( output )->setValue( match );
 		return;
 	}
 

--- a/src/GafferScene/FilterPlug.cpp
+++ b/src/GafferScene/FilterPlug.cpp
@@ -1,0 +1,109 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Gaffer/Dot.h"
+#include "Gaffer/SubGraph.h"
+#include "Gaffer/ArrayPlug.h"
+
+#include "GafferScene/FilterPlug.h"
+
+using namespace IECore;
+using namespace Gaffer;
+using namespace GafferScene;
+
+IE_CORE_DEFINERUNTIMETYPED( FilterPlug );
+
+FilterPlug::FilterPlug( const std::string &name, Direction direction, unsigned flags )
+	:	IntPlug( name, direction, Filter::NoMatch, Filter::NoMatch, Filter::EveryMatch, flags )
+{
+}
+
+FilterPlug::FilterPlug( const std::string &name, Direction direction, int defaultValue, int minValue, int maxValue, unsigned flags )
+	:	IntPlug( name, direction, defaultValue, minValue, maxValue, flags )
+{
+}
+
+FilterPlug::~FilterPlug()
+{
+}
+
+bool FilterPlug::acceptsInput( const Gaffer::Plug *input ) const
+{
+	if( !IntPlug::acceptsInput( input ) )
+	{
+		return false;
+	}
+
+	if( !input )
+	{
+		return true;
+	}
+
+	if( input->isInstanceOf( staticTypeId() ) )
+	{
+		return true;
+	}
+
+	// Really we want to return false here, but we must provide backwards
+	// compatibility for a time when FilterPlug didn't exist and IntPlugs
+	// were used instead. Those old plugs may have been promoted onto Boxes
+	// routed via Dots, or used within ArrayPlugs. In each case, dynamic
+	// IntPlugs will have been created and serialised into the script, so
+	// we must accept them.
+	/// \todo Remove this compatibility for version 1.0.0.0?
+	if( runTimeCast<const IntPlug>( input ) )
+	{
+		const Node *n = input->source<Plug>()->node();
+		if( runTimeCast<const SubGraph>( n ) || runTimeCast<const Dot>( n ) )
+		{
+			return true;
+		}
+		if( const ArrayPlug *arrayPlug = input->parent<ArrayPlug>() )
+		{
+			if( arrayPlug && arrayPlug->getChild<FilterPlug>( 0 ) )
+			{
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+Gaffer::PlugPtr FilterPlug::createCounterpart( const std::string &name, Direction direction ) const
+{
+	return new FilterPlug( name, direction, defaultValue(), minValue(), maxValue(), getFlags() );
+}

--- a/src/GafferScene/FilterProcessor.cpp
+++ b/src/GafferScene/FilterProcessor.cpp
@@ -35,8 +35,6 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "Gaffer/ArrayPlug.h"
-#include "Gaffer/SubGraph.h"
-#include "Gaffer/Dot.h"
 
 #include "GafferScene/FilterProcessor.h"
 
@@ -133,27 +131,6 @@ const Gaffer::Plug *FilterProcessor::correspondingInput( const Gaffer::Plug *out
 		return inPlug();
 	}
 	return Filter::correspondingInput( output );
-}
-
-bool FilterProcessor::acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const
-{
-	if( !Filter::acceptsInput( plug, inputPlug ) )
-	{
-		return false;
-	}
-
-	if( !inputPlug )
-	{
-		return true;
-	}
-
-	if( plug->parent<ArrayPlug>() == inPlugs() || plug == inPlug() )
-	{
-		const Node *n = inputPlug->source<Plug>()->node();
-		return runTimeCast<const Filter>( n ) || runTimeCast<const SubGraph>( n ) || runTimeCast<const Dot>( n );
-	}
-
-	return true;
 }
 
 void FilterProcessor::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const

--- a/src/GafferScene/FilteredSceneProcessor.cpp
+++ b/src/GafferScene/FilteredSceneProcessor.cpp
@@ -54,7 +54,7 @@ FilteredSceneProcessor::FilteredSceneProcessor( const std::string &name, Filter:
 	:	SceneProcessor( name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
-	addChild( new IntPlug( "filter", Plug::In, filterDefault, Filter::NoMatch, Filter::EveryMatch ) );
+	addChild( new FilterPlug( "filter", Plug::In, filterDefault, Filter::NoMatch, Filter::EveryMatch, Plug::Default ) );
 }
 
 FilteredSceneProcessor::~FilteredSceneProcessor()
@@ -84,50 +84,6 @@ void FilteredSceneProcessor::affects( const Gaffer::Plug *input, AffectedPlugsCo
 			outputs.push_back( filterPlug() );
 		}
 	}
-}
-
-bool FilteredSceneProcessor::acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const
-{
-	if( !SceneProcessor::acceptsInput( plug, inputPlug ) )
-	{
-		return false;
-	}
-
-	if( !inputPlug )
-	{
-		return true;
-	}
-
-	if( plug == filterPlug() )
-	{
-		// We only really want to accept inputs from Filter nodes.
-		const Plug *source = inputPlug->source<Plug>();
-		const Node *n = source->node();
-		if( const Filter *filter = runTimeCast<const Filter>( n ) )
-		{
-			if( source == filter->outPlug() )
-			{
-				return true;
-			}
-		}
-		// But we can also trust connections from FilteredSceneProcessor::filterPlug()
-		// because it will have these exact same checks applied when it gets an input.
-		// This is particularly necessary for derived classes which may wish to wire
-		// up an internal network with connections to the external filter plug.
-		if( const FilteredSceneProcessor *f = runTimeCast<const FilteredSceneProcessor>( n ) )
-		{
-			if( source == f->filterPlug() )
-			{
-				return true;
-			}
-		}
-		// And we must also accept certain intermediate plugs speculatively in case they
-		// provide a filter connection in the future. We can do this because we are
-		// safe in the knowledge that this check will be called when the intermediate
-		// plug is having its input set.
-		return runTimeCast<const SubGraph>( n ) || runTimeCast<const Dot>( n );
-	}
-	return true;
 }
 
 Gaffer::ContextPtr FilteredSceneProcessor::filterContext( const Gaffer::Context *context ) const

--- a/src/GafferSceneBindings/FilterPlugBinding.cpp
+++ b/src/GafferSceneBindings/FilterPlugBinding.cpp
@@ -1,0 +1,76 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "GafferBindings/PlugBinding.h"
+
+#include "GafferScene/FilterPlug.h"
+
+#include "GafferSceneBindings/FilterPlugBinding.h"
+
+using namespace boost::python;
+using namespace Gaffer;
+using namespace GafferBindings;
+using namespace GafferScene;
+using namespace GafferSceneBindings;
+
+void GafferSceneBindings::bindFilterPlug()
+{
+
+	PlugClass<FilterPlug>()
+		.def( init<const std::string &, Plug::Direction, unsigned>(
+				(
+					arg( "name" ) = Gaffer::GraphComponent::defaultName<FilterPlug>(),
+					arg( "direction" ) = Gaffer::Plug::In,
+					arg( "flags" ) = Gaffer::Plug::Default
+				)
+			)
+		)
+		.def( init<const std::string &, Plug::Direction, int, int, int, unsigned>(
+				(
+					arg( "name" ) = Gaffer::GraphComponent::defaultName<FilterPlug>(),
+					arg( "direction" ) = Gaffer::Plug::In,
+					arg( "defaultValue" ) = GafferScene::Filter::NoMatch,
+					arg( "minValue" ) = GafferScene::Filter::NoMatch,
+					arg( "maxValue" ) = GafferScene::Filter::EveryMatch,
+					arg( "flags" ) = Gaffer::Plug::Default
+				)
+			)
+		)
+	;
+
+}

--- a/src/GafferSceneModule/GafferSceneModule.cpp
+++ b/src/GafferSceneModule/GafferSceneModule.cpp
@@ -102,6 +102,7 @@
 #include "GafferSceneBindings/ParametersBinding.h"
 #include "GafferSceneBindings/PathMatcherDataPlugBinding.h"
 #include "GafferSceneBindings/MeshToPointsBinding.h"
+#include "GafferSceneBindings/FilterPlugBinding.h"
 
 using namespace boost::python;
 using namespace GafferBindings;
@@ -115,6 +116,7 @@ BOOST_PYTHON_MODULE( _GafferScene )
 	bindSceneNode();
 	bindSceneProcessor();
 	bindFilter();
+	bindFilterPlug();
 	bindFilteredSceneProcessor();
 	GafferBindings::DependencyNodeClass<SceneElementProcessor>();
 	GafferBindings::DependencyNodeClass<MeshType>();


### PR DESCRIPTION
To date, we've been using a plain old IntPlug to provide the output of a Filter node and the input to a FilteredSceneProcessor. But this alone was insufficient to provide the guarantee that only Filter outputs could be connected to a FilteredSceneProcessor input. We used FilteredSceneProcessor::acceptsInput() to add constraints in an attempt to enforce this, but these have their problems as witnessed by #1814 and the `SceneProcessorTest.testDeriveAndUseExternalFilters` test case added in this PR.

The FilterPlug is intended to provide a stronger mechanism for making the guarantees we need. By using a dedicated plug type, we ensure that the plug semantics are preserved when undergoing promotion, and nodes can rely on the plug type rather than a custom `acceptsInput()` method which will become more flawed as other means of duplicating/promoting plugs appear in the future.

This is a pattern that has repeated itself every single time we've used a less strongly typed plug along with a custom `Node::acceptsInput()` implementation, rather than use a custom plug type from the outset. We've already made an analogous transition from Plug to TaskPlug in GafferDispatch, and shortly will be adding a ShaderPlug for use as the input to a ShaderAssignment. The rationale for the original implementations was to reduce the proliferation of many specialist plug types, but it seems clear at this point that the general rule should be that a custom plug type should be preferred to `Node::acceptsInput` overloads.