### PR TITLE
Dispatcher performance fixes

### DIFF
--- a/python/GafferDispatch/LocalDispatcher.py
+++ b/python/GafferDispatch/LocalDispatcher.py
@@ -168,7 +168,7 @@ class LocalDispatcher( GafferDispatch.Dispatcher ) :
 		def kill( self ) :
 
 			if not self.failed() :
-				self.__kill( self.__batch )
+				self.__killBatchWalk( self.__batch )
 
 		def killed( self ) :
 
@@ -178,13 +178,17 @@ class LocalDispatcher( GafferDispatch.Dispatcher ) :
 
 			self.__setStatus( self.__batch, LocalDispatcher.Job.Status.Failed )
 
-		def __kill( self, batch ) :
+		def __killBatchWalk( self, batch ) :
+
+			if "killed" in batch.blindData() :
+				# Already visited via another path
+				return
 
 			# this doesn't set the status to Killed because that could
 			# run into a race condition with a background dispatch.
 			batch.blindData()["killed"] = IECore.BoolData( True )
 			for upstreamBatch in batch.preTasks() :
-				self.__kill( upstreamBatch )
+				self.__killBatchWalk( upstreamBatch )
 
 		## \todo Having separate functions for foreground and background
 		# dispatch functions is error prone. Have only one.

--- a/python/GafferDispatchTest/DispatcherTest.py
+++ b/python/GafferDispatchTest/DispatcherTest.py
@@ -1313,5 +1313,70 @@ class DispatcherTest( GafferTest.TestCase ) :
 		self.assertEqual( [ l.context.getFrame() for l in log ], [ 1, 2, 3, 4, 1 ] )
 		self.assertEqual( [ l.frames for l in log ], [ None, None, None, None, [ 1, 2, 3, 4 ] ] )
 
