### PR TITLE
ShaderView improvements

### DIFF
--- a/include/GafferSceneUI/ShaderView.h
+++ b/include/GafferSceneUI/ShaderView.h
@@ -92,6 +92,7 @@ class ShaderView : public GafferImageUI::ImageView
 		void plugInputChanged( Gaffer::Plug *plug );
 
 		void updateRenderer();
+		void updateRendererContext();
 		void updateRendererState();
 		void updateScene();
 

--- a/include/GafferSceneUI/ShaderView.h
+++ b/include/GafferSceneUI/ShaderView.h
@@ -86,10 +86,14 @@ class ShaderView : public GafferImageUI::ImageView
 
 	private :
 
+		typedef std::pair<std::string, std::string> PrefixAndName;
+		typedef std::map<PrefixAndName, Gaffer::NodePtr> Scenes;
+
 		void viewportVisibilityChanged();
 
 		void plugSet( Gaffer::Plug *plug );
 		void plugInputChanged( Gaffer::Plug *plug );
+		void sceneRegistrationChanged( const PrefixAndName &prefixAndName );
 
 		void updateRenderer();
 		void updateRendererContext();
@@ -101,8 +105,6 @@ class ShaderView : public GafferImageUI::ImageView
 		Gaffer::NodePtr m_renderer;
 		std::string m_rendererShaderPrefix;
 
-		typedef std::pair<std::string, std::string> PrefixAndName;
-		typedef std::map<PrefixAndName, Gaffer::NodePtr> Scenes;
 		Scenes m_scenes;
 		Gaffer::NodePtr m_scene;
 		PrefixAndName m_scenePrefixAndName;

--- a/python/GafferArnold/ArnoldShaderBall.py
+++ b/python/GafferArnold/ArnoldShaderBall.py
@@ -67,6 +67,11 @@ class ArnoldShaderBall( GafferScene.ShaderBall ) :
 		self["__arnoldOptions"]["options"]["aaSamples"]["enabled"].setValue( True )
 		self["__arnoldOptions"]["options"]["aaSamples"]["value"].setValue( 3 )
 
+		self.addChild(
+			self["__arnoldOptions"]["options"]["threads"].createCounterpart( "threads", Gaffer.Plug.Direction.In )
+		)
+		self["__arnoldOptions"]["options"]["threads"].setInput( self["threads"] )
+
 		self._outPlug().setInput( self["__arnoldOptions"]["out"] )
 
 IECore.registerRunTimeTyped( ArnoldShaderBall, typeName = "GafferArnold::ArnoldShaderBall" )

--- a/python/GafferArnoldUI/ArnoldShaderBallUI.py
+++ b/python/GafferArnoldUI/ArnoldShaderBallUI.py
@@ -61,7 +61,20 @@ Gaffer.Metadata.registerNode(
 			"pathPlugValueWidget:valid", True,
 			"pathPlugValueWidget:bookmarks", "texture",
 
-		]
+		],
+
+		"threads" : [
+
+			"description",
+			"""
+			The number of threads used by Arnold to render the
+			shader ball. A value of 0 uses all cores, and negative
+			values reserve cores for other uses - to be used by
+			the rest of the UI for instance.
+			"""
+
+		],
 
 	}
+
 )

--- a/python/GafferSceneUITest/ShaderViewTest.py
+++ b/python/GafferSceneUITest/ShaderViewTest.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import functools
+
 import IECore
 
 import Gaffer
@@ -162,6 +164,35 @@ class ShaderViewTest( GafferUITest.TestCase ) :
 		self.assertTrue( isinstance( sceneB, GafferScene.ShaderBall ) )
 		self.assertFalse( sceneA.isSame( sceneB ) )
 
