### PR TITLE
PerformanceMonitor for ArnoldRender

### DIFF
--- a/include/Gaffer/Monitor.h
+++ b/include/Gaffer/Monitor.h
@@ -62,6 +62,7 @@ class Monitor : boost::noncopyable
 			public :
 
 				/// Constructing the Scope makes the monitor active.
+				/// If monitor is NULL, the Scope is a no-op.
 				Scope( Monitor *monitor );
 				/// Destruction of the Scope makes the monitor inactive.
 				~Scope();

--- a/src/Gaffer/Monitor.cpp
+++ b/src/Gaffer/Monitor.cpp
@@ -68,11 +68,17 @@ bool Monitor::getActive() const
 Monitor::Scope::Scope( Monitor *monitor )
 	:	m_monitor( monitor )
 {
-	m_monitor->setActive( true );
+	if( m_monitor )
+	{
+		m_monitor->setActive( true );
+	}
 }
 
 Monitor::Scope::~Scope()
 {
-	m_monitor->setActive( false );
+	if( m_monitor )
+	{
+		m_monitor->setActive( false );
+	}
 }
 


### PR DESCRIPTION
The performance monitor switch in the StandardOptions node is meant to turn on a monitor during rendering, but this had not been implemented for the new style of render node used for Arnold rendering. This PR rectifies that.