### PR TITLE
InteractiveRenderUI: use buttons to drive the state

### DIFF
--- a/python/GafferSceneUI/InteractiveRenderUI.py
+++ b/python/GafferSceneUI/InteractiveRenderUI.py
@@ -36,6 +36,61 @@
 
 import Gaffer
 import GafferScene
+import GafferUI
+
+##########################################################################
+# UI for the state plug that allows setting the state through buttons
+##########################################################################
+
+class _StatePlugValueWidget( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plug, *args, **kwargs) :
+
+		row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal )
+		GafferUI.PlugValueWidget.__init__( self, row, plug )
+
+		with row :
+			self.__startPauseButton = GafferUI.Button( image = 'timelinePlay.png' )
+			self.__stopButton = GafferUI.Button( image = 'timelineStop.png' )
+
+			self.__startPauseClickedConnection = self.__startPauseButton.clickedSignal().connect( Gaffer.WeakMethod( self.__startPauseClicked ) )
+			self.__pauseClickedConnection = self.__stopButton.clickedSignal().connect( Gaffer.WeakMethod( self.__stopClicked ) )
+
+		self._updateFromPlug()
+
+	def _updateFromPlug( self ) :
+
+		with self.getContext() :
+			state = self.getPlug().getValue()
+
+			if state == GafferScene.InteractiveRender.State.Running:
+				self.__startPauseButton.setImage( 'timelinePause.png' )
+				self.__stopButton.setEnabled( True )
+			if state == GafferScene.InteractiveRender.State.Paused:
+				self.__startPauseButton.setImage( 'timelinePlay.png' )
+				self.__stopButton.setEnabled( True )
+			if state == GafferScene.InteractiveRender.State.Stopped:
+				self.__startPauseButton.setImage( 'timelinePlay.png' )
+				self.__stopButton.setEnabled( False )
+
+	def hasLabel( self ) :
+		return False
+
+	def __startPauseClicked( self, button ) :
+
+		with self.getContext() :
+			state = self.getPlug().getValue()
+
+			# When setting the plug value here, we deliberately don't use an UndoContext.
+			# Not enabling undo here is done so that users won't accidentally restart/stop their renderings.
+			if not state == GafferScene.InteractiveRender.State.Running:
+				self.getPlug().setValue( GafferScene.InteractiveRender.State.Running )
+			else:
+				self.getPlug().setValue( GafferScene.InteractiveRender.State.Paused )
+
+	def __stopClicked( self, button ) :
+		self.getPlug().setValue( GafferScene.InteractiveRender.State.Stopped )
+
 
 ##########################################################################
 # Metadata for GafferScene.Preview.InteractiveRender node. We intend
@@ -88,12 +143,7 @@ Gaffer.Metadata.registerNode(
 			Turns the rendering on and off, or pauses it.
 			""",
 
-			"preset:Stopped", GafferScene.InteractiveRender.State.Stopped,
-			"preset:Running", GafferScene.InteractiveRender.State.Running,
-			"preset:Paused", GafferScene.InteractiveRender.State.Paused,
-
-			## \todo Make a custom UI with play/pause/stop/restart buttons.
-			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+			"plugValueWidget:type", "GafferSceneUI.InteractiveRenderUI._StatePlugValueWidget",
 
 		],
 
@@ -159,12 +209,7 @@ Gaffer.Metadata.registerNode(
 			The interactive state.
 			""",
 
-			"preset:Stopped", GafferScene.InteractiveRender.State.Stopped,
-			"preset:Running", GafferScene.InteractiveRender.State.Running,
-			"preset:Paused", GafferScene.InteractiveRender.State.Paused,
-
-			## \todo Make a custom UI with play/pause/stop/restart buttons.
-			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+			"plugValueWidget:type", "GafferSceneUI.InteractiveRenderUI._StatePlugValueWidget",
 
 		],
 

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -13,7 +13,7 @@
    height="1000"
    id="svg2"
    version="1.1"
-   inkscape:version="0.47 r22583"
+   inkscape:version="0.48.4 r9939"
    sodipodi:docname="graphics.svg">
   <defs
      id="defs4">
@@ -50,17 +50,17 @@
      inkscape:pageopacity="1"
      inkscape:pageshadow="2"
      inkscape:zoom="8"
-     inkscape:cx="207.54469"
-     inkscape:cy="968.38621"
+     inkscape:cx="339.58867"
+     inkscape:cy="967.17855"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
-     showgrid="true"
+     showgrid="false"
      inkscape:window-width="1703"
      inkscape:window-height="943"
      inkscape:window-x="203"
      inkscape:window-y="25"
      inkscape:window-maximized="0"
-     inkscape:snap-global="true"
+     inkscape:snap-global="false"
      inkscape:snap-nodes="true"
      inkscape:snap-bbox="true"
      inkscape:object-nodes="true"
@@ -241,7 +241,7 @@
          inkscape:flatsided="true"
          inkscape:rounded="0"
          inkscape:randomized="0"
-         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 0,12.37179 z"
+         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
          transform="matrix(0,-0.65333366,0.646633,0,-363.80333,137.72891)" />
       <rect
          style="fill:none;stroke:none"
@@ -271,7 +271,7 @@
          inkscape:flatsided="true"
          inkscape:rounded="0"
          inkscape:randomized="0"
-         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 0,12.37179 z"
+         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
          transform="matrix(0,-0.65333366,0.646633,0,-363.80333,137.7289)" />
       <rect
          style="fill:none;stroke:none"
@@ -289,7 +289,7 @@
        inkscape:export-ydpi="10">
       <path
          transform="matrix(0,-0.65333366,0.646633,0,-363.80333,137.22889)"
-         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 0,12.37179 z"
+         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
          inkscape:randomized="0"
          inkscape:rounded="0"
          inkscape:flatsided="true"
@@ -356,7 +356,7 @@
          inkscape:flatsided="true"
          inkscape:rounded="0"
          inkscape:randomized="0"
-         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 0,12.37179 z"
+         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
          transform="matrix(0,-0.65333366,0.646633,0,-363.80333,137.72889)" />
       <rect
          style="fill:none;stroke:none"
@@ -899,7 +899,7 @@
        height="17"
        width="13"
        id="forExport:timelinePause"
-       style="fill:none;stroke:none" />
+       style="fill:none;stroke:none;fill-opacity:1;stroke-opacity:1" />
     <rect
        style="fill:none;stroke:none"
        id="forExport:timelineStart"
@@ -2746,5 +2746,22 @@
        y="10"
        transform="translate(0,52.362183)"
        inkscape:label="#rect3197" />
+    <rect
+       style="fill:#787878;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1.00011265;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="rect3127-7"
+       width="13.910246"
+       height="13.999775"
+       x="369.4538"
+       y="80.832184"
+       inkscape:label="#rect3127-7" />
+    <rect
+       style="fill:none;stroke:none"
+       id="forExport:timelineStop"
+       width="17"
+       height="17"
+       x="367.95401"
+       y="79.332184"
+       ry="1.8545461"
+       inkscape:label="#rect4590" />
   </g>
 </svg>


### PR DESCRIPTION
Undo currently potentially changes the state of the interactive rendering. This changes that by adding a plugValueWidget that drives that plug using a set of buttons.

@johnhaddon Not sure how you feel about some of the design decisions here. I tend to use namedtuples because it makes the code that uses them more readable. It's a bit overkill in this case. Let me know if there's anything you want me to change or approach completely differently. I added this to the base class because there was a todo tag that indicated that this was the place for it rather than just adding it to the Arnold node. 