### PR TITLE
ShaderPlug : Fix bug when `getInput() == NULL`.

### DIFF
--- a/python/GafferArnoldTest/ArnoldDisplacementTest.py
+++ b/python/GafferArnoldTest/ArnoldDisplacementTest.py
@@ -72,5 +72,10 @@ class ArnoldDisplacementTest( GafferSceneTest.SceneTestCase ) :
 		d["enabled"].setValue( False )
 		self.assertEqual( d.attributes(), IECore.CompoundObject() )
 
+	def testNoInput( self ) :
+
+		d = GafferArnold.ArnoldDisplacement()
+		self.assertTrue( "ai:disp_map" not in d.attributes() )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/ShaderPlug.cpp
+++ b/src/GafferScene/ShaderPlug.cpp
@@ -47,6 +47,30 @@ using namespace IECore;
 using namespace Gaffer;
 using namespace GafferScene;
 
+//////////////////////////////////////////////////////////////////////////
+// Internal utilities
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+const GafferScene::Shader *shader( const ShaderPlug *plug )
+{
+	const Plug *source = plug->source<Plug>();
+	if( source == plug )
+	{
+		// No input
+		return NULL;
+	}
+	return runTimeCast<const GafferScene::Shader>( source->node() );
+}
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// ShaderPlug
+//////////////////////////////////////////////////////////////////////////
+
 IE_CORE_DEFINERUNTIMETYPED( ShaderPlug );
 
 ShaderPlug::ShaderPlug( const std::string &name, Direction direction, unsigned flags )
@@ -115,12 +139,12 @@ bool ShaderPlug::acceptsInput( const Gaffer::Plug *input ) const
 
 IECore::MurmurHash ShaderPlug::attributesHash() const
 {
-	const Shader *shader = source<Plug>()->ancestor<Shader>();
-	return shader ? shader->attributesHash() : MurmurHash();
+	const Shader *s = shader( this );
+	return s ? s->attributesHash() : MurmurHash();
 }
 
 IECore::ConstCompoundObjectPtr ShaderPlug::attributes() const
 {
-	const Shader *shader = source<Plug>()->ancestor<Shader>();
-	return shader ? shader->attributes() : new CompoundObject;
+	const Shader *s = shader( this );
+	return s ? s->attributes() : new CompoundObject;
 }


### PR DESCRIPTION
We were using `source()` without checking that an input existed. In the case of ArnoldDisplacement, this meant that when looking for the shader for `ArnoldDisplacement::mapPlug()`, it found the ArnoldDisplacement node itself, leading to an infinite loop.