### PR TITLE
FilterPlug: Fix compatibility with legacy SubGraphs and Dots

### DIFF
--- a/python/GafferSceneTest/FilterSwitchTest.py
+++ b/python/GafferSceneTest/FilterSwitchTest.py
@@ -212,5 +212,22 @@ class FilterSwitchTest( GafferSceneTest.SceneTestCase ) :
 
 		s["i"]["filter"].setInput( s["s"]["out"] )
 
+	def testCompatibilityWithIntPlugs( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["p"] = GafferScene.PathFilter()
+
+		s["d"] = Gaffer.Dot()
+		s["d"].setup( Gaffer.IntPlug() )
+		s["d"]["in"].setInput( s["p"]["out"] )
+		s["s"] = GafferScene.FilterSwitch()
+		s["s"]["in"][0].setInput( s["d"]["out"] )
+
+		s["b"] = Gaffer.Box()
+		s["b"]["filter"] = Gaffer.IntPlug()
+		s["b"]["filter"].setInput( s["p"]["out"] )
+		s["b"]["s"] = GafferScene.FilterSwitch()
+		s["b"]["s"]["in"][0].setInput( s["b"]["filter"] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/FilterPlug.cpp
+++ b/src/GafferScene/FilterPlug.cpp
@@ -86,8 +86,9 @@ bool FilterPlug::acceptsInput( const Gaffer::Plug *input ) const
 	/// \todo Remove this compatibility for version 1.0.0.0?
 	if( runTimeCast<const IntPlug>( input ) )
 	{
-		const Node *n = input->source<Plug>()->node();
-		if( runTimeCast<const SubGraph>( n ) || runTimeCast<const Dot>( n ) )
+		const Plug *p = input->source<Plug>();
+		const Node *n = p->node();
+		if( runTimeCast<const FilterPlug>( p ) || runTimeCast<const SubGraph>( n ) || runTimeCast<const Dot>( n ) )
 		{
 			return true;
 		}


### PR DESCRIPTION
Note this causes a failure in UnionFilterTest which was explicitly ensuring these connections can't be made.

I'm not sure what you think about this @johnhaddon ... the problem seems to come up because we have a bunch of published tools with filters routed through Dots, and the way Dots are serialized into the files means that the `dot['out'].setInput( dot['in'] )` call gets rejected...

My change here seemed like the simplest workaround, though it obviously breaks that UnionFilter test. Maybe a better solution would be some sort of childAdded connection for Dots that makes the internal connection occur earlier? We'd still be stuck with the problem my new test case is pointing out, which is that you can't plug the output of an Int-Dot with a Filter source into anything...