### PR TITLE
Arnold ParameterHandler : Support gaffer.plugType metadata.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -643,7 +643,7 @@ libraries = {
 	},
 
 	"GafferArnoldTest" : {
-		"additionalFiles" : glob.glob( "python/GafferArnoldTest/volumes/*" ),
+		"additionalFiles" : glob.glob( "python/GafferArnoldTest/volumes/*" ) + glob.glob( "python/GafferArnoldTest/metadata/*" ),
 	},
 
 	"GafferArnoldUI" : {},

--- a/include/GafferArnold/ParameterHandler.h
+++ b/include/GafferArnold/ParameterHandler.h
@@ -45,12 +45,14 @@ namespace GafferArnold
 {
 
 /// A helper class for mapping Arnold parameters to Gaffer Plugs.
+/// \todo Should probably just be free functions in a ParameterAlgo.h
+/// header, and should maybe be private too.
 class ParameterHandler
 {
 
 	public :
 
-		static Gaffer::Plug *setupPlug( const AtParamEntry *parameter, Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction = Gaffer::Plug::In );
+		static Gaffer::Plug *setupPlug( const AtNodeEntry *node, const AtParamEntry *parameter, Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction = Gaffer::Plug::In );
 		static void setupPlugs( const AtNodeEntry *node, Gaffer::GraphComponent *plugsParent, Gaffer::Plug::Direction direction = Gaffer::Plug::In );
 };
 

--- a/python/GafferArnoldTest/ArnoldShaderTest.py
+++ b/python/GafferArnoldTest/ArnoldShaderTest.py
@@ -35,6 +35,7 @@
 #
 ##########################################################################
 
+import os
 import unittest
 
 import IECore
@@ -43,9 +44,10 @@ import IECoreArnold
 import Gaffer
 import GafferTest
 import GafferScene
+import GafferSceneTest
 import GafferArnold
 
-class ArnoldShaderTest( unittest.TestCase ) :
+class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 
 	def test( self ) :
 
@@ -403,6 +405,26 @@ class ArnoldShaderTest( unittest.TestCase ) :
 
 		self.assertTrue( "exposure" in n["parameters"] )
 		self.assertTrue( n["out"].typeId(), Gaffer.Plug.staticTypeId() )
+
+	def testColorParameterMetadata( self ) :
+
+		n = GafferArnold.ArnoldShader()
+		n.loadShader( "ray_switch" )
+
+		for p in n["parameters"] :
+			self.assertTrue( isinstance( p, Gaffer.Color4fPlug ) )
+
+		self.addCleanup( setattr, os.environ, "ARNOLD_PLUGIN_PATH", os.environ["ARNOLD_PLUGIN_PATH"] )
+		os.environ["ARNOLD_PLUGIN_PATH"] = os.environ["ARNOLD_PLUGIN_PATH"] + ":" + os.path.join( os.path.dirname( __file__ ), "metadata" )
+
+		n = GafferArnold.ArnoldShader()
+		n.loadShader( "ray_switch" )
+
+		for name in [ "camera", "shadow", "reflection" ] :
+			self.assertTrue( isinstance( n["parameters"][name], Gaffer.Color3fPlug ) )
+
+		for name in [ "refraction", "diffuse", "glossy" ] :
+			self.assertTrue( isinstance( n["parameters"][name], Gaffer.Color4fPlug ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferArnoldTest/metadata/colorPlugType.mtd
+++ b/python/GafferArnoldTest/metadata/colorPlugType.mtd
@@ -1,0 +1,51 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#     * Neither the name of Image Engine Design nor the names of any
+#       other contributors to this software may be used to endorse or
+#       promote products derived from this software without specific prior
+#       written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+[node ray_switch]
+
+	[attr camera]
+
+		gaffer.plugType       STRING  "Color3fPlug"
+
+	[attr shadow]
+
+		gaffer.plugType       STRING  "Color3fPlug"
+
+	[attr reflection]
+
+		gaffer.plugType       STRING  "Color3fPlug"
+
+	[attr refraction]
+
+		gaffer.plugType       STRING  "Color4fPlug"


### PR DESCRIPTION
Currently only implemented for RGBA parameters, where you can now optionally represent them as Color3fPlugs in Gaffer. Rewrote the plug creation for RGB and RGBA parameters to allow the reuse of suitable plugs in the same way as we do for `OSLShader::loadShader()`, making some progress towards adding a `keepExistingValues` argument to `ArnoldShader::loadShader()`.

The main use of this is to use a metadata file to cause ray_switch and bump shaders to have Color3f inputs compatible with the outputs from most regular shaders. This is something of a stopgap measure until we can improve the UI to support RGB->RGBA connections well.

Requires ImageEngine/cortex#514 to be useful, but doesn't have a hard dependency.

Breaking Changes :

- Added an argument to GafferArnold::ParameterAlgo::setupPlug().