### PR TITLE
Arnold trace set support

### DIFF
--- a/include/GafferScene/Preview/InteractiveRender.h
+++ b/include/GafferScene/Preview/InteractiveRender.h
@@ -40,6 +40,7 @@
 #include "Gaffer/Node.h"
 
 #include "GafferScene/ScenePlug.h"
+#include "GafferScene/Preview/RendererAlgo.h"
 #include "GafferScene/Private/IECoreScenePreview/Renderer.h"
 
 namespace Gaffer
@@ -120,8 +121,7 @@ class InteractiveRender : public Gaffer::Node
 		State m_state;
 		unsigned m_dirtyComponents;
 		IECore::ConstCompoundObjectPtr m_globals;
-		GafferScene::PathMatcher m_lightSet;
-		GafferScene::PathMatcher m_cameraSet;
+		GafferScene::Preview::RenderSets m_renderSets;
 		IECoreScenePreview::Renderer::ObjectInterfacePtr m_defaultCamera;
 
 		Gaffer::ContextPtr m_context; // Accessed with setContext()/getContext()

--- a/include/GafferScene/Preview/RendererAlgo.h
+++ b/include/GafferScene/Preview/RendererAlgo.h
@@ -105,9 +105,9 @@ class RenderSets : boost::noncopyable
 
 };
 
-void outputCameras( const ScenePlug *scene, const IECore::CompoundObject *globals, IECoreScenePreview::Renderer *renderer );
-void outputLights( const ScenePlug *scene, const IECore::CompoundObject *globals, IECoreScenePreview::Renderer *renderer );
-void outputObjects( const ScenePlug *scene, const IECore::CompoundObject *globals, IECoreScenePreview::Renderer *renderer );
+void outputCameras( const ScenePlug *scene, const IECore::CompoundObject *globals, const RenderSets &renderSets, IECoreScenePreview::Renderer *renderer );
+void outputLights( const ScenePlug *scene, const IECore::CompoundObject *globals, const RenderSets &renderSets, IECoreScenePreview::Renderer *renderer );
+void outputObjects( const ScenePlug *scene, const IECore::CompoundObject *globals, const RenderSets &renderSets, IECoreScenePreview::Renderer *renderer );
 
 /// Applies the resolution, aspect ratio etc from the globals to the camera.
 void applyCameraGlobals( IECore::Camera *camera, const IECore::CompoundObject *globals );

--- a/include/GafferScene/Preview/RendererAlgo.h
+++ b/include/GafferScene/Preview/RendererAlgo.h
@@ -37,6 +37,11 @@
 #ifndef GAFFERSCENE_PREVIEW_RENDERERALGO_H
 #define GAFFERSCENE_PREVIEW_RENDERERALGO_H
 
+#include "boost/container/flat_map.hpp"
+
+#include "IECore/VectorTypedData.h"
+
+#include "GafferScene/PathMatcher.h"
 #include "GafferScene/Private/IECoreScenePreview/Renderer.h"
 
 namespace GafferScene
