### PR TITLE
Simple LightTweaks node

### DIFF
--- a/include/GafferScene/LightTweaks.h
+++ b/include/GafferScene/LightTweaks.h
@@ -1,0 +1,128 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENE_LIGHTTWEAKS_H
+#define GAFFERSCENE_LIGHTTWEAKS_H
+
+#include "Gaffer/StringPlug.h"
+
+#include "GafferScene/SceneElementProcessor.h"
+
+namespace GafferScene
+{
+
+class LightTweaks : public SceneElementProcessor
+{
+
+	public :
+
+		LightTweaks( const std::string &name=defaultName<LightTweaks>() );
+		virtual ~LightTweaks();
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::LightTweaks, LightTweaksTypeId, SceneElementProcessor );
+
+		/// Compound plug type used to represent a tweak.
+		/// Add instances of these to the tweaksPlug() to
+		/// add tweaks.
+		class TweakPlug : public Gaffer::Plug
+		{
+
+			public :
+
+				IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::LightTweaks::TweakPlug, LightTweaksTweakPlugTypeId, Gaffer::Plug );
+
+				TweakPlug( const std::string &tweakName, Gaffer::ValuePlugPtr tweakValuePlug, bool enabled = true );
+				TweakPlug( const std::string &tweakName, const IECore::Data *tweakValue, bool enabled = true );
+				/// Primarily used for serialisation.
+				TweakPlug( const std::string &name=defaultName<TweakPlug>(), Direction direction=In, unsigned flags=Default );
+
+				enum Mode
+				{
+					Replace,
+					Add,
+					Subtract,
+					Multiply
+				};
+
+				Gaffer::StringPlug *namePlug();
+				const Gaffer::StringPlug *namePlug() const;
+
+				Gaffer::BoolPlug *enabledPlug();
+				const Gaffer::BoolPlug *enabledPlug() const;
+
+				Gaffer::IntPlug *modePlug();
+				const Gaffer::IntPlug *modePlug() const;
+
+				template<typename T>
+				T *valuePlug();
+				template<typename T>
+				const T *valuePlug() const;
+
+				virtual bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const;
+				virtual Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
+
+			private :
+
+				void construct( const std::string &tweakName, Gaffer::ValuePlugPtr tweakValuePlug, bool enabled );
+
+		};
+
+		typedef Gaffer::FilteredChildIterator<Gaffer::PlugPredicate<Gaffer::Plug::Invalid, TweakPlug> > TweakPlugIterator;
+		IE_CORE_DECLAREPTR( TweakPlug )
+
+		Gaffer::StringPlug *typePlug();
+		const Gaffer::StringPlug *typePlug() const;
+
+		Gaffer::Plug *tweaksPlug();
+		const Gaffer::Plug *tweaksPlug() const;
+
+		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+
+	protected :
+
+		virtual bool processesAttributes() const;
+		virtual void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		virtual IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputAttributes ) const;
+
+		static size_t g_firstPlugIndex;
+
+};
+
+IE_CORE_DECLAREPTR( LightTweaks )
+
+} // namespace GafferScene
+
+#endif // GAFFERSCENE_LIGHTTWEAKS_H

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -129,6 +129,8 @@ enum TypeId
 	SceneLoopTypeId = 110584,
 	RenderTypeId = 110585,
 	FilterPlugTypeId = 110586,
+	LightTweaksTypeId = 110587,
+	LightTweaksTweakPlugTypeId = 110588,
 
 	PreviewInteractiveRenderTypeId = 110649,
 

--- a/include/GafferSceneBindings/LightTweaksBinding.h
+++ b/include/GafferSceneBindings/LightTweaksBinding.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENEBINDINGS_LIGHTTWEAKSBINDING_H
+#define GAFFERSCENEBINDINGS_LIGHTTWEAKSBINDING_H
+
+namespace GafferSceneBindings
+{
+
+void bindLightTweaks();
+
+} // namespace GafferSceneBindings
+
+#endif // GAFFERSCENEBINDINGS_LIGHTTWEAKSBINDING_H

