### PR TITLE
Docs at IE

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -372,7 +372,8 @@ def checkSphinx( context ) :
 
 conf = Configure( env, custom_tests = { "checkInkscape" : checkInkscape, "checkSphinx" : checkSphinx } )
 
-if not conf.checkInkscape():
+haveInkscape = conf.checkInkscape()
+if not haveInkscape and env["INKSCAPE"] != "disableGraphics" :
 	print 'Inkscape is not installed!'
 	Exit(1)
 
@@ -989,15 +990,21 @@ def buildGraphics( target, source, env ) :
 				shell = True,
 			)
 
-for source, target in (
-	( "resources/graphics.svg", "arrowDown10.png" ),
-	( "resources/GafferLogo.svg", "GafferLogo.png" ),
-	( "resources/GafferLogoMini.svg", "GafferLogoMini.png" ),
-) :
+if haveInkscape :
 
-	graphicsBuild = env.Command( os.path.join( "$BUILD_DIR/graphics/", target ), source, buildGraphics )
-	env.NoCache( graphicsBuild )
-	env.Alias( "build", graphicsBuild )
+	for source, target in (
+		( "resources/graphics.svg", "arrowDown10.png" ),
+		( "resources/GafferLogo.svg", "GafferLogo.png" ),
+		( "resources/GafferLogoMini.svg", "GafferLogoMini.png" ),
+	) :
+
+		graphicsBuild = env.Command( os.path.join( "$BUILD_DIR/graphics/", target ), source, buildGraphics )
+		env.NoCache( graphicsBuild )
+		env.Alias( "build", graphicsBuild )
+
+else :
+
+	sys.stderr.write( "WARNING : Inkscape not found - not building graphics. Check INKSCAPE build variable.\n" )
 
 #########################################################################################################
 # Resources

--- a/SConstruct
+++ b/SConstruct
@@ -264,6 +264,14 @@ options.Add(
 	"sphinx-build",
 )
 
+options.Add(
+	"INSTALL_POST_COMMAND",
+	"A command which is run following a successful install process. "
+	"This could be used to customise installation further for a "
+	"particular site.",
+	"",
+)
+
 ###############################################################################################
 # Basic environment object. All the other environments will be based on this.
 ###############################################################################################
@@ -1114,6 +1122,10 @@ else :
 	env.NoCache( install )
 
 	env.Alias( "install", install )
+
+	if env["INSTALL_POST_COMMAND"] != "" :
+		# this is the only way we could find to get a post action to run for an alias
+		env.Alias( "install", install, "$INSTALL_POST_COMMAND" )
 
 #########################################################################################################
 # Packaging

--- a/config/ie/options
+++ b/config/ie/options
@@ -35,6 +35,8 @@
 ##########################################################################
 
 import os
+import sys
+
 import IEEnv
 
 ##########################################################################
@@ -141,13 +143,16 @@ else :
 	installRoot = os.path.expanduser( "/tmp/gafferTestInstalls" )
 	versionString += "dev"
 
-BUILD_DIR = buildRoot + "/apps/gaffer/" + versionString + "/" + IEEnv.platform() + "/cortex/" + cortexMajorVersion + "/" + targetApp
-INSTALL_DIR = installRoot + "/apps/gaffer/" + versionString + "/" + IEEnv.platform() + "/cortex/" + cortexMajorVersion + "/" + targetApp
+baseBuildDir = os.path.join( buildRoot, "apps", "gaffer", versionString, IEEnv.platform(), "cortex", cortexMajorVersion )
+baseInstallDir = os.path.join( installRoot, "apps", "gaffer", versionString, IEEnv.platform(), "cortex", cortexMajorVersion )
+
+BUILD_DIR = os.path.join( baseBuildDir, targetApp )
+INSTALL_DIR = os.path.join( baseInstallDir, targetApp )
 
 if targetAppVersion :
 	
-	BUILD_DIR = BUILD_DIR + "/" + targetAppMajorVersion
-	INSTALL_DIR = INSTALL_DIR + "/" + targetAppMajorVersion
+	BUILD_DIR = os.path.join( BUILD_DIR, targetAppMajorVersion )
+	INSTALL_DIR = os.path.join( INSTALL_DIR, targetAppMajorVersion )
 
 ##########################################################################
 # get include locations right
@@ -288,6 +293,12 @@ CXX = os.path.join( compilerReg["location"], compilerReg["bin"] )
 
 SPHINX = os.path.join( sphinxRoot, "bin", "sphinx-build" )
 
+# for app installs we copy the docs and graphics from the standalone install
+if targetAppVersion and "install" in sys.argv :
+	SPHINX = "disableDocs"
+	INKSCAPE = "disableGraphics"
+	INSTALL_POST_COMMAND="scons -i -f config/ie/postInstall STANDALONE_INSTALL_DIR={baseInstallDir}/gaffer INSTALL_DIR=$INSTALL_DIR".format( baseInstallDir = baseInstallDir )
+
 ##########################################################################
 # figure out the lib suffixes
 ##########################################################################
@@ -316,7 +327,7 @@ os.environ["PYTHONHOME"] = os.path.join( pythonReg["location"], compiler, compil
 os.environ["OCIO"] = os.path.join( IEEnv.Environment.rootPath(), "config", "openColorIO", "nuke-default", "config.ocio" )
 
 # we need these imported so we can run the commands to generate the documentation
-ENV_VARS_TO_IMPORT="PATH PYTHONPATH PYTHONHOME IEENV_ROOT IEENV_DISABLE_WRAPPER_ENV_CHECK IECORE_FONT_PATHS IECOREGL_SHADER_INCLUDE_PATHS OCIO IEENV_WORKING_PATH DOXYGEN_VERSION OSL_VERSION"
+ENV_VARS_TO_IMPORT="PATH PYTHONPATH PYTHONHOME IEENV_ROOT IEENV_DISABLE_WRAPPER_ENV_CHECK IECORE_FONT_PATHS IECOREGL_SHADER_INCLUDE_PATHS OCIO IEENV_WORKING_PATH DOXYGEN_VERSION OSL_VERSION SCONS_VERSION"
 # the output is pretty tedious without this disabled
 os.environ["IEENV_DISABLE_WRAPPER_ENV_CHECK"] = "1"
 

--- a/config/ie/postInstall
+++ b/config/ie/postInstall
@@ -1,0 +1,50 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import os
+import shutil
+
+for subdir in ( "doc", "graphics" ) :
+
+	standaloneDir = os.path.join( ARGUMENTS['STANDALONE_INSTALL_DIR'], subdir )
+	appDir = os.path.join( ARGUMENTS['INSTALL_DIR'], subdir )
+
+	if os.path.isdir( standaloneDir ) :
+
+		if os.path.isdir( appDir ) :
+			shutil.rmtree( appDir )
+
+		shutil.copytree( standaloneDir, appDir, symlinks=True )


### PR DESCRIPTION
This is an attempt to bail out of per-app doc builds at IE. The first commit works fine (we get docs for the main build and we don't get the docs per-app). But the second commit is not working yet (and is quite ugly in general).

@johnhaddon do you have a better idea for that last one? Even if I hadn't hit the versionString problem, I don't really like my approach in the first place...