### PR TITLE
GafferArnold : Use new read/write UniverseBlock arguments.

### DIFF
--- a/src/GafferArnold/ArnoldLight.cpp
+++ b/src/GafferArnold/ArnoldLight.cpp
@@ -67,7 +67,7 @@ ArnoldLight::~ArnoldLight()
 
 void ArnoldLight::loadShader( const std::string &shaderName )
 {
-	IECoreArnold::UniverseBlock arnoldUniverse;
+	IECoreArnold::UniverseBlock arnoldUniverse( /* writable = */ false );
 
 	const AtNodeEntry *shader = AiNodeEntryLookUp( shaderName.c_str() );
 	if( !shader )

--- a/src/GafferArnold/ArnoldShader.cpp
+++ b/src/GafferArnold/ArnoldShader.cpp
@@ -71,7 +71,7 @@ ArnoldShader::~ArnoldShader()
 
 void ArnoldShader::loadShader( const std::string &shaderName )
 {
-	IECoreArnold::UniverseBlock arnoldUniverse;
+	IECoreArnold::UniverseBlock arnoldUniverse( /* writable = */ false );
 
 	const AtNodeEntry *shader = AiNodeEntryLookUp( shaderName.c_str() );
 	if( !shader )

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -1056,7 +1056,7 @@ class ArnoldRenderer : public IECoreScenePreview::Renderer
 
 		ArnoldRenderer( RenderType renderType, const std::string &fileName )
 			:	m_renderType( renderType ),
-				m_universeBlock( boost::make_shared<UniverseBlock>() ),
+				m_universeBlock( boost::make_shared<UniverseBlock>(  /* writable = */ true ) ),
 				m_shaderCache( new ShaderCache ),
 				m_instanceCache( new InstanceCache ),
 				m_assFileName( fileName )


### PR DESCRIPTION
This means we now emit an error when a second arnold render is attempted in the same process, rather than fail in bizarre ways.

Requires ImageEngine/cortex/#514