--- a/python/GafferSceneTest/LightTweaksTest.py
+++ b/python/GafferSceneTest/LightTweaksTest.py
@@ -1,0 +1,112 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferScene
+import GafferSceneTest
+
+class LightTweaksTest( GafferSceneTest.SceneTestCase ) :
+
+	def test( self ) :
+
+		l = GafferSceneTest.TestLight()
+		l["parameters"]["intensity"].setValue( IECore.Color3f( 1 ) )
+
+		t = GafferScene.LightTweaks()
+		t["in"].setInput( l["out"] )
+
+		self.assertSceneValid( t["out"] )
+		self.assertScenesEqual( t["out"], l["out"] )
+		self.assertSceneHashesEqual( t["out"], l["out"] )
+		self.assertEqual( l["out"].attributes( "/light" )["light"][0].parameters["intensity"].value, IECore.Color3f( 1 ) )
+
+		f = GafferScene.PathFilter()
+		f["paths"].setValue( IECore.StringVectorData( [ "/light" ] ) )
+
+		t["filter"].setInput( f["out"] )
+
+		self.assertSceneValid( t["out"] )
+		self.assertScenesEqual( t["out"], l["out"] )
+		self.assertSceneHashesEqual( t["out"], l["out"] )
+
+		intensityTweak = t.TweakPlug( "intensity", IECore.Color3f( 1, 0, 0 ) )
+		t["tweaks"].addChild( intensityTweak )
+
+		self.assertSceneValid( t["out"] )
+
+		self.assertEqual( t["out"].attributes( "/light" )["light"][0].parameters["intensity"].value, IECore.Color3f( 1, 0, 0 ) )
+
+		intensityTweak["value"].setValue( IECore.Color3f( 100 ) )
+		self.assertEqual( t["out"].attributes( "/light" )["light"][0].parameters["intensity"].value, IECore.Color3f( 100 ) )
+
+		intensityTweak["enabled"].setValue( False )
+		self.assertEqual( t["out"].attributes( "/light" )["light"][0].parameters["intensity"].value, IECore.Color3f( 1 ) )
+
+		intensityTweak["enabled"].setValue( True )
+		intensityTweak["mode"].setValue( intensityTweak.Mode.Add )
+		self.assertEqual( t["out"].attributes( "/light" )["light"][0].parameters["intensity"].value, IECore.Color3f( 101 ) )
+
+		intensityTweak["mode"].setValue( intensityTweak.Mode.Subtract )
+		intensityTweak["value"].setValue( IECore.Color3f( 0.1, 0.2, 0.3 ) )
+		self.assertEqual( t["out"].attributes( "/light" )["light"][0].parameters["intensity"].value, IECore.Color3f( 0.9, 0.8, 0.7 ) )
+
+		intensityTweak["mode"].setValue( intensityTweak.Mode.Multiply )
+		l["parameters"]["intensity"].setValue( IECore.Color3f( 2 ) )
+		self.assertEqual( t["out"].attributes( "/light" )["light"][0].parameters["intensity"].value, IECore.Color3f( 0.2, 0.4, 0.6 ) )
+
+		t["type"].setValue( "" )
+		self.assertScenesEqual( t["out"], l["out"] )
+
+	def testSerialisation( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["t"] = GafferScene.LightTweaks()
+		s["t"]["tweaks"].addChild( GafferScene.LightTweaks.TweakPlug( "test", 1.0 ) )
+		s["t"]["tweaks"].addChild( GafferScene.LightTweaks.TweakPlug( "test", IECore.Color3f( 1, 2, 3 ) ) )
+
+		ss = Gaffer.ScriptNode()
+		ss.execute( s.serialise() )
+
+		for i in range( 0, len( s["t"]["tweaks"] ) ) :
+			for n in s["t"]["tweaks"][i].keys() :
+				self.assertEqual( ss["t"]["tweaks"][i][n].getValue(), s["t"]["tweaks"][i][n].getValue() )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -114,6 +114,7 @@ from MeshToPointsTest import MeshToPointsTest
 from InteractiveRenderTest import InteractiveRenderTest
 from FilteredSceneProcessorTest import FilteredSceneProcessorTest
 from ShaderBallTest import ShaderBallTest
+from LightTweaksTest import LightTweaksTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferSceneUI/LightTweaksUI.py
+++ b/python/GafferSceneUI/LightTweaksUI.py
@@ -1,0 +1,351 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import functools
+
+import IECore
+
+import Gaffer
+import GafferUI
+import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.LightTweaks,
+
+	"description",
+	"""
+	Makes modifications to light parameter values.
+	""",
+
+	plugs = {
+
+		"type" : [
+
+			"description",
+			"""
+			The type of light to modify. This is actually the name
+			of an attribute which contains the light shader
+			network.
+			""",
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+			"preset:All", "light *:light",
+			"preset:Appleseed", "as:light",
+			"preset:Arnold", "ai:light",
+			"preset:RenderMan", "ri:light",
+
+		],
+
+		"tweaks" : [
+
+			"description",
+			"""
+			The tweaks to be made to the parameters of the light.
+			Arbitrary numbers of user defined tweaks may be
+			added as children of this plug via the user
+			interface, or using the LightTweaks API via python.
+			""",
+
+			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
+			"layout:customWidget:footer:widgetType", "GafferSceneUI.LightTweaksUI._TweaksFooter",
+			"layout:customWidget:footer:index", -1,
+
+		],
+
+		"tweaks.*.name" : [
+
+			"description",
+			"""
+			The name of the parameter to apply the tweak to.
+			"""
+
+		],
+
+		"tweaks.*.mode" : [
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+			"preset:Replace", GafferScene.LightTweaks.TweakPlug.Mode.Replace,
+			"preset:Add", GafferScene.LightTweaks.TweakPlug.Mode.Add,
+			"preset:Subtract", GafferScene.LightTweaks.TweakPlug.Mode.Subtract,
+			"preset:Multiply", GafferScene.LightTweaks.TweakPlug.Mode.Multiply,
+
+		],
+
+	}
+
+)
+
+class _TweakPlugValueWidget( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, childPlug ) :
+
+		self.__row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 )
+
+		GafferUI.PlugValueWidget.__init__( self, self.__row, childPlug )
+
+
+		nameWidget = GafferUI.StringPlugValueWidget( childPlug["name"] )
+		nameWidget.textWidget()._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() )
+
+		self.__row.append( nameWidget,
+			verticalAlignment = GafferUI.Label.VerticalAlignment.Top
+		)
+
+		self.__row.append(
+			GafferUI.BoolPlugValueWidget(
+				childPlug["enabled"],
+				displayMode = GafferUI.BoolWidget.DisplayMode.Switch
+			),
+			verticalAlignment = GafferUI.Label.VerticalAlignment.Top,
+		)
+
+		self.__row.append( GafferUI.PlugValueWidget.create( childPlug["mode"] ) )
+		self.__row.append( GafferUI.PlugValueWidget.create( childPlug["value"] ), expand = True )
+
+		self._updateFromPlug()
+
+	def setPlug( self, plug ) :
+
+		GafferUI.PlugValueWidget.setPlug( self, plug )
+
+		self.__row[0].setPlug( plug["name"] )
+		self.__row[1].setPlug( plug["enabled"] )
+		self.__row[2].setPlug( plug["mode"] )
+		self.__row[3].setPlug( plug["value"] )
+
+	def hasLabel( self ) :
+
+		return True
+
+	def childPlugValueWidget( self, childPlug, lazy=True ) :
+
+		for w in self.__row :
+			if w.getPlug().isSame( childPlug ) :
+				return w
+
+		return None
+
+	def setReadOnly( self, readOnly ) :
+
+		if readOnly == self.getReadOnly() :
+			return
+
+		GafferUI.PlugValueWidget.setReadOnly( self, readOnly )
+
+		for w in self.__row :
+			w.setReadOnly( readOnly )
+
+	def _updateFromPlug( self ) :
+
+		with self.getContext() :
+			enabled = self.getPlug()["enabled"].getValue()
+
+		for i in ( 0, 2, 3 ) :
+			self.__row[i].setEnabled( enabled )
+
+GafferUI.PlugValueWidget.registerType( GafferScene.LightTweaks.TweakPlug, _TweakPlugValueWidget )
+
+class _TweaksFooter( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plug ) :
+
+		row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal )
+
+		GafferUI.PlugValueWidget.__init__( self, row, plug )
+
+		with row :
+
+				GafferUI.Spacer( IECore.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
+
+				GafferUI.MenuButton(
+					image = "plus.png",
+					hasFrame = False,
+					menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) )
+				)
+
+				GafferUI.Spacer( IECore.V2i( 1 ), IECore.V2i( 999999, 1 ), parenting = { "expand" : True } )
+
+	def _updateFromPlug( self ) :
+
+		self.setEnabled( self._editable() )
+
+	def __menuDefinition( self ) :
+
+		result = IECore.MenuDefinition()
+
+		result.append(
+			"/From Affected",
+			{
+				"subMenu" : Gaffer.WeakMethod( self.__addFromAffectedMenuDefinition )
+			}
+		)
+
+		result.append(
+			"/From Selection",
+			{
+				"subMenu" : Gaffer.WeakMethod( self.__addFromSelectedMenuDefinition )
+			}
+		)
+
+		result.append( "/FromPathsDivider", { "divider" : True } )
+
+		for item in [
+			Gaffer.BoolPlug,
+			Gaffer.FloatPlug,
+			Gaffer.IntPlug,
+			"NumericDivider",
+			Gaffer.StringPlug,
+			"StringDivider",
+			Gaffer.V2iPlug,
+			Gaffer.V3iPlug,
+			Gaffer.V2fPlug,
+			Gaffer.V3fPlug,
+			"VectorDivider",
+			Gaffer.Color3fPlug,
+			Gaffer.Color4fPlug
+		] :
+
+			if isinstance( item, basestring ) :
+				result.append( "/" + item, { "divider" : True } )
+			else :
+				result.append(
+					"/" + item.__name__.replace( "Plug", "" ),
+					{
+						"command" : functools.partial( Gaffer.WeakMethod( self.__addTweak ), "", item ),
+					}
+				)
+
+		return result
+
+	def __addFromAffectedMenuDefinition( self ) :
+
+		paths = []
+		node = self.__lightTweaksNode()
+		if node is not None :
+			pathMatcher = GafferScene.PathMatcher()
+			with self.getContext() :
+				GafferScene.matchingPaths( node["filter"], node["in"], pathMatcher )
+				paths = pathMatcher.paths()
+
+		return self.__addFromPathsMenuDefinition( paths )
+
+	def __addFromSelectedMenuDefinition( self ) :
+
+		paths = []
+		node = self.__lightTweaksNode()
+		if node is not None :
+			paths = self.getContext().get( "ui:scene:selectedPaths", [] )
+			paths = [ p for p in paths if GafferScene.exists( node["in"], p ) ]
+
+		return self.__addFromPathsMenuDefinition( paths )
+
+	def __addFromPathsMenuDefinition( self, paths ) :
+
+		result = IECore.MenuDefinition()
+
+		node = self.__lightTweaksNode()
+		if node is None :
+			result.append(
+				"/No Scene Found", { "active" : False }
+			)
+			return result
+
+		parameters = {}
+		with self.getContext() :
+			attributeNamePatterns = node["type"].getValue()
+			for path in paths :
+				attributes = node["in"].attributes( path )
+				for name, network in attributes.items() :
+					if not Gaffer.matchMultiple( name, attributeNamePatterns ) :
+						continue
+					if not isinstance( network, IECore.ObjectVector ) or not len( network ):
+						continue
+					if not isinstance( network[-1], IECore.Shader ) :
+						continue
+					shader = network[-1]
+					for parameterName, parameterValue in shader.parameters.items() :
+						if parameterName.startswith( "__" ) :
+							continue
+						parameters[parameterName] = parameterValue
+
+		if not len( parameters ) :
+			result.append(
+				"/No Parameters Found", { "active" : False }
+			)
+			return result
+
+		for parameterName in sorted( parameters.keys() ) :
+			result.append(
+				"/" + parameterName,
+				{
+					"command" :	functools.partial(
+						Gaffer.WeakMethod( self.__addTweak ),
+						parameterName, parameters[parameterName]
+					)
+				}
+			)
+
+		return result
+
+	def __lightTweaksNode( self ) :
+
+		# Our plug may not belong to a LightTweaks node
+		# directly. Instead it may have been promoted
+		# elsewhere and be driving a target plug on a
+		# LightTweaksNode.
+
+		def walkOutputs( plug ) :
+
+			if isinstance( plug.node(), GafferScene.LightTweaks ) :
+				return plug.node()
+
+			for output in plug.outputs() :
+				node = walkOutputs( output )
+				if node is not None :
+					return node
+
+		return walkOutputs( self.getPlug() )
+
+	def __addTweak( self, name, plugTypeOrValue ) :
+
+		if isinstance( plugTypeOrValue, IECore.Data ) :
+			plug = GafferScene.LightTweaks.TweakPlug( name, plugTypeOrValue )
+		else :
+			plug = GafferScene.LightTweaks.TweakPlug( name, plugTypeOrValue() )
+
+		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+			self.getPlug().addChild( plug )

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -125,6 +125,7 @@ import FilterProcessorUI
 import MeshToPointsUI
 import RenderUI
 import ShaderBallUI
