### PR TITLE
Support looking through lights, round 2

### DIFF
--- a/include/GafferScene/LightToCamera.h
+++ b/include/GafferScene/LightToCamera.h
@@ -1,0 +1,97 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENE_LIGHTTOCAMERA_H
+#define GAFFERSCENE_LIGHTTOCAMERA_H
+
+#include "GafferScene/SceneElementProcessor.h"
+
+namespace Gaffer
+{
+
+IE_CORE_FORWARDDECLARE( StringPlug )
+
+} // namespace Gaffer
+
+namespace GafferScene
+{
+
+class LightToCamera : public SceneElementProcessor
+{
+
+	public :
+
+		LightToCamera( const std::string &name=defaultName<LightToCamera>() );
+		virtual ~LightToCamera();
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::LightToCamera, LightToCameraTypeId, SceneElementProcessor );
+
+		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		virtual bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const;
+
+	protected :
+
+		virtual bool processesAttributes() const;
+		virtual void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		virtual IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputAttributes ) const;
+
+		virtual bool processesObject() const;
+		virtual void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		virtual IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const;
+
+		virtual bool processesTransform() const;
+		virtual void hashProcessedTransform( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		virtual Imath::M44f computeProcessedTransform( const ScenePath &path, const Gaffer::Context *context, const Imath::M44f &inputTransform ) const;
+
+		virtual void hashSetNames( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
+		virtual void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
+
+		virtual IECore::ConstInternedStringVectorDataPtr computeSetNames( const Gaffer::Context *context, const ScenePlug *parent ) const;
+		virtual GafferScene::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const;
+
+
+
+	private :
+
+		static size_t g_firstPlugIndex;
+
+};
+
+IE_CORE_DECLAREPTR( LightToCamera )
+
+} // namespace GafferScene
+
+#endif // GAFFERSCENE_LIGHTTOCAMERA_H

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -132,6 +132,7 @@ enum TypeId
 	LightTweaksTypeId = 110587,
 	LightTweaksTweakPlugTypeId = 110588,
 	CopyOptionsTypeId = 110589,
+	LightToCameraTypeId = 110590,
 
 	PreviewInteractiveRenderTypeId = 110649,
 

--- a/include/GafferSceneBindings/LightToCameraBinding.h
+++ b/include/GafferSceneBindings/LightToCameraBinding.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENEBINDINGS_LIGHTTOCAMERABINDING_H
+#define GAFFERSCENEBINDINGS_LIGHTTOCAMERABINDING_H
+
+namespace GafferSceneBindings
+{
+
+void bindLightToCamera();
+
+} // namespace GafferSceneBindings
+
+#endif // GAFFERSCENEBINDINGS_LIGHTTOCAMERABINDING_H

