### PR TITLE
Arnold backend : Support direct assignment of "osl:shader" attributes.

### DIFF
--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -344,6 +344,7 @@ IECore::InternedString g_lightShaderAttributeName( "light" );
 IECore::InternedString g_doubleSidedAttributeName( "doubleSided" );
 
 IECore::InternedString g_oslSurfaceShaderAttributeName( "osl:surface" );
+IECore::InternedString g_oslShaderAttributeName( "osl:shader" );
 
 IECore::InternedString g_cameraVisibilityAttributeName( "ai:visibility:camera" );
 IECore::InternedString g_shadowVisibilityAttributeName( "ai:visibility:shadow" );
@@ -499,6 +500,7 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 
 			const IECore::ObjectVector *surfaceShaderAttribute = attribute<IECore::ObjectVector>( g_arnoldSurfaceShaderAttributeName, attributes );
 			surfaceShaderAttribute = surfaceShaderAttribute ? surfaceShaderAttribute : attribute<IECore::ObjectVector>( g_oslSurfaceShaderAttributeName, attributes );
+			surfaceShaderAttribute = surfaceShaderAttribute ? surfaceShaderAttribute : attribute<IECore::ObjectVector>( g_oslShaderAttributeName, attributes );
 			surfaceShaderAttribute = surfaceShaderAttribute ? surfaceShaderAttribute : attribute<IECore::ObjectVector>( g_surfaceShaderAttributeName, attributes );
 			if( surfaceShaderAttribute )
 			{


### PR DESCRIPTION
This makes it possible to replace Appleseed when rendering OSL shader balls using the following config :

```
import GafferSceneUI
import GafferArnold

GafferSceneUI.ShaderView.registerRenderer( "osl", GafferArnold.InteractiveArnoldRender )
GafferSceneUI.ShaderView.registerScene( "osl", "Default", GafferArnold.ArnoldShaderBall )
```