+	def testScaling( self ) :
+
+		# A series of interleaved per-frame and per-sequence
+		# tasks like this :
+		#
+		#    perFrameA
+		#      |
+		#    perSequenceA
+		#      |
+		#    perFrameB
+		#      |
+		#    perSequenceB
+		#      |
+		#    ...
+		#
+		# Leads to a batch graph like this :
+		#
+		#    pfA1 pfA2 pfA3
+		#      \   |   /
+		#       \  |  /
+		#        \ | /
+		#      sequenceA
+		#        / | \
+		#       /  |  \
+		#      /   |   \
+		#    pfB1 pfB2 pfB3
+		#      \   |   /
+		#       \  |  /
+		#        \ | /
+		#      sequenceB
+		#        / | \
+		#    ...
+		#
+		# This fan-out/gather pattern generates a DAG with
+		# a huge number of unique paths, exposing any errors
+		# in the Dispatcher's pruning of previsited batches
+		# by utterly destroying performance.
+
+		s = Gaffer.ScriptNode()
+
+		lastTask = None
+		for i in range( 0, 5 ) :
+
+			perFrame = GafferDispatch.PythonCommand()
+			perFrame["command"].setValue( "context.getFrame()" )
+			s["perFrame%d" % i] = perFrame
+
+			if lastTask is not None :
+				perFrame["preTasks"][0].setInput( lastTask["task"] )
+
+			perSequence = GafferDispatch.PythonCommand()
+			perSequence["command"].setValue( "pass" )
+			perSequence["sequence"].setValue( True )
+			perSequence["preTasks"][0].setInput( perFrame["task"] )
+			s["perSequence%d" % i] = perSequence
+
+			lastTask = perSequence
+
+		d = self.TestDispatcher()
+
+		d["framesMode"].setValue( d.FramesMode.CustomRange )
+		d["frameRange"].setValue( "1-1000" )
+
+		d.dispatch( [ lastTask ] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferDispatchTest/DispatcherTest.py
+++ b/python/GafferDispatchTest/DispatcherTest.py
@@ -39,6 +39,7 @@ import stat
 import unittest
 import functools
 import itertools
+import time
 
 import IECore
 
@@ -1376,7 +1377,9 @@ class DispatcherTest( GafferTest.TestCase ) :
 		d["framesMode"].setValue( d.FramesMode.CustomRange )
 		d["frameRange"].setValue( "1-1000" )
 
+		t = time.clock()
 		d.dispatch( [ lastTask ] )
+		self.assertLess( time.clock() - t, 4 )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferDispatchTest/LocalDispatcherTest.py
+++ b/python/GafferDispatchTest/LocalDispatcherTest.py
@@ -38,6 +38,7 @@ import os
 import stat
 import shutil
 import unittest
+import time
 
 import IECore
 
@@ -771,11 +772,18 @@ class LocalDispatcherTest( GafferTest.TestCase ) :
 		d["framesMode"].setValue( d.FramesMode.CustomRange )
 		d["frameRange"].setValue( "1-1000" )
 
+		t = time.clock()
 		d.dispatch( [ lastTask ] )
+		self.assertLess( time.clock() - t, 6 )
 
 		d["executeInBackground"].setValue( True )
+
 		d.dispatch( [ lastTask ] )
+
+		t = time.clock()
 		d.jobPool().jobs()[0].kill()
+		self.assertLess( time.clock() - t, 1 )
+
 		d.jobPool().waitForAll()
 
 	def tearDown( self ) :

--- a/python/GafferDispatchTest/LocalDispatcherTest.py
+++ b/python/GafferDispatchTest/LocalDispatcherTest.py
@@ -773,6 +773,11 @@ class LocalDispatcherTest( GafferTest.TestCase ) :
 
 		d.dispatch( [ lastTask ] )
 
+		d["executeInBackground"].setValue( True )
+		d.dispatch( [ lastTask ] )
+		d.jobPool().jobs()[0].kill()
+		d.jobPool().waitForAll()
+
 	def tearDown( self ) :
 
 		GafferTest.TestCase.tearDown( self )

--- a/src/GafferDispatch/Dispatcher.cpp
+++ b/src/GafferDispatch/Dispatcher.cpp
@@ -56,7 +56,9 @@ static InternedString g_immediatePlugName( "immediate" );
 static InternedString g_postTaskIndexBlindDataName( "dispatcher:postTaskIndex" );
 static InternedString g_immediateBlindDataName( "dispatcher:immediate" );
 static InternedString g_executedBlindDataName( "dispatcher:executed" );
+static InternedString g_visitedBlindDataName( "dispatcher:visited" );
 static InternedString g_jobDirectoryContextEntry( "dispatcher:jobDirectory" );
+static IECore::BoolDataPtr g_trueBoolData = new BoolData( true );
 
 size_t Dispatcher::g_firstPlugIndex = 0;
 Dispatcher::PreDispatchSignal Dispatcher::g_preDispatchSignal;
@@ -446,7 +448,7 @@ class Dispatcher::Batcher
 				/// have expressions on it? If so, should we be doing the same before
 				/// calling requiresSequenceExecution()? Or should we instead require that
 				/// they always be constant?
-				batch->blindData()->writable()[g_immediateBlindDataName] = new BoolData( true );
+				batch->blindData()->writable()[g_immediateBlindDataName] = g_trueBoolData;
 			}
 
 			// Remember which batch we stored this task in, for
@@ -674,7 +676,7 @@ void Dispatcher::dispatch( const std::vector<NodePtr> &nodes ) const
 
 void Dispatcher::executeAndPruneImmediateBatches( TaskBatch *batch, bool immediate ) const
 {
-	if( batch->blindData()->member<BoolData>( g_executedBlindDataName ) )
+	if( batch->blindData()->member<BoolData>( g_visitedBlindDataName ) )
 	{
 		return;
 	}
@@ -698,8 +700,10 @@ void Dispatcher::executeAndPruneImmediateBatches( TaskBatch *batch, bool immedia
 	if( immediate )
 	{
 		batch->execute();
-		batch->blindData()->writable()[g_executedBlindDataName] = new BoolData( true );
+		batch->blindData()->writable()[g_executedBlindDataName] = g_trueBoolData;
 	}
+
+	batch->blindData()->writable()[g_visitedBlindDataName] = g_trueBoolData;
 }
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
A series of interleaved per-frame and per-sequence task nodes like this :

```
   perFrameA
     |
   perSequenceA
     |
   perFrameB
     |
   perSequenceB
     |
   ...
```

Leads to a batch graph like this :

```
   pfA1 pfA2 pfA3
     \   |   /
      \  |  /
       \ | /
     sequenceA
       / | \
      /  |  \
     /   |   \
   pfB1 pfB2 pfB3
     \   |   /
      \  |  /
       \ | /
     sequenceB
       / | \
   ...
```

This fan-out/gather pattern generates a DAG with a huge number of unique paths, exposing any omissions in the Dispatcher's pruning of previsited batches by utterly destroying performance.

This PR fixes performance by adding the necessary pruning to all batch graph traversals.