+import LightTweaksUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/src/GafferScene/LightTweaks.cpp
+++ b/src/GafferScene/LightTweaks.cpp
@@ -258,7 +258,7 @@ void numericTweak( Data *data, PlugType *plug, LightTweaks::TweakPlug::Mode mode
 
 void tweak( Data *data, Plug *plug, LightTweaks::TweakPlug::Mode mode )
 {
-	switch( plug->typeId() )
+	switch( static_cast<Gaffer::TypeId>( plug->typeId() ) )
 	{
 		case FloatPlugTypeId :
 			numericTweak( data, static_cast<const FloatPlug *>( plug ), mode );

--- a/src/GafferScene/LightTweaks.cpp
+++ b/src/GafferScene/LightTweaks.cpp
@@ -1,0 +1,466 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "IECore/Shader.h"
+#include "IECore/SimpleTypedData.h"
+#include "IECore/SplineData.h"
+
+#include "Gaffer/StringAlgo.h"
+#include "Gaffer/CompoundDataPlug.h"
+#include "Gaffer/SplinePlug.h"
+
+#include "GafferScene/LightTweaks.h"
+
+using namespace std;
+using namespace IECore;
+using namespace Gaffer;
+using namespace GafferScene;
+
+//////////////////////////////////////////////////////////////////////////
+// TweakPlug
+//////////////////////////////////////////////////////////////////////////
+
+IE_CORE_DEFINERUNTIMETYPED( LightTweaks::TweakPlug );
+
+LightTweaks::TweakPlug::TweakPlug( const std::string &tweakName, Gaffer::ValuePlugPtr valuePlug, bool enabled )
+	:	Plug( "tweak", In, Default | Dynamic )
+{
+	construct( tweakName, valuePlug, enabled );
+}
+
+LightTweaks::TweakPlug::TweakPlug( const std::string &tweakName, const IECore::Data *value, bool enabled )
+	:	Plug( "tweak", In, Default | Dynamic )
+{
+	construct( tweakName, CompoundDataPlug::createPlugFromData( "value", In, Default | Dynamic, value ), enabled );
+}
+
+LightTweaks::TweakPlug::TweakPlug( const std::string &name, Direction direction, unsigned flags )
+	:	Plug( name, direction, flags )
+{
+}
+
+void LightTweaks::TweakPlug::construct( const std::string &tweakName, Gaffer::ValuePlugPtr valuePlug, bool enabled )
+{
+	addChild( new StringPlug( "name" ) );
+	addChild( new BoolPlug( "enabled", Plug::In, true ) );
+	addChild( new IntPlug( "mode", Plug::In, Replace, Replace, Multiply ) );
+	valuePlug->setName( "value" );
+	valuePlug->setFlags( Dynamic, true );
+	addChild( valuePlug );
+
+	namePlug()->setValue( tweakName );
+	enabledPlug()->setValue( enabled );
+}
+
+Gaffer::StringPlug *LightTweaks::TweakPlug::namePlug()
+{
+	return getChild<StringPlug>( 0 );
+}
+
+const Gaffer::StringPlug *LightTweaks::TweakPlug::namePlug() const
+{
+	return getChild<StringPlug>( 0 );
+}
+
+Gaffer::BoolPlug *LightTweaks::TweakPlug::enabledPlug()
+{
+	return getChild<BoolPlug>( 1 );
+}
+
+const Gaffer::BoolPlug *LightTweaks::TweakPlug::enabledPlug() const
+{
+	return getChild<BoolPlug>( 1 );
+}
+
+Gaffer::IntPlug *LightTweaks::TweakPlug::modePlug()
+{
+	return getChild<IntPlug>( 2 );
+}
+
+const Gaffer::IntPlug *LightTweaks::TweakPlug::modePlug() const
+{
+	return getChild<IntPlug>( 2 );
+}
+
+template<typename T>
+T *LightTweaks::TweakPlug::valuePlug()
+{
+	return getChild<T>( 3 );
+}
+
+template<typename T>
+const T *LightTweaks::TweakPlug::valuePlug() const
+{
+	return getChild<T>( 3 );
+}
+
+bool LightTweaks::TweakPlug::acceptsChild( const Gaffer::GraphComponent *potentialChild ) const
+{
+	if( !Plug::acceptsChild( potentialChild ) )
+	{
+		return false;
+	}
+
+	if(
+		potentialChild->isInstanceOf( StringPlug::staticTypeId() ) &&
+		potentialChild->getName() == "name" &&
+		!getChild<Plug>( "name" )
+	)
+	{
+		return true;
+	}
+	else if(
+		potentialChild->isInstanceOf( BoolPlug::staticTypeId() ) &&
+		potentialChild->getName() == "enabled" &&
+		!getChild<Plug>( "enabled" )
+	)
+	{
+		return true;
+	}
+	else if(
+		potentialChild->isInstanceOf( IntPlug::staticTypeId() ) &&
+		potentialChild->getName() == "mode" &&
+		!getChild<Plug>( "mode" )
+	)
+	{
+		return true;
+	}
+	else if(
+		potentialChild->isInstanceOf( ValuePlug::staticTypeId() ) &&
+		potentialChild->getName() == "value" &&
+		!getChild<Plug>( "value" )
+	)
+	{
+		return true;
+	}
+
+	return false;
+}
+
+Gaffer::PlugPtr LightTweaks::TweakPlug::createCounterpart( const std::string &name, Direction direction ) const
+{
+	PlugPtr result = new TweakPlug( name, direction, getFlags() );
+	for( PlugIterator it( this ); !it.done(); ++it )
+	{
+		result->addChild( (*it)->createCounterpart( (*it)->getName(), direction ) );
+	}
+	return result;
+}
+
+//////////////////////////////////////////////////////////////////////////
+// LightTweaks
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+const char *modeToString( LightTweaks::TweakPlug::Mode mode )
+{
+	switch( mode )
+	{
+		case LightTweaks::TweakPlug::Replace :
+			return "Replace";
+		case LightTweaks::TweakPlug::Add :
+			return "Add";
+		case LightTweaks::TweakPlug::Subtract :
+			return "Subtract";
+		case LightTweaks::TweakPlug::Multiply :
+			return "Multiply";
+		default :
+			return "Invalid";
+	}
+}
+
+template<typename PlugType>
+void basicTweak( Data *data, PlugType *plug, LightTweaks::TweakPlug::Mode mode )
+{
+	if( mode != LightTweaks::TweakPlug::Replace )
+	{
+		throw IECore::Exception( boost::str( boost::format(
+			"%s mode not supported for \"%s\""
+		) % modeToString( mode ) % data->typeName() ) );
+	}
+
+	typedef TypedData<typename PlugType::ValueType> DataType;
+	DataType *typedData = runTimeCast<DataType>( data );
+	if( !typedData )
+	{
+		throw IECore::Exception( boost::str( boost::format(
+			"Plug type \"%s\" does not match parameter type \"%s\""
+		) % plug->typeName() % data->typeName() ) );
+	}
+
+	typedData->writable() = plug->getValue();
+}
+
+template<typename PlugType>
+void numericTweak( Data *data, PlugType *plug, LightTweaks::TweakPlug::Mode mode )
+{
+	typedef TypedData<typename PlugType::ValueType> DataType;
+	DataType *typedData = runTimeCast<DataType>( data );
+	if( !typedData )
+	{
+		throw IECore::Exception( boost::str( boost::format(
+			"Plug type \"%s\" does not match parameter type \"%s\""
+		) % plug->typeName() % data->typeName() ) );
+	}
+
+	const typename PlugType::ValueType value = plug->getValue();
+	switch( mode )
+	{
+		case LightTweaks::TweakPlug::Replace :
+			typedData->writable() = value;
+			break;
+		case LightTweaks::TweakPlug::Add :
+			typedData->writable() += value;
+			break;
+		case LightTweaks::TweakPlug::Subtract :
+			typedData->writable() -= value;
+			break;
+		case LightTweaks::TweakPlug::Multiply :
+			typedData->writable() *= value;
+			break;
+	}
+}
+
+void tweak( Data *data, Plug *plug, LightTweaks::TweakPlug::Mode mode )
+{
+	switch( plug->typeId() )
+	{
+		case FloatPlugTypeId :
+			numericTweak( data, static_cast<const FloatPlug *>( plug ), mode );
+			break;
+		case IntPlugTypeId :
+			numericTweak( data, static_cast<const IntPlug *>( plug ), mode );
+			break;
+		case StringPlugTypeId :
+			basicTweak( data, static_cast<const StringPlug *>( plug ), mode );
+			break;
+		case BoolPlugTypeId :
+			basicTweak( data, static_cast<const BoolPlug *>( plug ), mode );
+			break;
+		case V2iPlugTypeId :
+			numericTweak( data, static_cast<const V2iPlug *>( plug ), mode );
+			break;
+		case V3iPlugTypeId :
+			numericTweak( data, static_cast<const V3iPlug *>( plug ), mode );
+			break;
+		case V2fPlugTypeId :
+			numericTweak( data, static_cast<const V2fPlug *>( plug ), mode );
+			break;
+		case V3fPlugTypeId :
+			numericTweak( data, static_cast<const V3fPlug *>( plug ), mode );
+			break;
+		case Color3fPlugTypeId :
+			numericTweak( data, static_cast<const Color3fPlug *>( plug ), mode );
+			break;
+		case Color4fPlugTypeId :
+			numericTweak( data, static_cast<const Color4fPlug *>( plug ), mode );
+			break;
+		case Box2fPlugTypeId :
+			basicTweak( data, static_cast<const Box2fPlug *>( plug ), mode );
+			break;
+		case Box2iPlugTypeId :
+			basicTweak( data, static_cast<const Box2iPlug *>( plug ), mode );
+			break;
+		case Box3fPlugTypeId :
+			basicTweak( data, static_cast<const Box3fPlug *>( plug ), mode );
+			break;
+		case Box3iPlugTypeId :
+			basicTweak( data, static_cast<const Box3iPlug *>( plug ), mode );
+			break;
+		case SplineffPlugTypeId :
+			basicTweak( data, static_cast<const SplineffPlug *>( plug ), mode );
+			break;
+		case SplinefColor3fPlugTypeId :
+			basicTweak( data, static_cast<const SplinefColor3fPlug *>( plug ), mode );
+			break;
+		case M44fPlugTypeId :
+			basicTweak( data, static_cast<const M44fPlug *>( plug ), mode );
+			break;
+		default :
+			throw IECore::Exception(
+				boost::str( boost::format( "Plug \"%s\" has unsupported type \"%s\"" ) % plug->getName().string() % plug->typeName() )
+			);
+	}
+}
+
+} // namespace
+
+IE_CORE_DEFINERUNTIMETYPED( LightTweaks );
+
+size_t LightTweaks::g_firstPlugIndex = 0;
+
+LightTweaks::LightTweaks( const std::string &name )
+	:	SceneElementProcessor( name, Filter::NoMatch )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+	addChild( new StringPlug( "type", Plug::In, "light *:light" ) );
+	addChild( new Plug( "tweaks" ) );
+
+	// Fast pass-throughs for the things we don't alter.
+	outPlug()->objectPlug()->setInput( inPlug()->objectPlug() );
+	outPlug()->transformPlug()->setInput( inPlug()->transformPlug() );
+	outPlug()->boundPlug()->setInput( inPlug()->boundPlug() );
+}
+
+LightTweaks::~LightTweaks()
+{
+}
+
+Gaffer::StringPlug *LightTweaks::typePlug()
+{
+	return getChild<Gaffer::StringPlug>( g_firstPlugIndex );
+}
+
+const Gaffer::StringPlug *LightTweaks::typePlug() const
+{
+	return getChild<Gaffer::StringPlug>( g_firstPlugIndex );
+}
+
+Gaffer::Plug *LightTweaks::tweaksPlug()
+{
+	return getChild<Gaffer::Plug>( g_firstPlugIndex + 1 );
+}
+
+const Gaffer::Plug *LightTweaks::tweaksPlug() const
+{
+	return getChild<Gaffer::Plug>( g_firstPlugIndex + 1 );
+}
+
+void LightTweaks::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
+{
+	SceneElementProcessor::affects( input, outputs );
+
+	if( tweaksPlug()->isAncestorOf( input ) || input == typePlug() )
+	{
+		outputs.push_back( outPlug()->attributesPlug() );
+	}
+}
+
+bool LightTweaks::processesAttributes() const
+{
+	// Although the base class says that we should return a constant, it should
+	// be OK to return this because it's constant across the hierarchy.
+	return !tweaksPlug()->children().empty();
+}
+
+void LightTweaks::hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	typePlug()->hash( h );
+	for( TweakPlugIterator tIt( tweaksPlug() ); !tIt.done(); ++tIt )
+	{
+		for( ValuePlugIterator vIt( tIt->get() ); !vIt.done(); ++vIt )
+		{
+			(*vIt)->hash( h );
+		}
+	}
+}
+
+IECore::ConstCompoundObjectPtr LightTweaks::computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputAttributes ) const
+{
+	const string type = typePlug()->getValue();
+	if( type.empty() )
+	{
+		return inputAttributes;
+	}
+
+	const Plug *tweaksPlug = this->tweaksPlug();
+	if( tweaksPlug->children().empty() )
+	{
+		return inputAttributes;
+	}
+
+
+	CompoundObjectPtr result = new CompoundObject;
+	const CompoundObject::ObjectMap &in = inputAttributes->members();
+	CompoundObject::ObjectMap &out = result->members();
+	for( CompoundObject::ObjectMap::const_iterator it = in.begin(), eIt = in.end(); it != eIt; ++it )
+	{
+		if( !matchMultiple( it->first, type ) )
+		{
+			out.insert( *it );
+			continue;
+		}
+		const ObjectVector *network = runTimeCast<const ObjectVector>( it->second.get() );
+		if( !network || network->members().empty() )
+		{
+			out.insert( *it );
+			continue;
+		}
+
+		const Shader *lightShader = runTimeCast<const Shader>( network->members().back().get() );
+		if( !lightShader )
+		{
+			out.insert( *it );
+			continue;
+		}
+
+		ObjectVectorPtr tweakedNetwork = new ObjectVector;
+		tweakedNetwork->members() = network->members();
+		ShaderPtr tweakedShader = lightShader->copy();
+		tweakedNetwork->members().back() = tweakedShader;
+
+		for( TweakPlugIterator tIt( tweaksPlug ); !tIt.done(); ++tIt )
+		{
+			if( !(*tIt)->enabledPlug()->getValue() )
+			{
+				continue;
+			}
+			const std::string name = (*tIt)->namePlug()->getValue();
+			if( name.empty() )
+			{
+				continue;
+			}
+
+			Data *parameterValue = tweakedShader->parametersData()->member<Data>( name );
+			if( !parameterValue )
+			{
+				throw IECore::Exception( boost::str( boost::format( "Parameter \"%s\" does not exist" ) % name ) );
+			}
+
+			tweak(
+				parameterValue,
+				(*tIt)->valuePlug<Plug>(),
+				static_cast<TweakPlug::Mode>( (*tIt)->modePlug()->getValue() )
+			);
+		}
+
+		out[it->first] = tweakedNetwork;
+	}
+
+	return result;
+}

