### PR TITLE
ObjectSource, Light: change interface for default set membership

### DIFF
--- a/include/GafferScene/Camera.h
+++ b/include/GafferScene/Camera.h
@@ -69,7 +69,7 @@ class Camera : public ObjectSource
 		virtual void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 		virtual IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const;
 
-		virtual IECore::InternedString standardSetName() const;
+		virtual IECore::ConstInternedStringVectorDataPtr computeStandardSetNames() const;
 
 	private :
 

--- a/include/GafferScene/ClippingPlane.h
+++ b/include/GafferScene/ClippingPlane.h
@@ -57,7 +57,7 @@ class ClippingPlane : public ObjectSource
 		virtual void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 		virtual IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const;
 
-		virtual IECore::InternedString standardSetName() const;
+		virtual IECore::ConstInternedStringVectorDataPtr computeStandardSetNames() const;
 
 };
 

--- a/include/GafferScene/CoordinateSystem.h
+++ b/include/GafferScene/CoordinateSystem.h
@@ -57,8 +57,7 @@ class CoordinateSystem : public ObjectSource
 		virtual void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 		virtual IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const;
 
-		virtual IECore::InternedString standardSetName() const;
-
+		virtual IECore::ConstInternedStringVectorDataPtr computeStandardSetNames() const;
 };
 
 IE_CORE_DECLAREPTR( CoordinateSystem )

--- a/include/GafferScene/Light.h
+++ b/include/GafferScene/Light.h
@@ -66,7 +66,7 @@ class Light : public ObjectSource
 		virtual IECore::ConstCompoundObjectPtr computeAttributes( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
 
 
-		virtual IECore::InternedString standardSetName() const;
+		virtual IECore::ConstInternedStringVectorDataPtr computeStandardSetNames() const;
 
 		/// Must be implemented by derived classes to hash and generate the light to be placed
 		/// in the scene graph.

--- a/include/GafferScene/ObjectSource.h
+++ b/include/GafferScene/ObjectSource.h
@@ -104,9 +104,8 @@ class ObjectSource : public SceneNode
 		virtual void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const = 0;
 		virtual IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const = 0;
 
-		/// May be reimplemented to returns the name of a set the object will always be a part of.
-		/// The value returned must be a constant.
-		virtual IECore::InternedString standardSetName() const;
+		virtual void hashStandardSetNames( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		virtual IECore::ConstInternedStringVectorDataPtr computeStandardSetNames() const;
 
 	private :
 

--- a/src/GafferScene/Camera.cpp
+++ b/src/GafferScene/Camera.cpp
@@ -126,7 +126,9 @@ IECore::ConstObjectPtr Camera::computeSource( const Context *context ) const
 	return result;
 }
 
-IECore::InternedString Camera::standardSetName() const
+IECore::ConstInternedStringVectorDataPtr Camera::computeStandardSetNames() const
 {
-	return g_camerasSetName;
+	IECore::InternedStringVectorDataPtr result = new IECore::InternedStringVectorData();
+	result->writable().push_back( g_camerasSetName );
+	return result;
 }

--- a/src/GafferScene/ClippingPlane.cpp
+++ b/src/GafferScene/ClippingPlane.cpp
@@ -67,7 +67,9 @@ IECore::ConstObjectPtr ClippingPlane::computeSource( const Context *context ) co
 	return new IECore::ClippingPlane();
 }
 
-IECore::InternedString ClippingPlane::standardSetName() const
+IECore::ConstInternedStringVectorDataPtr ClippingPlane::computeStandardSetNames() const
 {
-	return g_clippingPlanesSetName;
+	IECore::InternedStringVectorDataPtr result = new IECore::InternedStringVectorData();
+	result->writable().push_back( g_clippingPlanesSetName );
+	return result;
 }

--- a/src/GafferScene/CoordinateSystem.cpp
+++ b/src/GafferScene/CoordinateSystem.cpp
@@ -67,7 +67,10 @@ IECore::ConstObjectPtr CoordinateSystem::computeSource( const Context *context )
 	return new IECore::CoordinateSystem();
 }
 
-IECore::InternedString CoordinateSystem::standardSetName() const
+IECore::ConstInternedStringVectorDataPtr CoordinateSystem::computeStandardSetNames() const
 {
-	return g_coordinateSystemsSetName;
+	IECore::InternedStringVectorDataPtr result = new IECore::InternedStringVectorData();
+	result->writable().push_back( g_coordinateSystemsSetName );
+	return result;
 }
+

--- a/src/GafferScene/Light.cpp
+++ b/src/GafferScene/Light.cpp
@@ -96,10 +96,6 @@ IECore::ConstObjectPtr Light::computeSource( const Context *context ) const
 	return IECore::NullObject::defaultNullObject();
 }
 
-IECore::InternedString Light::standardSetName() const
-{
-	return g_lightsSetName;
-}
 
 void Light::hashAttributes( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
@@ -136,5 +132,12 @@ IECore::ConstCompoundObjectPtr Light::computeAttributes( const SceneNode::SceneP
 
 	result->members()[lightAttribute] = lightShaders;
 
+	return result;
+}
+
+IECore::ConstInternedStringVectorDataPtr Light::computeStandardSetNames() const
+{
+	IECore::InternedStringVectorDataPtr result = new IECore::InternedStringVectorData();
+	result->writable().push_back( g_lightsSetName );
 	return result;
 }


### PR DESCRIPTION
The idea here is to provide an interface that allows an object to be
part of multiple sets per default. We use this at IE to add lights to
both "__lights" and a set based on the light type.

John, instead of adding that additional plug that we talked about, this
will work without that extra level of indirection. How do you feel about
this solution? I made the corresponding changes in IERendering
already and that seems to work fine. We don't seem to need the plug
currently, but the way the API is changed here would allow us to add
a plug easily if we should need one at some point?