+	def testReregisterScene( self ) :
+
+		def shaderBallCreator( resolution ) :
+
+			result = GafferScene.ShaderBall()
+			result["resolution"].setValue( resolution )
+
+			return result
+
+		GafferSceneUI.ShaderView.registerScene( "test", "Default", functools.partial( shaderBallCreator, 16 ) )
+
+		shader = GafferSceneTest.TestShader()
+		shader["type"].setValue( "test:surface" )
+		shader["name"].setValue( "test" )
+
+		view = GafferUI.View.create( shader["out"] )
+		scene1 = view.scene()
+		self.assertEqual( view.scene()["resolution"].getValue(), 16 )
+
+		GafferSceneUI.ShaderView.registerScene( "test", "Default", functools.partial( shaderBallCreator, 32 ) )
+		self.assertFalse( view.scene().isSame( scene1 ) )
+		self.assertEqual( view.scene()["resolution"].getValue(), 32 )
+
+		GafferSceneUI.ShaderView.registerScene( "test", "HiRes", functools.partial( shaderBallCreator, 2048 ) )
+		view["scene"].setValue( "HiRes" )
+		self.assertEqual( view.scene()["resolution"].getValue(), 2048 )
+
+		GafferSceneUI.ShaderView.registerScene( "test", "HiRes", functools.partial( shaderBallCreator, 4096 ) )
+		self.assertEqual( view.scene()["resolution"].getValue(), 4096 )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/GadgetWidgetTest.py
+++ b/python/GafferUITest/GadgetWidgetTest.py
@@ -1,0 +1,70 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import GafferUI
+import GafferUITest
+
+class GadgetWidgetTest( GafferUITest.TestCase ) :
+
+	def testViewportVisibility( self ) :
+
+		with GafferUI.Window() as w :
+			gw = GafferUI.GadgetWidget()
+
+		vg1 = gw.getViewportGadget()
+
+		self.assertFalse( gw.visible() )
+		self.assertFalse( vg1.visible() )
+
+		w.setVisible( True )
+		self.assertTrue( gw.visible() )
+		self.assertTrue( vg1.visible() )
+
+		vg2 = GafferUI.ViewportGadget()
+		self.assertFalse( vg2.visible() )
+
+		gw.setViewportGadget( vg2 )
+		self.assertTrue( vg2.visible() )
+		self.assertFalse( vg1.visible() )
+
+		w.setVisible( False )
+		self.assertFalse( vg1.visible() )
+		self.assertFalse( vg2.visible() )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferUITest/__init__.py
+++ b/python/GafferUITest/__init__.py
@@ -106,6 +106,7 @@ from ReferenceUITest import ReferenceUITest
 from CompoundDataPlugValueWidgetTest import CompoundDataPlugValueWidgetTest
 from GraphGadgetTest import GraphGadgetTest
 from MenuBarTest import MenuBarTest
+from GadgetWidgetTest import GadgetWidgetTest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferUI/ViewportGadget.cpp
+++ b/src/GafferUI/ViewportGadget.cpp
@@ -67,6 +67,8 @@ ViewportGadget::ViewportGadget( GadgetPtr primaryChild )
 	  m_cameraEditable( true ),
 	  m_dragTracking( false )
 {
+	// Viewport visibility is managed by GadgetWidgets,
+	setVisible( false );
 
 	setPrimaryChild( primaryChild );
 

--- a/startup/gui/shaderView.py
+++ b/startup/gui/shaderView.py
@@ -54,4 +54,15 @@ with IECore.IgnoredExceptions( ImportError ) :
 
 	import GafferArnold
 	GafferSceneUI.ShaderView.registerRenderer( "ai", GafferArnold.InteractiveArnoldRender )
-	GafferSceneUI.ShaderView.registerScene( "ai", "Default", GafferArnold.ArnoldShaderBall )
+
+	def __arnoldShaderBall() :
+
+		result = GafferArnold.ArnoldShaderBall()
+
+		# Reserve some cores for the rest of the UI
+		result["threads"]["enabled"].setValue( True )
+		result["threads"]["value"].setValue( -3 )
+
+		return result
+
+	GafferSceneUI.ShaderView.registerScene( "ai", "Default", __arnoldShaderBall )


### PR DESCRIPTION
This improves UI responsiveness when viewing a shader ball for the first time. When this happens, there can be a short delay while the renderer starts up, but (at least for Arnold) this occurs on the background rendering thread. Unfortunately we were performing redundant scene updates immediately after requesting startup, and to perform an update we need to pause the renderer, which means requesting an abort from the UI thread and then waiting to join the background rendering thread. This locked the main thread until the renderer had started up.

Eliminating the redundant updates doesn't make the renderer start up any faster, but does at least mean that the main UI thread is responsive in the meantime.