@@ -52,6 +57,53 @@ void outputOptions( const IECore::CompoundObject *globals, const IECore::Compoun
 
 void outputOutputs( const IECore::CompoundObject *globals, IECoreScenePreview::Renderer *renderer );
 void outputOutputs( const IECore::CompoundObject *globals, const IECore::CompoundObject *previousGlobals, IECoreScenePreview::Renderer *renderer );
+
+/// Utility class to handle all the set computations needed for a render.
+class RenderSets : boost::noncopyable
+{
+
+	public :
+
+		RenderSets();
+		RenderSets( const ScenePlug *scene );
+
+		enum Changed
+		{
+			NothingChanged = 0,
+			CamerasSetChanged = 1,
+			LightsSetChanged = 2,
+			RenderSetsChanged = 4
+		};
+
+		/// Returns a bitmask describing which sets
+		/// changed.
+		unsigned update( const ScenePlug *scene );
+		void clear();
+
+		const PathMatcher &camerasSet() const;
+		const PathMatcher &lightsSet() const;
+
+		IECore::ConstInternedStringVectorDataPtr setsAttribute( const std::vector<IECore::InternedString> &path ) const;
+
+	private :
+
+		struct Set
+		{
+			IECore::InternedString unprefixedName; // With "render:" stripped off
+			IECore::MurmurHash hash;
+			PathMatcher set;
+		};
+
+		typedef boost::container::flat_map<IECore::InternedString, Set> Sets;
+
+		struct Updater;
+
+		// Stores all the "render:" sets.
+		Sets m_sets;
+		Set m_camerasSet;
+		Set m_lightsSet;
+
+};
 
 void outputCameras( const ScenePlug *scene, const IECore::CompoundObject *globals, IECoreScenePreview::Renderer *renderer );
 void outputLights( const ScenePlug *scene, const IECore::CompoundObject *globals, IECoreScenePreview::Renderer *renderer );

--- a/include/GafferScene/Private/IECoreScenePreview/Renderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/Renderer.h
@@ -111,6 +111,7 @@ class Renderer : public IECore::RefCounted
 		/// "doubleSided", BoolData, true
 		/// "surface", ObjectVector of IECore::Shaders
 		/// "light", ObjectVector of IECore::Shaders
+		/// "sets", InternedStringVectorData of set names
 		///
 		/// Renderer Specific Attributes
 		/// ----------------------------
@@ -178,9 +179,9 @@ class Renderer : public IECore::RefCounted
 		/// resolution to be rendered, creating overscan outside the displayWindow.  The
 		/// default value is the whole standard resolution, running from
 		/// 0,0 to resolution.x - 1, resolution.y - 1,
-		/// with 0,0 representing the upper left corner.  
+		/// with 0,0 representing the upper left corner.
 		///
-		/// \todo This follows the conventions of Cortex, and matches the OpenEXR display window, 
+		/// \todo This follows the conventions of Cortex, and matches the OpenEXR display window,
 		/// but does not match Gaffer image conventions ( origin in lower left corner,
 		/// indexing pixel corners rather than pixel centers ).  We are planning to switch
 		/// this to match the Gaffer convention instead.

--- a/include/GafferScene/SceneAlgo.h
+++ b/include/GafferScene/SceneAlgo.h
@@ -118,6 +118,8 @@ bool setExists( const ScenePlug *scene, const IECore::InternedString &setName );
 /// Returns all the sets in the scene, indexed by name. Performs individual set
 /// computations in parallel for improved performance.
 IECore::ConstCompoundDataPtr sets( const ScenePlug *scene );
+/// As above, but returning only the requested sets.
+IECore::ConstCompoundDataPtr sets( const ScenePlug *scene, const std::vector<IECore::InternedString> &setNames );
 
 /// Returns a bounding box for the specified object. Typically
 /// this is provided by the VisibleRenderable::bound() method, but

--- a/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
+++ b/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
@@ -109,9 +109,34 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 		shader["parameters"]["Kd"].setValue( 1 )
 		return shader, shader["parameters"]["Kd_color"]
 
+	def _createTraceSetShader( self ) :
+
+		# There appears to be no standard Arnold shader
+		# which uses trace sets, so we use an AlSurface.
+		# If one is not available, the base class will
+		# skip the test.
+
+		shader = GafferArnold.ArnoldShader()
+		try :
+			shader.loadShader( "alSurface" )
+		except :
+			return None, None
+
+		shader["parameters"]["diffuseStrength"].setValue( 0 )
+		shader["parameters"]["specular1Roughness"].setValue( 0 )
+		shader["parameters"]["specular1FresnelMode"].setValue( "metallic" )
+		shader["parameters"]["specular1Reflectivity"].setValue( IECore.Color3f( 1 ) )
+		shader["parameters"]["specular1EdgeTint"].setValue( IECore.Color3f( 1 ) )
+
+		return shader, shader["parameters"]["traceSetSpecular1"]
+
 	def _cameraVisibilityAttribute( self ) :
 
 		return "ai:visibility:camera"
+
+	def _traceDepthOptions( self ) :
+
+		return "ai:GI_glossy_depth", "ai:GI_diffuse_depth", "ai:GI_reflection_depth"
 
 	def _createPointLight( self ) :
 

--- a/python/GafferSceneTest/SceneAlgoTest.py
+++ b/python/GafferSceneTest/SceneAlgoTest.py
@@ -165,6 +165,11 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 		for n in sets.keys() :
 			self.assertTrue( sets[n].isSame( light["out"].set( n, _copy = False ) ) )
 
+		someSets = GafferScene.sets( light["out"], ( "A", "B" ), _copy = False )
+		self.assertEqual( set( someSets.keys() ), { "A", "B" } )
+		for n in someSets.keys() :
+			self.assertTrue( someSets[n].isSame( light["out"].set( n, _copy = False ) ) )
+
 	def testMatchingPathsWithPathMatcher( self ) :
 
 		s = GafferScene.Sphere()

--- a/src/GafferScene/Preview/InteractiveRender.cpp
+++ b/src/GafferScene/Preview/InteractiveRender.cpp
@@ -70,6 +70,7 @@ namespace
 InternedString g_cameraGlobalName( "option:render:camera" );
 
 InternedString g_visibleAttributeName( "scene:visible" );
+InternedString g_setsAttributeName( "sets" );
 
 bool visible( const CompoundObject *attributes )
 {
@@ -123,7 +124,8 @@ class InteractiveRender::SceneGraph
 			ChildNamesComponent = 16,
 			GlobalsComponent = 32,
 			SetsComponent = 64,
-			AllComponents = BoundComponent | TransformComponent | AttributesComponent | ObjectComponent | ChildNamesComponent | GlobalsComponent | SetsComponent
+			RenderSetsComponent = 128, // Sets prefixed with "render:"
+			AllComponents = BoundComponent | TransformComponent | AttributesComponent | ObjectComponent | ChildNamesComponent | GlobalsComponent | SetsComponent | RenderSetsComponent
 		};
 
 		// Constructs the root of the scene graph.
@@ -146,7 +148,7 @@ class InteractiveRender::SceneGraph
 
 		// Called by SceneGraphUpdateTask to update this location. Returns a bitmask
 		// of the components which were changed.
-		unsigned update( const ScenePlug *scene, unsigned dirtyComponents, unsigned changedParentComponents, Type type, IECoreScenePreview::Renderer *renderer, const IECore::CompoundObject *globals )
+		unsigned update( const ScenePlug *scene, const ScenePlug::ScenePath &path, unsigned dirtyComponents, unsigned changedParentComponents, Type type, IECoreScenePreview::Renderer *renderer, const IECore::CompoundObject *globals, const RenderSets &renderSets )
 		{
 			unsigned changedComponents = 0;
 
@@ -180,6 +182,19 @@ class InteractiveRender::SceneGraph
 			{
 				clear();
 				return changedComponents;
+			}
+
+			// Render Sets. We must obviously update these if
+			// the sets have changed, but we also need to do an
+			// update if the attributes have changed, because in
+			// that case we may have overwritten the sets attribute.
+
+			if( ( dirtyComponents & RenderSetsComponent ) || ( changedComponents & AttributesComponent ) )
+			{
+				if( updateRenderSets( path, renderSets ) )
+				{
+					changedComponents |= AttributesComponent;
+				}
 			}
 
 			// Transform
@@ -307,6 +322,15 @@ class InteractiveRender::SceneGraph
 			m_fullAttributes->members() = globalAttributes->members();
 			m_attributesInterface = NULL;
 
+			return true;
+		}
+
+		bool updateRenderSets( const ScenePlug::ScenePath &path, const RenderSets &renderSets )
+		{
+			m_fullAttributes->members()[g_setsAttributeName] = boost::const_pointer_cast<InternedStringVectorData>(
+				renderSets.setsAttribute( path )
+			);
+			m_attributesInterface = NULL;
 			return true;
 		}
 
@@ -529,11 +553,13 @@ class InteractiveRender::SceneGraphUpdateTask : public tbb::task
 
 			unsigned changedComponents = m_sceneGraph->update(
 				scene(),
+				m_scenePath,
 				m_dirtyComponents,
 				m_changedParentComponents,
 				sceneGraphMatch & Filter::ExactMatch ? m_sceneGraphType : SceneGraph::NoType,
 				m_interactiveRender->m_renderer.get(),
-				m_interactiveRender->m_globals.get()
+				m_interactiveRender->m_globals.get(),
+				m_interactiveRender->m_renderSets
 			);
 
 			// Spawn subtasks to apply updates to each child.
@@ -571,13 +597,13 @@ class InteractiveRender::SceneGraphUpdateTask : public tbb::task
 			switch( m_sceneGraphType )
 			{
 				case SceneGraph::CameraType :
-					return m_interactiveRender->m_cameraSet.match( m_scenePath );
+					return m_interactiveRender->m_renderSets.camerasSet().match( m_scenePath );
 				case SceneGraph::LightType :
-					return m_interactiveRender->m_lightSet.match( m_scenePath );
+					return m_interactiveRender->m_renderSets.lightsSet().match( m_scenePath );
 				case SceneGraph::ObjectType :
 				{
-					unsigned m = m_interactiveRender->m_lightSet.match( m_scenePath ) |
-					             m_interactiveRender->m_cameraSet.match( m_scenePath );
+					unsigned m = m_interactiveRender->m_renderSets.lightsSet().match( m_scenePath ) |
+					             m_interactiveRender->m_renderSets.camerasSet().match( m_scenePath );
 					if( m & Filter::ExactMatch )
 					{
 						return Filter::AncestorMatch | Filter::DescendantMatch;
@@ -814,8 +840,10 @@ void InteractiveRender::update()
 
 	if( m_dirtyComponents & SceneGraph::SetsComponent )
 	{
-		m_lightSet = inPlug()->set( "__lights" )->readable();
-		m_cameraSet = inPlug()->set( "__cameras" )->readable();
+		if( m_renderSets.update( inPlug() ) & RenderSets::RenderSetsChanged )
+		{
+			m_dirtyComponents |= SceneGraph::RenderSetsComponent;
+		}
 	}
 
 	for( int i = SceneGraph::FirstType; i <= SceneGraph::LastType; ++i )
@@ -900,7 +928,7 @@ void InteractiveRender::stop()
 	m_renderer = NULL;
 
 	m_globals = inPlug()->globalsPlug()->defaultValue();
-	m_lightSet.clear();
+	m_renderSets.clear();
 
 	m_dirtyComponents = SceneGraph::AllComponents;
 	m_state = Stopped;

--- a/src/GafferScene/Preview/Render.cpp
+++ b/src/GafferScene/Preview/Render.cpp
@@ -228,9 +228,12 @@ void Render::execute() const
 
 	outputOptions( globals.get(), renderer.get() );
 	outputOutputs( globals.get(), renderer.get() );
-	outputCameras( inPlug(), globals.get(), renderer.get() );
-	outputLights( inPlug(), globals.get(), renderer.get() );
-	outputObjects( inPlug(), globals.get(), renderer.get() );
+
+	RenderSets renderSets( inPlug() );
+
+	outputCameras( inPlug(), globals.get(), renderSets, renderer.get() );
+	outputLights( inPlug(), globals.get(), renderSets, renderer.get() );
+	outputObjects( inPlug(), globals.get(), renderSets, renderer.get() );
 
 	renderer->render();
 	renderer.reset();

--- a/src/GafferScene/Preview/RendererAlgo.cpp
+++ b/src/GafferScene/Preview/RendererAlgo.cpp
@@ -364,6 +364,7 @@ const InternedString g_transformBlurOptionName( "option:render:transformBlur" );
 const InternedString g_deformationBlurOptionName( "option:render:deformationBlur" );
 const InternedString g_shutterOptionName( "option:render:shutter" );
 
+static InternedString g_setsAttributeName( "sets" );
 static InternedString g_visibleAttributeName( "scene:visible" );
 static InternedString g_transformBlurAttributeName( "gaffer:transformBlur" );
 static InternedString g_transformBlurSegmentsAttributeName( "gaffer:transformBlurSegments" );
@@ -385,8 +386,8 @@ IECore::InternedString optionName( const IECore::InternedString &globalsName )
 struct LocationOutput
 {
 
-	LocationOutput( IECoreScenePreview::Renderer *renderer, const IECore::CompoundObject *globals )
-		:	m_renderer( renderer ), m_attributes( globalAttributes( globals ) )
+	LocationOutput( IECoreScenePreview::Renderer *renderer, const IECore::CompoundObject *globals, const GafferScene::Preview::RenderSets &renderSets )
+		:	m_renderer( renderer ), m_attributes( globalAttributes( globals ) ), m_renderSets( renderSets )
 	{
 		const BoolData *transformBlurData = globals->member<BoolData>( g_transformBlurOptionName );
 		m_options.transformBlur = transformBlurData ? transformBlurData->readable() : false;
@@ -401,7 +402,7 @@ struct LocationOutput
 
 	bool operator()( const ScenePlug *scene, const ScenePlug::ScenePath &path )
 	{
-		updateAttributes( scene );
+		updateAttributes( scene, path );
 
 		if( const IECore::BoolData *d = m_attributes->member<IECore::BoolData>( g_visibleAttributeName ) )
 		{
@@ -481,10 +482,12 @@ struct LocationOutput
 			return d ? d->readable() : 1;
 		}
 
-		void updateAttributes( const ScenePlug *scene )
+		void updateAttributes( const ScenePlug *scene, const ScenePlug::ScenePath &path )
 		{
 			IECore::ConstCompoundObjectPtr attributes = scene->attributesPlug()->getValue();
-			if( attributes->members().empty() )
+			IECore::ConstInternedStringVectorDataPtr setsAttribute = m_renderSets.setsAttribute( path );
+
+			if( attributes->members().empty() && !setsAttribute )
 			{
 				return;
 			}
@@ -495,6 +498,11 @@ struct LocationOutput
 			for( CompoundObject::ObjectMap::const_iterator it = attributes->members().begin(), eIt = attributes->members().end(); it != eIt; ++it )
 			{
 				updatedAttributes->members()[it->first] = it->second;
+			}
+
+			if( setsAttribute )
+			{
+				updatedAttributes->members()[g_setsAttributeName] = boost::const_pointer_cast<InternedStringVectorData>( setsAttribute );
 			}
 
 			m_attributes = updatedAttributes;
@@ -572,6 +580,7 @@ struct LocationOutput
 
 		Options m_options;
 		IECore::ConstCompoundObjectPtr m_attributes;
+		const GafferScene::Preview::RenderSets &m_renderSets;
 
 		std::vector<M44f> m_transformSamples;
 		std::vector<float> m_transformTimes;
@@ -581,8 +590,8 @@ struct LocationOutput
 struct CameraOutput : public LocationOutput
 {
 
-	CameraOutput( IECoreScenePreview::Renderer *renderer, const IECore::CompoundObject *globals, const PathMatcher &cameraSet )
-		:	LocationOutput( renderer, globals ), m_globals( globals ), m_cameraSet( cameraSet )
+	CameraOutput( IECoreScenePreview::Renderer *renderer, const IECore::CompoundObject *globals, const GafferScene::Preview::RenderSets &renderSets )
+		:	LocationOutput( renderer, globals, renderSets ), m_globals( globals ), m_cameraSet( renderSets.camerasSet() )
 	{
 	}
 
@@ -631,8 +640,8 @@ struct CameraOutput : public LocationOutput
 struct LightOutput : public LocationOutput
 {
 
-	LightOutput( IECoreScenePreview::Renderer *renderer, const IECore::CompoundObject *globals, const PathMatcher &lightSet )
-		:	LocationOutput( renderer, globals ), m_lightSet( lightSet )
+	LightOutput( IECoreScenePreview::Renderer *renderer, const IECore::CompoundObject *globals, const GafferScene::Preview::RenderSets &renderSets )
+		:	LocationOutput( renderer, globals, renderSets ), m_lightSet( renderSets.lightsSet() )
 	{
 	}
 
@@ -669,8 +678,8 @@ struct LightOutput : public LocationOutput
 struct ObjectOutput : public LocationOutput
 {
 
-	ObjectOutput( IECoreScenePreview::Renderer *renderer, const IECore::CompoundObject *globals, const PathMatcher &cameraSet, const PathMatcher &lightSet )
-		:	LocationOutput( renderer, globals ), m_cameraSet( cameraSet ), m_lightSet( lightSet )
+	ObjectOutput( IECoreScenePreview::Renderer *renderer, const IECore::CompoundObject *globals, const GafferScene::Preview::RenderSets &renderSets )
+		:	LocationOutput( renderer, globals, renderSets ), m_cameraSet( renderSets.camerasSet() ), m_lightSet( renderSets.lightsSet() )
 	{
 	}
 
@@ -857,10 +866,8 @@ void outputOutputs( const IECore::CompoundObject *globals, const IECore::Compoun
 	}
 }
 
-void outputCameras( const ScenePlug *scene, const IECore::CompoundObject *globals, IECoreScenePreview::Renderer *renderer )
+void outputCameras( const ScenePlug *scene, const IECore::CompoundObject *globals, const RenderSets &renderSets, IECoreScenePreview::Renderer *renderer )
 {
-	ConstPathMatcherDataPtr cameraSet = scene->set( "__cameras" );
-
 	const StringData *cameraOption = globals->member<StringData>( g_cameraOptionLegacyName );
 	if( cameraOption && !cameraOption->readable().empty() )
 	{
@@ -869,13 +876,13 @@ void outputCameras( const ScenePlug *scene, const IECore::CompoundObject *global
 		{
 			throw IECore::Exception( "Camera \"" + cameraOption->readable() + "\" does not exist" );
 		}
-		if( !(cameraSet->readable().match( cameraPath ) & Filter::ExactMatch) )
+		if( !( renderSets.camerasSet().match( cameraPath ) & Filter::ExactMatch ) )
 		{
 			throw IECore::Exception( "Camera \"" + cameraOption->readable() + "\" is not in the camera set" );
 		}
 	}
 
-	CameraOutput output( renderer, globals, cameraSet->readable() );
+	CameraOutput output( renderer, globals, renderSets );
 	parallelProcessLocations( scene, output );
 
 	if( !cameraOption || cameraOption->readable().empty() )
@@ -892,18 +899,15 @@ void outputCameras( const ScenePlug *scene, const IECore::CompoundObject *global
 	}
 }
 
-void outputLights( const ScenePlug *scene, const IECore::CompoundObject *globals, IECoreScenePreview::Renderer *renderer )
+void outputLights( const ScenePlug *scene, const IECore::CompoundObject *globals, const RenderSets &renderSets, IECoreScenePreview::Renderer *renderer )
 {
-	ConstPathMatcherDataPtr lightSet = scene->set( "__lights" );
-	LightOutput output( renderer, globals, lightSet->readable() );
+	LightOutput output( renderer, globals, renderSets );
 	parallelProcessLocations( scene, output );
 }
 
-void outputObjects( const ScenePlug *scene, const IECore::CompoundObject *globals, IECoreScenePreview::Renderer *renderer )
+void outputObjects( const ScenePlug *scene, const IECore::CompoundObject *globals, const RenderSets &renderSets, IECoreScenePreview::Renderer *renderer )
 {
-	ConstPathMatcherDataPtr cameraSet = scene->set( "__cameras" );
-	ConstPathMatcherDataPtr lightSet = scene->set( "__lights" );
-	ObjectOutput output( renderer, globals, cameraSet->readable(), lightSet->readable() );
+	ObjectOutput output( renderer, globals, renderSets );
 	parallelProcessLocations( scene, output );
 }
 
@@ -988,7 +992,7 @@ void applyCameraGlobals( IECore::Camera *camera, const IECore::CompoundObject *g
 		);
 	}
 
-	
+
 	const Box2fData *cropWindowData = globals->member<Box2fData>( "option:render:cropWindow" );
 	if( cropWindowData )
 	{
@@ -1003,7 +1007,7 @@ void applyCameraGlobals( IECore::Camera *camera, const IECore::CompoundObject *g
 		renderRegion.max.x = std::min( renderRegion.max.x, cropRegion.max.x );
 		renderRegion.min.y = std::max( renderRegion.min.y, cropRegion.min.y );
 		renderRegion.max.y = std::min( renderRegion.max.y, cropRegion.max.y );
-			
+
 	}
 
 	camera->parameters()["renderRegion"] = new Box2iData( renderRegion );

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -470,10 +470,15 @@ struct Sets
 IECore::ConstCompoundDataPtr GafferScene::sets( const ScenePlug *scene )
 {
 	ConstInternedStringVectorDataPtr setNamesData = scene->setNamesPlug()->getValue();
-	std::vector<GafferScene::ConstPathMatcherDataPtr> setsVector;
-	setsVector.resize( setNamesData->readable().size(), NULL );
+	return sets( scene, setNamesData->readable() );
+}
 
-	Sets setsCompute( scene, setNamesData->readable(), setsVector );
+IECore::ConstCompoundDataPtr GafferScene::sets( const ScenePlug *scene, const std::vector<IECore::InternedString> &setNames )
+{
+	std::vector<GafferScene::ConstPathMatcherDataPtr> setsVector;
+	setsVector.resize( setNames.size(), NULL );
+
+	Sets setsCompute( scene, setNames, setsVector );
 	parallel_for( tbb::blocked_range<size_t>( 0, setsVector.size() ), setsCompute );
 
 	CompoundDataPtr result = new CompoundData;
@@ -481,7 +486,7 @@ IECore::ConstCompoundDataPtr GafferScene::sets( const ScenePlug *scene )
 	{
 		// The const_pointer_cast is ok because we're just using it to put the set into
 		// a container that will be const on return - we never modify the set itself.
-		result->writable()[setNamesData->readable()[i]] = boost::const_pointer_cast<GafferScene::PathMatcherData>( setsVector[i] );
+		result->writable()[setNames[i]] = boost::const_pointer_cast<GafferScene::PathMatcherData>( setsVector[i] );
 	}
 	return result;
 }


### PR DESCRIPTION
This adds support for specifying Arnold traces sets using standard gaffer sets with a "render:" prefix on them. The implementation is intended to one day support set membership in other renderers (for instance RenderMan's "grouping:membership" attribute), but only once they are updated to use the new Renderer API.

A couple of things to note :

- The second commit isn't strictly necessary for this PR. I added it thinking I could use it in RenderSets but turned out to need something more specialised. I've left it in because I can imagine it being useful, especially from Python.
- The last commit should be squashed with the previous one before merging, but I've left it on its own because I think it's worthy of discussion. Arnold appears to treat objects which have not been placed in any trace sets as if they are in all trace sets, which I find really unhelpful. For instance, you can start with an object in no sets at all, and use a shader tracing the "foo" set, and the object will be visible. Then you put the object in the "bar" set and suddenly it disappears, even though its membership of "foo" is unchanged from before. I can't see how this is helpful in any way, but it's documented [here](https://support.solidangle.com/display/ARP/Using+Trace+Sets) so doesn't seem to be considered a bug. Although I generally advocate for the renderer backends to present renderers in their default behaviour as much as possible, I really think this is one case where we might want to make a correction. Any opinions?