### PR TITLE
ArnoldShader reloading

### DIFF
--- a/include/GafferArnold/ArnoldShader.h
+++ b/include/GafferArnold/ArnoldShader.h
@@ -55,7 +55,10 @@ class ArnoldShader : public GafferScene::Shader
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferArnold::ArnoldShader, ArnoldShaderTypeId, GafferScene::Shader );
 
+		/// \todo Remove this version, and add `keepExistingValues = false` default
+		/// to version below.
 		void loadShader( const std::string &shaderName );
+		void loadShader( const std::string &shaderName, bool keepExistingValues );
 
 };
 

--- a/include/GafferArnold/ParameterHandler.h
+++ b/include/GafferArnold/ParameterHandler.h
@@ -52,8 +52,10 @@ class ParameterHandler
 
 	public :
 
+		static Gaffer::Plug *setupPlug( const IECore::InternedString &parameterName, int parameterType, Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction = Gaffer::Plug::In );
 		static Gaffer::Plug *setupPlug( const AtNodeEntry *node, const AtParamEntry *parameter, Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction = Gaffer::Plug::In );
 		static void setupPlugs( const AtNodeEntry *node, Gaffer::GraphComponent *plugsParent, Gaffer::Plug::Direction direction = Gaffer::Plug::In );
+
 };
 
 } // namespace GafferArnold

--- a/python/GafferArnoldTest/ArnoldShaderTest.py
+++ b/python/GafferArnoldTest/ArnoldShaderTest.py
@@ -533,5 +533,13 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 		shader.loadShader( "lambert", keepExistingValues = False )
 		assertParametersEqual( shader, lambert )
 
