### PR TITLE
Arnold Shader menu : Support gaffer.nodeMenu.category metadata.

### DIFF
--- a/python/GafferArnoldUI/ShaderMenu.py
+++ b/python/GafferArnoldUI/ShaderMenu.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import functools
+import collections
 
 import arnold
 
@@ -47,6 +48,12 @@ import GafferArnold
 
 def appendShaders( menuDefinition, prefix="/Arnold" ) :
 
+	MenuItem = collections.namedtuple( "MenuItem", [ "menuPath", "nodeCreator" ] )
+
+	# Build a list of menu items we want to create.
+
+	categorisedMenuItems = []
+	uncategorisedMenuItems = []
 	with IECoreArnold.UniverseBlock() :
 
 		it = arnold.AiUniverseGetNodeEntryIterator( arnold.AI_NODE_SHADER | arnold.AI_NODE_LIGHT )
@@ -57,30 +64,61 @@ def appendShaders( menuDefinition, prefix="/Arnold" ) :
 			shaderName = arnold.AiNodeEntryGetName( nodeEntry )
 			displayName = " ".join( [ IECore.CamelCase.toSpaced( x ) for x in shaderName.split( "_" ) ] )
 
+			category = __aiMetadataGetStr( nodeEntry, "", "gaffer.nodeMenu.category" )
+			if category == "" :
+				continue
+
 			if arnold.AiNodeEntryGetType( nodeEntry ) == arnold.AI_NODE_SHADER :
-				menuPath = prefix + "/Shader/" + displayName
+				menuPath = "Shader"
 				nodeCreator = functools.partial( __shaderCreator, shaderName, GafferArnold.ArnoldShader )
 			else :
-				menuPath = prefix + "/Light/" + displayName
+				menuPath = "Light"
 				if shaderName != "mesh_light" :
 					nodeCreator = functools.partial( __shaderCreator, shaderName, GafferArnold.ArnoldLight )
 				else :
 					nodeCreator = GafferArnold.ArnoldMeshLight
 
-			menuDefinition.append(
-				menuPath,
-				{
-					"command" : GafferUI.NodeMenu.nodeCreatorWrapper( nodeCreator ),
-					"searchText" : "ai" + displayName.replace( " ", "" ),
-				}
-			)
+			if category :
+				menuPath += "/" + category.strip( "/" )
+			menuPath += "/" + displayName
+
+			if category :
+				categorisedMenuItems.append( MenuItem( menuPath, nodeCreator ) )
+			else :
+				uncategorisedMenuItems.append( MenuItem( menuPath, nodeCreator ) )
 
 		arnold.AiNodeEntryIteratorDestroy( it )
 
-		arnold.AiEnd()
+	# Tidy up uncategorised shaders into a submenu if necessary.
+
+	rootsWithCategories = set( [ m.menuPath.partition( "/" )[0] for m in categorisedMenuItems ] )
+
+	for i, menuItem in enumerate( uncategorisedMenuItems ) :
+		s = menuItem.menuPath.split( "/" )
+		if s[0] in rootsWithCategories :
+			uncategorisedMenuItems[i] = MenuItem( "/".join( [ s[0], "Other", s[1] ] ), menuItem.nodeCreator )
+
+	# Create the actual menu items.
+
+	for menuItem in categorisedMenuItems + uncategorisedMenuItems :
+		menuDefinition.append(
+			prefix + "/" + menuItem.menuPath,
+			{
+				"command" : GafferUI.NodeMenu.nodeCreatorWrapper( menuItem.nodeCreator ),
+				"searchText" : "ai" + menuItem.menuPath.rpartition( "/" )[2].replace( " ", "" ),
+			}
+		)
 
 def __shaderCreator( name, nodeType ) :
 
 	shader = nodeType( name )
 	shader.loadShader( name )
 	return shader
+
+def __aiMetadataGetStr( nodeEntry, paramName, name ) :
+
+	value = arnold.AtString()
+	if arnold.AiMetaDataGetStr( nodeEntry, paramName, name, value ) :
+		return value.value
+
+	return None

--- a/python/GafferRenderManUI/ShaderMenu.py
+++ b/python/GafferRenderManUI/ShaderMenu.py
@@ -49,7 +49,7 @@ def appendShaders( menuDefinition, prefix="/RenderMan/Shader", matchExpression =
 	searchPaths = [ p for p in searchPaths if p != "." ]
 
 	GafferSceneUI.ShaderUI.appendShaders(
-		menuDefinition, prefix, searchPaths, [ "slo", "sdl" ], __nodeCreator, matchExpression
+		menuDefinition, prefix, searchPaths, [ "slo", "sdl" ], __nodeCreator, matchExpression, searchTextPrefix = "ri"
 	)
 
 def __nodeCreator( nodeName, shaderName ) :

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -198,9 +198,9 @@ GafferUI.NodeFinderDialogue.registerMode( "Shader Names", __shaderNameExtractor 
 ##########################################################################
 
 ## Appends menu items for the creation of all shaders found on some searchpaths.
-def appendShaders( menuDefinition, prefix, searchPaths, extensions, nodeCreator, matchExpression = "*" ) :
+def appendShaders( menuDefinition, prefix, searchPaths, extensions, nodeCreator, matchExpression = "*", searchTextPrefix = "" ) :
 
-	menuDefinition.append( prefix, { "subMenu" : IECore.curry( __shaderSubMenu, searchPaths, extensions, nodeCreator, matchExpression ) } )
+	menuDefinition.append( prefix, { "subMenu" : IECore.curry( __shaderSubMenu, searchPaths, extensions, nodeCreator, matchExpression, searchTextPrefix ) } )
 
 def __nodeName( shaderName ) :
 
@@ -224,7 +224,7 @@ def __loadFromFile( menu, extensions, nodeCreator ) :
 
 	return nodeCreator( __nodeName( shaderName ), shaderName )
 
-def __shaderSubMenu( searchPaths, extensions, nodeCreator, matchExpression ) :
+def __shaderSubMenu( searchPaths, extensions, nodeCreator, matchExpression, searchTextPrefix ) :
 
 	if isinstance( matchExpression, str ) :
 		matchExpression = re.compile( fnmatch.translate( matchExpression ) )
@@ -266,7 +266,7 @@ def __shaderSubMenu( searchPaths, extensions, nodeCreator, matchExpression ) :
 			menuPath,
 			{
 				"command" : GafferUI.NodeMenu.nodeCreatorWrapper( IECore.curry( nodeCreator, __nodeName( shader ), shader ) ),
-				"searchText" : menuPath.rpartition( "/" )[-1].replace( " ", "" ),
+				"searchText" : searchTextPrefix + menuPath.rpartition( "/" )[-1].replace( " ", "" ),
 			},
 		)
 

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -342,7 +342,8 @@ if moduleSearchPath.find( "GafferOSL" ) :
 		#   Appleseed shaders.
 		# - [^/]*$ matches the rest of the shader name, ensuring it
 		#   doesn't include any directory separators.
-		matchExpression = re.compile( "(^|.*/)(?!as_)[^/]*$")
+		matchExpression = re.compile( "(^|.*/)(?!as_)[^/]*$"),
+		searchTextPrefix = "osl",
 	)
 
 	nodeMenu.append( "/OSL/Image", GafferOSL.OSLImage, searchText = "OSLImage" )


### PR DESCRIPTION
This can be used to place shaders into specific submenus.

I've also added prefixes to the RenderMan and OSL search text since it was getting a little confusing, there being 11 different nodes with "noise" in their name now (when AlShaders and MtoA shaders are loaded at least).