--- a/python/GafferArnoldUITest/LightToCameraTest.py
+++ b/python/GafferArnoldUITest/LightToCameraTest.py
@@ -1,0 +1,105 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import arnold
+
+import IECore
+import IECoreArnold
+
+import GafferScene
+import GafferSceneTest
+import GafferArnold
+
+# LightToCamera is not Arnold specific, but I'm putting this test somewhere
+# where we already have lights and metadata set up
+class LightToCameraTest( GafferSceneTest.SceneTestCase ) :
+
+	def testBasic( self ) :
+
+		g = GafferScene.Group()
+
+		inputs = []
+		for shader, name in [
+			("spot_light", "spot1"),
+			("spot_light", "spot2"),
+			("distant_light", "distant1"),
+			("skydome_light", "env1"),
+				]:
+			l = GafferArnold.ArnoldLight()
+			l.loadShader( shader )
+			l["name"].setValue( name )
+			inputs.append( l )
+
+		inputs.append( GafferScene.Camera() )
+		for i in inputs:
+			g["in"][-1].setInput( i["out"] )
+
+		f = GafferScene.PathFilter()
+		f['paths'].setValue( IECore.StringVectorData( [ "/group/spot1", "/group/env1", "/group/distant1" ] ) )
+
+		lc = GafferScene.LightToCamera()
+		lc["in"].setInput( g["out"] )
+		lc["filter"].setInput( f["out"] )
+
+		# Test spot to persp cam
+		self.assertEqual( lc["out"].object( "/group/spot1" ).parameters(),IECore.CompoundData({
+			'projection:fov':IECore.FloatData( 65 ),
+			'clippingPlanes':IECore.V2fData( IECore.V2f( 0.01, 100000 ) ),
+			'projection':IECore.StringData( 'perspective' ),
+			'resolutionOverride':IECore.V2iData( IECore.V2i( 512, 512 ) ),
+			'screenWindow':IECore.Box2fData( IECore.Box2f( IECore.V2f( -1, -1 ), IECore.V2f( 1, 1 ) ) )
+		} ) )
+
+		# Test distant to ortho cam
+		self.assertEqual( lc["out"].object( "/group/distant1" ).parameters(),IECore.CompoundData({
+			'clippingPlanes':IECore.V2fData( IECore.V2f( -100000, 100000 ) ),
+			'projection':IECore.StringData( 'orthographic' ),
+			'resolutionOverride':IECore.V2iData( IECore.V2i( 512, 512 ) ),
+			'screenWindow':IECore.Box2fData( IECore.Box2f( IECore.V2f( -1, -1 ), IECore.V2f( 1, 1 ) ) )
+		} ) )
+
+		# Test light with no corresponding camera ( gets default cam )
+		self.assertEqual( lc["out"].object( "/group/env1" ).parameters(),IECore.CompoundData({
+            'projection':IECore.StringData( 'perspective' ),
+            'resolutionOverride':IECore.V2iData( IECore.V2i( 512, 512 ) )
+        } ) )
+
+		self.assertEqual( lc["out"].set( "__lights" ).value.paths(), [ "/group/spot2" ] )
+		self.assertEqual( set( lc["out"].set( "__cameras" ).value.paths() ) ,
+			set( [ "/group/camera", "/group/spot1", "/group/distant1", "/group/env1" ] ) )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferArnoldUITest/__init__.py
+++ b/python/GafferArnoldUITest/__init__.py
@@ -36,6 +36,7 @@
 
 from DocumentationTest import DocumentationTest
 from ArnoldShaderUITest import ArnoldShaderUITest
+from LightToCameraTest import LightToCameraTest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUI/LightToCameraUI.py
+++ b/python/GafferSceneUI/LightToCameraUI.py
@@ -1,0 +1,64 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.LightToCamera,
+
+	"description",
+	"""
+	A node to convert lights into cameras with a field of view matching the cone of the light.
+	Supports spot lights, and for directional lights creates a basic ortho camera.
+	Intended for use in the viewport SceneView, but could also be used if you wished to render
+	through a light.
+	""",
+
+	plugs = {
+
+		"filter" : [
+
+			"description",
+			"""
+			Filter to specify the locations to look for lights to convert.
+			""",
+
+		],
+	}
+
+)

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -127,6 +127,7 @@ import MeshToPointsUI
 import RenderUI
 import ShaderBallUI
 import LightTweaksUI