+	def testLoadShaderInSerialisation( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["s"] = GafferArnold.ArnoldShader()
+		s["s"].loadShader( "lambert" )
+
+		self.assertTrue( """loadShader( "lambert", keepExistingValues=True )""" in s.serialise() )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferArnoldTest/ArnoldShaderTest.py
+++ b/python/GafferArnoldTest/ArnoldShaderTest.py
@@ -444,5 +444,94 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 		flat.loadShader( "flat" )
 		flat["parameters"]["color"].setInput( colorSpline["out"]["c"] )
 
+	def testReload( self ) :
+
+		image = GafferArnold.ArnoldShader()
+		image.loadShader( "image" )
+
+		image["parameters"]["swap_st"].setValue( True )
+		image["parameters"]["uvcoords"].setValue( IECore.V2f( 0.5, 1 ) )
+		image["parameters"]["missing_tile_color"].setValue( IECore.Color4f( 0.25, 0.5, 0.75, 1 ) )
+		image["parameters"]["start_channel"].setValue( 1 )
+		image["parameters"]["swrap"].setValue( "black" )
+
+		lambert = GafferArnold.ArnoldShader()
+		lambert.loadShader( "lambert" )
+
+		lambert["parameters"]["Kd"].setValue( 0.25 )
+		lambert["parameters"]["Kd_color"].setInput( image["out"] )
+		lambert["parameters"]["opacity"].setValue( IECore.Color3f( 0.1 ) )
+		lambert["parameters"]["aov_direct_diffuse"].setValue( "test" )
+
+		originalImagePlugs = image.children()
+		originalImageParameterPlugs = image["parameters"].children()
+
+		originalLambertPlugs = lambert.children()
+		originalLambertParameterPlugs = lambert["parameters"].children()
+
+		lambert.loadShader( "lambert", keepExistingValues = True )
+
+		def assertValuesWereKept() :
+
+			self.assertEqual( image["parameters"]["swap_st"].getValue(), True )
+			self.assertEqual( image["parameters"]["uvcoords"].getValue(), IECore.V2f( 0.5, 1 ) )
+			self.assertEqual( image["parameters"]["missing_tile_color"].getValue(), IECore.Color4f( 0.25, 0.5, 0.75, 1 ) )
+			self.assertEqual( image["parameters"]["start_channel"].getValue(), 1 )
+			self.assertEqual( image["parameters"]["swrap"].getValue(), "black" )
+
+			self.assertEqual( image.children(), originalImagePlugs )
+			self.assertEqual( image["parameters"].children(), originalImageParameterPlugs )
+
+			self.assertEqual( lambert["parameters"]["Kd"].getValue(), 0.25 )
+			self.assertTrue( lambert["parameters"]["Kd_color"].getInput().isSame( image["out"] ) )
+			self.assertEqual( lambert["parameters"]["opacity"].getValue(), IECore.Color3f( 0.1 ) )
+			self.assertEqual( lambert["parameters"]["aov_direct_diffuse"].getValue(), "test" )
+
+			self.assertEqual( lambert.children(), originalLambertPlugs )
+			self.assertEqual( lambert["parameters"].children(), originalLambertParameterPlugs )
+
+		assertValuesWereKept()
+
+		image.loadShader( "image", keepExistingValues = True )
+
+		assertValuesWereKept()
+
+		image.loadShader( "image", keepExistingValues = False )
+
+		for p in image["parameters"].children() :
+			self.assertTrue( p.isSetToDefault() )
+
+		self.assertTrue( lambert["parameters"]["Kd_color"].getInput() is None )
+
+	def testLoadDifferentShader( self ) :
+
+		standard = GafferArnold.ArnoldShader()
+		standard.loadShader( "standard" )
+
+		lambert = GafferArnold.ArnoldShader()
+		lambert.loadShader( "lambert" )
+
+		shader = GafferArnold.ArnoldShader()
+		shader.loadShader( "lambert" )
+
+		def assertParametersEqual( s1, s2, ignore = [] ) :
+
+			self.assertEqual( set( s1["parameters"].keys() ), set( s2["parameters"].keys() ) )
+			for k in s1["parameters"].keys() :
+				if k in ignore :
+					continue
+				self.assertEqual( s1["parameters"][k].getValue(), s2["parameters"][k].getValue() )
+
+		assertParametersEqual( shader, lambert )
+
+		shader["parameters"]["Kd"].setValue( 0.25 )
+
+		shader.loadShader( "standard", keepExistingValues = True )
+		assertParametersEqual( shader, standard, ignore = [ "Kd" ] )
+		self.assertEqual( shader["parameters"]["Kd"].getValue(), 0.25 )
+
+		shader.loadShader( "lambert", keepExistingValues = False )
+		assertParametersEqual( shader, lambert )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -167,9 +167,8 @@ class _ShaderNamePlugValueWidget( GafferUI.PlugValueWidget ) :
 		with self.getContext() :
 			shaderName = self.getPlug().getValue()
 			self.__label.setText( "<h3>Shader : " + shaderName + "</h3>" )
-			## \todo Disable the type check once we've got all the shader types implementing reloading properly.
-			nodeType = self.getPlug().node().typeName()
-			self.__button.setEnabled( bool( shaderName ) and ( "RenderMan" in nodeType or "OSL" in nodeType ) )
+			## \todo Disable the type check once we've got OpenGLShader implementing reloading properly.
+			self.__button.setEnabled( not isinstance( self.getPlug().node(), GafferScene.OpenGLShader ) )
 
 	def __buttonClicked( self, button ) :
 

--- a/src/GafferArnoldModule/GafferArnoldModule.cpp
+++ b/src/GafferArnoldModule/GafferArnoldModule.cpp
@@ -56,7 +56,13 @@ BOOST_PYTHON_MODULE( _GafferArnold )
 {
 
 	GafferBindings::DependencyNodeClass<ArnoldShader>()
-		.def( "loadShader", (void (ArnoldShader::*)( const std::string & ) )&ArnoldShader::loadShader )
+		.def(
+			"loadShader", (void (ArnoldShader::*)( const std::string &, bool ))&ArnoldShader::loadShader,
+			(
+				arg( "shaderName" ),
+				arg( "keepExistingValues" ) = false
+			)
+		)
 	;
 
 	GafferBindings::NodeClass<ArnoldLight>()

--- a/src/GafferOSLModule/GafferOSLModule.cpp
+++ b/src/GafferOSLModule/GafferOSLModule.cpp
@@ -56,7 +56,7 @@ namespace
 {
 
 /// \todo Move this serialisation to the bindings for GafferScene::Shader, once we've made Shader::loadShader() virtual
-/// and implemented it so reloading works in ArnoldShader and OpenGLShader.
+/// and implemented it so reloading works in OpenGLShader.
 class OSLShaderSerialiser : public GafferBindings::NodeSerialiser
 {
 

--- a/src/GafferRenderManModule/GafferRenderManModule.cpp
+++ b/src/GafferRenderManModule/GafferRenderManModule.cpp
@@ -57,7 +57,7 @@ namespace
 {
 
 /// \todo Move this serialisation to the bindings for GafferScene::Shader, once we've made Shader::loadShader() virtual
-/// and implemented it so reloading works in ArnoldShader and OpenGLShader. Also consider how we might share loading code
+/// and implemented it so reloading works in OpenGLShader. Also consider how we might share loading code
 /// between shaders and lights.
 class RenderManShaderSerialiser : public GafferBindings::NodeSerialiser
 {


### PR DESCRIPTION
This implements reloading for Arnold shaders, to update the plugs on a node when parameters are added to or removed from an Arnold shader. It's implemented in the same way as we've done for RenderManShader and OSLShader for a long time, with the reload button in the NodeEditor now active, and an auto-reload being done during script loading.

I've added unit tests and there's a fair body of existing tests which rely on ArnoldShader functioning correctly, but because this deals with serialisation there is potential for data loss if I've fluffed something. A beady eyed review and an initial rollout to one brave soul (@boberfly?) might be in order. 