--- a/src/GafferSceneBindings/LightTweaksBinding.cpp
+++ b/src/GafferSceneBindings/LightTweaksBinding.cpp
@@ -1,0 +1,154 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "GafferBindings/DependencyNodeBinding.h"
+#include "GafferBindings/PlugBinding.h"
+
+#include "GafferScene/LightTweaks.h"
+
+#include "GafferSceneBindings/LightTweaksBinding.h"
+
+using namespace boost::python;
+using namespace Gaffer;
+using namespace GafferBindings;
+using namespace GafferScene;
+
+namespace
+{
+
+LightTweaks::TweakPlugPtr constructUsingData( const std::string &tweakName, IECore::ConstDataPtr tweakValue, bool enabled )
+{
+	return new LightTweaks::TweakPlug( tweakName, tweakValue.get(), enabled );
+}
+
+std::string maskedTweakPlugRepr( const LightTweaks::TweakPlug *plug, unsigned flagsMask )
+{
+	// The only reason we have a different __repr__ implementation than Gaffer::Plug is
+	// because we can't determine the nested class name from a PyObject.
+	std::string result = "GafferScene.LightTweaks.TweakPlug( \"" + plug->getName().string() + "\", ";
+
+	if( plug->direction()!=Plug::In )
+	{
+		result += "direction = " + PlugSerialiser::directionRepr( plug->direction() ) + ", ";
+	}
+
+	const unsigned flags = plug->getFlags() & flagsMask;
+	if( flags != Plug::Default )
+	{
+		result += "flags = " + PlugSerialiser::flagsRepr( flags ) + ", ";
+	}
+
+	result += ")";
+
+	return result;
+}
+
+std::string tweakPlugRepr( const LightTweaks::TweakPlug *plug )
+{
+	return maskedTweakPlugRepr( plug, Plug::All );
+}
+
+class TweakPlugSerialiser : public PlugSerialiser
+{
+
+	public :
+
+		virtual std::string constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const
+		{
+			return maskedTweakPlugRepr( static_cast<const LightTweaks::TweakPlug *>( graphComponent ), Plug::All & ~Plug::ReadOnly );
+		}
+
+		virtual bool childNeedsConstruction( const Gaffer::GraphComponent *child ) const
+		{
+			// If the parent is dynamic then all the children will need construction.
+			const Plug *parent = child->parent<Plug>();
+			return parent->getFlags( Gaffer::Plug::Dynamic );
+		}
+
+};
+
+} // namespace
+
+void GafferSceneBindings::bindLightTweaks()
+{
+	scope lightTweaksScope = DependencyNodeClass<LightTweaks>();
+
+	scope tweakPlugScope = PlugClass<LightTweaks::TweakPlug>()
+		.def(
+			init<const char *, Plug::Direction, unsigned>(
+				(
+					boost::python::arg_( "name" )=GraphComponent::defaultName<LightTweaks::TweakPlug>(),
+					boost::python::arg_( "direction" )=Plug::In,
+					boost::python::arg_( "flags" )=Plug::Default
+				)
+			)
+		)
+		.def(
+			"__init__",
+			make_constructor(
+				constructUsingData,
+				default_call_policies(),
+				(
+					boost::python::arg_( "tweakName" ),
+					boost::python::arg_( "tweakValuePlug" ),
+					boost::python::arg_( "enabled" )=true
+				)
+			)
+		)
+		.def(
+			init<const std::string &, const ValuePlugPtr, bool>(
+				(
+					boost::python::arg_( "tweakName" ),
+					boost::python::arg_( "tweakValue" ),
+					boost::python::arg_( "enabled" )=true
+				)
+			)
+		)
+		.def( "__repr__", tweakPlugRepr )
+	;
+
+	enum_<LightTweaks::TweakPlug::Mode>( "Mode" )
+		.value( "Replace", LightTweaks::TweakPlug::Replace )
+		.value( "Add", LightTweaks::TweakPlug::Add )
+		.value( "Subtract", LightTweaks::TweakPlug::Subtract )
+		.value( "Multiply", LightTweaks::TweakPlug::Multiply )
+	;
+
+	Serialisation::registerSerialiser( LightTweaks::TweakPlug::staticTypeId(), new TweakPlugSerialiser );
+
+}