+import LightToCameraUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/src/GafferScene/Isolate.cpp
+++ b/src/GafferScene/Isolate.cpp
@@ -246,7 +246,7 @@ void Isolate::hashSet( const IECore::InternedString &setName, const Gaffer::Cont
 	// calls to computeSet() and a huge overhead in recomputing
 	// the same sets repeatedly.
 	//
-	// See further comments in FilteredSceneProcessor::affects().
+	// See further comments in acceptsInput()
 	ContextPtr c = filterContext( context );
 	c->remove( ScenePlug::scenePathContextName );
 	Context::Scope s( c.get() );

--- a/src/GafferScene/LightToCamera.cpp
+++ b/src/GafferScene/LightToCamera.cpp
@@ -1,0 +1,502 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "IECore/CompoundData.h"
+#include "IECore/Camera.h"
+#include "IECore/Shader.h"
+#include "IECore/Transform.h"
+#include "OpenEXR/ImathMatrix.h"
+#include "OpenEXR/ImathVec.h"
+#include "GafferScene/LightToCamera.h"
+#include "Gaffer/Metadata.h"
+#include "Gaffer/Context.h"
+#include "boost/algorithm/string.hpp"
+
+using namespace IECore;
+using namespace Gaffer;
+using namespace GafferScene;
+using namespace Imath;
+
+static IECore::InternedString g_lightsSetName( "__lights" );
+static IECore::InternedString g_camerasSetName( "__cameras" );
+
+/// \todo: This stuff should all end up as part of the light accessor API once that exists
+/// In the meantime, I've tried to set it up vaguely similarly to how that will work
+namespace 
+{
+
+template<typename T>
+T parameter( InternedString metadataTarget, const IECore::CompoundData *parameters, InternedString parameterNameMetadata, T defaultValue )
+{
+	ConstStringDataPtr parameterName = Metadata::value<StringData>( metadataTarget, parameterNameMetadata );
+	if( !parameterName )
+	{
+		return defaultValue;
+	}
+
+	typedef IECore::TypedData<T> DataType;
+	if( const DataType *parameterData = parameters->member<DataType>( parameterName->readable() ) )
+	{
+		return parameterData->readable();
+	}
+
+	return defaultValue;
+}
+
+// Return the first light shader found in attributes
+void light( const CompoundObject *attributes, const IECore::CompoundData* &shaderParameters, std::string &metadataTarget )
+{
+	for( IECore::CompoundObject::ObjectMap::const_iterator it = attributes->members().begin();
+		it != attributes->members().end(); it++ )
+	{
+		const std::string &attributeName = it->first.string();
+		if( !( boost::ends_with( attributeName, ":light" ) || attributeName == "light" ) )
+		{
+			continue;
+		}
+
+		const IECore::ObjectVector *shaderVector = IECore::runTimeCast<const IECore::ObjectVector>( it->second.get() );
+		if( !shaderVector || shaderVector->members().empty() )
+		{
+			continue;
+		}
+
+		IECore::InternedString shaderName;
+		const IECore::Shader *shader = IECore::runTimeCast<const IECore::Shader>( shaderVector->members().back().get() );
+		if( !shader )
+		{
+			continue;
+		}
+
+		metadataTarget = attributeName + ":" + shader->getName();
+		shaderParameters = shader->parametersData();
+		return;
+	}
+
+	metadataTarget = "";
+	shaderParameters = NULL;
+	return;
+}
+
+const char *light_type( const IECore::CompoundData *shaderParameters, const std::string &metadataTarget )
+{
+	ConstStringDataPtr type = Metadata::value<StringData>( metadataTarget, "type" );
+	if( !type || !shaderParameters )
+	{
+		return "";
+	}
+
+	return type->readable().c_str();
+}
+
+float light_outerAngle( const IECore::CompoundData *shaderParameters, const std::string &metadataTarget )
+{
+	float coneAngle = parameter<float>( metadataTarget, shaderParameters, "coneAngleParameter", 0.0f );
+	float penumbraAngle = parameter<float>( metadataTarget, shaderParameters, "penumbraAngleParameter", 0.0f );
+
+	if( ConstStringDataPtr angleUnit = Metadata::value<StringData>( metadataTarget, "angleUnit" ) )
+	{
+		if( angleUnit->readable() == "radians" )
+		{
+			coneAngle *= 180.0 / M_PI;
+			penumbraAngle *= 180 / M_PI;
+		}
+	}
+
+	const std::string *penumbraType = NULL;
+	ConstStringDataPtr penumbraTypeData = Metadata::value<StringData>( metadataTarget, "penumbraType" );
+	if( penumbraTypeData )
+	{
+		penumbraType = &penumbraTypeData->readable();
+	}
+
+	float outerAngle = coneAngle;
+
+	// In "inset" or "absolute" modes, the outer angle is just the cone angle.  "outset" needs
+	// adjustment 
+	if( penumbraType && *penumbraType == "outset" )
+	{
+		outerAngle = coneAngle + 2.0f * penumbraAngle;
+	}
+
+	// Match the minimum coneAngle supported by Arnold to avoid special cases
+	outerAngle = std::max( 0.25f, outerAngle );
+
+	return outerAngle;
+}
+
+float light_lensRadius( const IECore::CompoundData *shaderParameters, const std::string &metadataTarget )
+{
+	if( parameter<bool>( metadataTarget, shaderParameters, "lensRadiusEnableParameter", true ) )
+	{
+		return parameter<float>( metadataTarget, shaderParameters, "lensRadiusParameter", 0.0f );
+	}
+	return 0.0f;
+}
+
+float light_focalPointOffset( float lensRadius, float outerAngle )
+{
+	return lensRadius / tan( 0.5f * outerAngle * M_PI / 180.0f );
+}
+
+M44f light_cameraTransform( const IECore::CompoundData *shaderParameters, const std::string &metadataTarget )
+{
+	const char *type = light_type( shaderParameters, metadataTarget );
+
+	if( type && !strcmp( type, "spot" ) )
+	{
+		float lensRadius = light_lensRadius( shaderParameters, metadataTarget );
+		float outerAngle = light_outerAngle( shaderParameters, metadataTarget );
+
+		float focalPointOffset = light_focalPointOffset( lensRadius, outerAngle );
+		M44f transformOffset;
+		transformOffset.setTranslation( V3f( 0.0f, 0.0f, focalPointOffset ) );
+		return transformOffset;
+	}
+	else
+	{
+		return M44f();
+	}
+}
+
+IECore::CameraPtr light_toCamera( const IECore::CompoundData *shaderParameters, const std::string &metadataTarget )
+{
+	IECore::CameraPtr result = new IECore::Camera();
+	const char *type = light_type( shaderParameters, metadataTarget );
+
+
+	float screenWindowScale = 1.0f;
+	if( type && !strcmp( type, "distant" ) )
+	{
+		const float locatorScale = parameter<float>( metadataTarget, shaderParameters, "locatorScaleParameter", 1 );
+		
+		result->parameters()["projection"] = new StringData( "orthographic" );
+		result->parameters()["clippingPlanes"] = new V2fData( V2f( -100000, 100000 ) );
+		screenWindowScale = locatorScale;
+	}
+	else if( type && !strcmp( type, "spot" ) )
+	{
+		float lensRadius = light_lensRadius( shaderParameters, metadataTarget );
+		float outerAngle = light_outerAngle( shaderParameters, metadataTarget );
+
+		float focalPointOffset = light_focalPointOffset( lensRadius, outerAngle );
+
+		// Set clipping plane to cover the area in front of the spot, with small adjustments
+		// to make sure that we don't go under 0.01 in near clip to preserve depth range,
+		// and we keep the near clip slightly past the origin of the light so we don't see
+		// the light's color indicator when looking through it in the viewport
+		result->parameters()["clippingPlanes"] = new V2fData( V2f( std::max( focalPointOffset + 0.0001f, 0.01f ), 100000 ) );
+		result->parameters()["projection"] = new StringData( "perspective" );
+		result->parameters()["projection:fov"] = new FloatData( outerAngle );
+	}
+	else
+	{
+		return NULL;
+	}
+
+	// Hardcode resolution to some sort of square by default, interface for selecting resolution
+	// not yet decided, as per John
+	result->parameters()["resolutionOverride"] = new V2iData( V2i( 512, 512 ) );
+	Box2f screenWindow( screenWindowScale * V2f( -1.0f ), screenWindowScale * V2f( 1.0f ) );
+	result->parameters()["screenWindow"] = new Box2fData( screenWindow );
+
+	return result;
+}
+
+} // namespace
+
+IE_CORE_DEFINERUNTIMETYPED( LightToCamera );
+
+size_t LightToCamera::g_firstPlugIndex = 0;
+
+LightToCamera::LightToCamera( const std::string &name )
+	:	SceneElementProcessor( name, GafferScene::Filter::NoMatch )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+
+	// Fast pass-throughs for things we don't modify
+	outPlug()->boundPlug()->setInput( inPlug()->boundPlug() );
+
+	// We do modify sets
+	outPlug()->setNamesPlug()->setInput( NULL );
+	outPlug()->setPlug()->setInput( NULL );
+}
+
+LightToCamera::~LightToCamera()
+{
+}
+
+void LightToCamera::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
+{
+	SceneElementProcessor::affects( input, outputs );
+
+	if( input == inPlug()->attributesPlug() )
+	{
+		outputs.push_back( outPlug()->objectPlug() );
+		outputs.push_back( outPlug()->transformPlug() );
+		outputs.push_back( outPlug()->setPlug() );
+		outputs.push_back( outPlug()->setNamesPlug() );
+	}
+	else if( input == filterPlug() )
+	{
+		outputs.push_back( outPlug()->setPlug() );
+		outputs.push_back( outPlug()->setNamesPlug() );
+	}
+}
+
+bool LightToCamera::acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const
+{
+	if( !SceneElementProcessor::acceptsInput( plug, inputPlug ) )
+	{
+		return false;
+	}
+
+	if( plug == filterPlug() )
+	{
+		if( const Filter *filter = runTimeCast<const Filter>( inputPlug->source<Plug>()->node() ) )
+		{
+			if(
+				filter->sceneAffectsMatch( inPlug(), inPlug()->boundPlug() ) ||
+				filter->sceneAffectsMatch( inPlug(), inPlug()->transformPlug() ) ||
+				filter->sceneAffectsMatch( inPlug(), inPlug()->attributesPlug() ) ||
+				filter->sceneAffectsMatch( inPlug(), inPlug()->objectPlug() ) ||
+				filter->sceneAffectsMatch( inPlug(), inPlug()->childNamesPlug() )
+			)
+			{
+				// We make a single call to filterHash() in hashSet(), to account for
+				// the fact that the filter is used in remapping sets. This wouldn't
+				// work for filter types which actually vary based on data within the
+				// scene hierarchy, because then multiple calls would be necessary.
+				// We could make more calls here, but that would be expensive.
+				/// \todo In an ideal world we'd be able to compute a hash for the
+				/// filter across a whole hierarchy.
+				return false;
+			}
+		}
+	}
+
+	return true;
+}
+
+
+bool LightToCamera::processesObject() const
+{
+	return true;
+}
+
+void LightToCamera::hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	inPlug()->attributesPlug()->hash( h );
+}
+
+IECore::ConstObjectPtr LightToCamera::computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const
+{
+	const IECore::CompoundData* shaderParameters;
+	std::string metadataTarget;
+	light( inPlug()->attributesPlug()->getValue().get(), shaderParameters, metadataTarget );
+	IECore::ConstCameraPtr camera = NULL;
+	if( shaderParameters )
+	{
+		camera = light_toCamera( shaderParameters, metadataTarget );
+	}
+
+	if( camera )
+	{
+		return camera;
+	}
+	else
+	{
+		IECore::CameraPtr defaultCamera = new IECore::Camera();
+		defaultCamera->parameters()["projection"] = new StringData( "perspective" );
+		defaultCamera->parameters()["resolutionOverride"] = new V2iData( V2i( 512, 512 ) );
+		return defaultCamera;
+	}
+}
+
+bool LightToCamera::processesTransform() const
+{
+	return true;
+}
+
+void LightToCamera::hashProcessedTransform( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	inPlug()->attributesPlug()->hash( h );
+}
+
+M44f LightToCamera::computeProcessedTransform( const ScenePath &path, const Gaffer::Context *context, const M44f &inputTransform ) const
+{
+	const IECore::CompoundData* shaderParameters;
+	std::string metadataTarget;
+	light( inPlug()->attributesPlug()->getValue().get(), shaderParameters, metadataTarget );
+	IECore::ConstCameraPtr camera = NULL;
+	if( shaderParameters )
+	{
+		return light_cameraTransform( shaderParameters, metadataTarget ) * inputTransform;
+	}
+
+	return inputTransform;
+}
+
+bool LightToCamera::processesAttributes() const
+{
+	return true;
+}
+
+void LightToCamera::hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	// Attributes depend only on input attributes
+}
+	
+
+IECore::ConstCompoundObjectPtr LightToCamera::computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputAttributes ) const
+{
+	CompoundObjectPtr result = new CompoundObject;
+	for( CompoundObject::ObjectMap::const_iterator it = inputAttributes->members().begin(), eIt = inputAttributes->members().end(); it != eIt; ++it )
+	{
+		const std::string &attributeName = it->first.string();
+		if( !( boost::ends_with( attributeName, ":light" ) || attributeName == "light" ) )
+		{
+			result->members()[it->first] = it->second;
+		}
+	}
+
+	return result;
+}
+
+void LightToCamera::hashSetNames( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
+{
+	SceneElementProcessor::hashSetNames( context, parent, h );
+	// We always just add a __cameras set if it doesn't yet exist, without spending time checking
+	// whether it will be non-empty ( usually there will already be a __cameras set anyway )
+}
+
+
+IECore::ConstInternedStringVectorDataPtr LightToCamera::computeSetNames( const Gaffer::Context *context, const ScenePlug *parent ) const
+{
+	ConstInternedStringVectorDataPtr inputSetNamesData = inPlug()->setNamesPlug()->getValue();
+	const std::vector<InternedString> &inNames = inputSetNamesData->readable();
+
+	if( std::find( inNames.begin(), inNames.end(), g_camerasSetName ) != inNames.end() )
+	{
+		return inputSetNamesData;
+	}
+
+	InternedStringVectorDataPtr resultData = inputSetNamesData->copy();
+	resultData->writable().push_back( g_camerasSetName );
+	return resultData;
+}
+
+void LightToCamera::hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
+{
+	if( setName != g_camerasSetName && setName != g_lightsSetName )
+	{
+		h = inPlug()->setPlug()->hash();
+		return;
+	}
+
+	SceneElementProcessor::hashSet( setName, context, parent, h );
+	inPlug()->setPlug()->hash( h );
+
+
+	// This setup is copied from Prune
+
+	// The sets themselves do not depend on the "scene:path"
+	// context entry - the whole point is that they're global.
+	// However, the PathFilter is dependent on scene:path, so
+	// we must remove the path before hashing in the filter in
+	// case we're computed from multiple contexts with different
+	// paths (from a SetFilter for instance). If we didn't do this,
+	// our different hashes would lead to huge numbers of redundant
+	// calls to computeSet() and a huge overhead in recomputing
+	// the same sets repeatedly.
+	//
+	// See further comments in acceptsInput
+	ContextPtr c = filterContext( context );
+	c->remove( ScenePlug::scenePathContextName );
+	Context::Scope s( c.get() );
+	filterPlug()->hash( h );
+}
+
+GafferScene::ConstPathMatcherDataPtr LightToCamera::computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const
+{
+	ConstPathMatcherDataPtr inputSetData = inPlug()->setPlug()->getValue();
+
+	bool isLightSet = setName == g_lightsSetName;
+	bool isCameraSet = setName == g_camerasSetName;
+	if( !( isLightSet || isCameraSet ) )
+	{
+		return inputSetData;
+	}
+
+	ConstPathMatcherDataPtr lightSetData;
+	if( isLightSet )
+	{
+		lightSetData = inputSetData;
+	}
+	else
+	{
+		lightSetData = inPlug()->set( g_lightsSetName );
+	}
+
+	const PathMatcher &lightSet = lightSetData->readable();
+
+
+	PathMatcherDataPtr outputSetData = inputSetData->copy();
+	PathMatcher &outputSet = outputSetData->writable();
+
+	ContextPtr tmpContext = filterContext( context );
+	Context::Scope scopedContext( tmpContext.get() );
+
+	for( PathMatcher::RawIterator pIt = lightSet.begin(), peIt = lightSet.end(); pIt != peIt; ++pIt )
+	{
+		tmpContext->set( ScenePlug::scenePathContextName, *pIt );
+		const int m = filterPlug()->getValue();
+		if( m & Filter::ExactMatch )
+		{
+			if( isLightSet )
+			{
+				outputSet.removePath( *pIt );
+			}
+			else
+			{
+				outputSet.addPath( *pIt );
+			}
+		}
+	}
+
+	return outputSetData;
+}
+

--- a/src/GafferScene/Prune.cpp
+++ b/src/GafferScene/Prune.cpp
@@ -247,7 +247,7 @@ void Prune::hashSet( const IECore::InternedString &setName, const Gaffer::Contex
 	// calls to computeSet() and a huge overhead in recomputing
 	// the same sets repeatedly.
 	//
-	// See further comments in FilteredSceneProcessor::affects().
+	// See further comments in acceptsInput()
 	ContextPtr c = filterContext( context );
 	c->remove( ScenePlug::scenePathContextName );
 	Context::Scope s( c.get() );

--- a/src/GafferSceneBindings/LightToCameraBinding.cpp
+++ b/src/GafferSceneBindings/LightToCameraBinding.cpp
@@ -1,0 +1,46 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferBindings/DependencyNodeBinding.h"
+
+#include "GafferScene/LightToCamera.h"
+
+#include "GafferSceneBindings/LightToCameraBinding.h"
+
+void GafferSceneBindings::bindLightToCamera()
+{
+	GafferBindings::DependencyNodeClass<GafferScene::LightToCamera>();
+}

--- a/src/GafferSceneModule/GafferSceneModule.cpp
+++ b/src/GafferSceneModule/GafferSceneModule.cpp
@@ -105,6 +105,7 @@
 #include "GafferSceneBindings/MeshToPointsBinding.h"
 #include "GafferSceneBindings/FilterPlugBinding.h"
 #include "GafferSceneBindings/LightTweaksBinding.h"
+#include "GafferSceneBindings/LightToCameraBinding.h"
 
 using namespace boost::python;
 using namespace GafferBindings;
@@ -191,5 +192,6 @@ BOOST_PYTHON_MODULE( _GafferScene )
 	bindPathMatcherDataPlug();
 	bindMeshToPoints();
 	bindLightTweaks();
+	bindLightToCamera();
 
 }

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -229,6 +229,7 @@ nodeMenu.append( "/Scene/Object/Delete Primitive Variables", GafferScene.DeleteP
 nodeMenu.append( "/Scene/Object/Mesh Type", GafferScene.MeshType, searchText = "MeshType" )
 nodeMenu.append( "/Scene/Object/Points Type", GafferScene.PointsType, searchText = "PointsType" )
 nodeMenu.append( "/Scene/Object/Mesh To Points", GafferScene.MeshToPoints, searchText = "MeshToPoints" )
+nodeMenu.append( "/Scene/Object/Light To Camera", GafferScene.LightToCamera, searchText = "LightToCamera" )
 nodeMenu.append( "/Scene/Object/Map Projection", GafferScene.MapProjection, searchText = "MapProjection" )
 nodeMenu.append( "/Scene/Object/Map Offset", GafferScene.MapOffset, searchText = "MapOffset"  )
 nodeMenu.append( "/Scene/Object/Parameters", GafferScene.Parameters )


### PR DESCRIPTION
Started trying out John's suggestion on #1830 

Looks like it's basically working.  The LightToCamera node adds camera objects on lights, and adjusts transforms to get the projections right ( still need to set clipping planes properly ).

Next step is how would this actually connect up to the scene view?  We wouldn't want to actually render this scene with extra cameras added to it and transforms adjusted, so we would need to merge the camera we want to render with back into the scene.

One possibility:  use a Group node to group the whole scene into a __cameraRoot group, set it's visibility to false, and then parent it back to /.  Then the scene view just needs to prepend /__cameraRoot on the front of the camera path, and it will pick up an accurate camera if you give it a light.

Possible issues with this approach:
* Requires support for rendering from invisible camera ( currently works fine with GL view, and I think we decided that the long term convention was going to be that rendering from invisible cameras is OK? )
* Andrew thinks it's horrifying to have an extra copy of the scene under __cameraRoot in an internal processing network in the scene view.  I'm not sure if it's horrifying - I feel like relying on lazy evaluation to mean that we will just pick out the camera path we're interested in without evaluating extra stuff might be a gaffery thing to do?  It would be completely invisible to users anyway.
* When looking through a light, you still want to see the light viewport visualiser ( so you can see penumbra angle at least, and more stuff on the IE visualisers ), so I would have to modify the way that SceneView::LookThrough::updateLookThroughCamera() sets m_view->hideFilter().  I'm not quite sure why this was needed in the first place, the camera visualiser doesn't seem to show up when the view location is right at its origin anyway.  Maybe I need to treat objects in the __lights set differently?

Or maybe you've got a way better idea how this is all supposed to work?  Andrew suggested adding cameras as children of the lights instead of replacing them - I'm really hoping that if I need to do hierarchy manipulation, it will be doable using existing Gaffer nodes rather than implementing custom hierarchy manipulation.