--- a/src/GafferSceneModule/GafferSceneModule.cpp
+++ b/src/GafferSceneModule/GafferSceneModule.cpp
@@ -104,6 +104,7 @@
 #include "GafferSceneBindings/PathMatcherDataPlugBinding.h"
 #include "GafferSceneBindings/MeshToPointsBinding.h"
 #include "GafferSceneBindings/FilterPlugBinding.h"
+#include "GafferSceneBindings/LightTweaksBinding.h"
 
 using namespace boost::python;
 using namespace GafferBindings;
@@ -189,5 +190,6 @@ BOOST_PYTHON_MODULE( _GafferScene )
 	bindParameters();
 	bindPathMatcherDataPlug();
 	bindMeshToPoints();
+	bindLightTweaks();
 
 }

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -238,6 +238,7 @@ nodeMenu.append( "/Scene/Attributes/Standard Attributes", GafferScene.StandardAt
 nodeMenu.append( "/Scene/Attributes/Custom Attributes", GafferScene.CustomAttributes, searchText = "CustomAttributes" )
 nodeMenu.append( "/Scene/Attributes/Delete Attributes", GafferScene.DeleteAttributes, searchText = "DeleteAttributes" )
 nodeMenu.append( "/Scene/Attributes/Attribute Visualiser", GafferScene.AttributeVisualiser, searchText = "AttributeVisualiser" )
+nodeMenu.append( "/Scene/Attributes/Light Tweaks", GafferScene.LightTweaks, searchText = "LightTweaks" )
 nodeMenu.append( "/Scene/Filters/Set Filter", GafferScene.SetFilter, searchText = "SetFilter" )
 nodeMenu.append( "/Scene/Filters/Path Filter", GafferScene.PathFilter, searchText = "PathFilter" )
 nodeMenu.append( "/Scene/Filters/Union Filter", GafferScene.UnionFilter, searchText = "UnionFilter" )


### PR DESCRIPTION
This is a simple implementation of a node for applying downstream tweaks to lights. It's basically identical in functionality to the existing Parameters node, but with lights as a target. It might be that this is sufficient for Image Engine's needs for now, if the plan is to box it up to provide an interface more specific to our custom lights. Or it might be that we want to consider these potential additions before merging :

- Custom UI for automatically adding parameters taken from the currently selected light.
- A way of doing modifications using expressions (`oldValue * 2 + .1`) rather than just overwrites.
- Anything else folks would like.