### PR TITLE
Arnold curve attributes

### DIFF
--- a/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
+++ b/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
@@ -587,24 +587,6 @@ class RendererTest( GafferTest.TestCase ) :
 		r.render()
 		del r
 
-		def assertInstanced( *names ) :
-
-			firstInstanceNode = arnold.AiNodeLookUpByName( names[0] )
-			for name in names :
-
-				instanceNode = arnold.AiNodeLookUpByName( name )
-				self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( instanceNode ) ), "ginstance" )
-
-				nodePtr = arnold.AiNodeGetPtr( instanceNode, "node" )
-				self.assertEqual( nodePtr, arnold.AiNodeGetPtr( firstInstanceNode, "node" ) )
-				self.assertEqual( arnold.AiNodeGetInt( arnold.AtNode.from_address( nodePtr ), "visibility" ), 0 )
-
-		def assertNotInstanced( *names ) :
-
-			for name in names :
-				node = arnold.AiNodeLookUpByName( name )
-				self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( node ) ), "polymesh" )
-
 		with IECoreArnold.UniverseBlock() :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
@@ -616,26 +598,26 @@ class RendererTest( GafferTest.TestCase ) :
 			self.assertEqual( numPolyMeshes, 5 )
 			self.assertEqual( numInstances, 10 )
 
-			assertInstanced(
+			self.__assertInstanced(
 				"polyDefaultAttributes1",
 				"polyDefaultAttributes2",
 				"polyAdaptiveAttributes1",
 				"polyAdaptiveAttributes2",
 			)
 
-			assertInstanced(
+			self.__assertInstanced(
 				"subdivDefaultAttributes1",
 				"subdivDefaultAttributes2",
 				"subdivNonAdaptiveAttributes1",
 				"subdivNonAdaptiveAttributes2",
 			)
 
-			assertNotInstanced(
+			self.__assertNotInstanced(
 				"subdivAdaptiveAttributes1",
 				"subdivAdaptiveAttributes2"
 			)
 
-			assertInstanced(
+			self.__assertInstanced(
 				"subdivAdaptiveObjectSpaceAttributes1",
 				"subdivAdaptiveObjectSpaceAttributes2",
 			)
@@ -1121,6 +1103,102 @@ class RendererTest( GafferTest.TestCase ) :
 				for i in range( 0, a.contents.nelements ) :
 					self.assertEqual( arnold.AiArrayGetStr( a, i ), sets[i] )
 
+	def testCurvesAttributes( self ) :
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"IECoreArnold::Renderer",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
+			self.temporaryDirectory() + "/test.ass"
+		)
+
+		curves = IECore.CurvesPrimitive.createBox( IECore.Box3f( IECore.V3f( -1 ), IECore.V3f( 1 ) ) )
+
+		defaultAttributes = r.attributes( IECore.CompoundObject() )
+
+		pixelWidth1Attributes = r.attributes(
+			IECore.CompoundObject( {
+				"ai:curves:min_pixel_width" : IECore.FloatData( 1 ),
+			} )
+		)
+
+		pixelWidth2Attributes = r.attributes(
+			IECore.CompoundObject( {
+				"ai:curves:min_pixel_width" : IECore.FloatData( 2 ),
+			} )
+		)
+
+		modeRibbonAttributes = r.attributes(
+			IECore.CompoundObject( {
+				"ai:curves:mode" : IECore.StringData( "ribbon" ),
+			} )
+		)
+
+		modeThickAttributes = r.attributes(
+			IECore.CompoundObject( {
+				"ai:curves:mode" : IECore.StringData( "thick" ),
+			} )
+		)
+
+		pixelWidth0ModeRibbonAttributes = r.attributes(
+			IECore.CompoundObject( {
+				"ai:curves:min_pixel_width" : IECore.FloatData( 0 ),
+				"ai:curves:mode" : IECore.StringData( "ribbon" ),
+			} )
+		)
+
+		r.object( "default", curves.copy(), defaultAttributes )
+		r.object( "pixelWidth1", curves.copy(), pixelWidth1Attributes )
+		r.object( "pixelWidth1Duplicate", curves.copy(), pixelWidth1Attributes )
+		r.object( "pixelWidth2", curves.copy(), pixelWidth2Attributes )
+		r.object( "modeRibbon", curves.copy(), modeRibbonAttributes )
+		r.object( "modeThick", curves.copy(), modeThickAttributes )
+		r.object( "pixelWidth0ModeRibbon", curves.copy(), pixelWidth0ModeRibbonAttributes )
+
+		r.render()
+		del r
+
+		with IECoreArnold.UniverseBlock() :
+
+			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
+
+			shapes = self.__allNodes( type = arnold.AI_NODE_SHAPE )
+			numInstances = len( [ s for s in shapes if arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( s ) ) == "ginstance" ] )
+			numCurves = len( [ s for s in shapes if arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( s ) ) == "curves" ] )
+
+			self.assertEqual( numInstances, 7 )
+			self.assertEqual( numCurves, 4 )
+
+			self.__assertInstanced(
+				"default",
+				"modeRibbon",
+				"pixelWidth0ModeRibbon",
+			)
+
+			self.__assertInstanced(
+				"pixelWidth1",
+				"pixelWidth1Duplicate",
+			)
+
+			for name in ( "pixelWidth2", "modeRibbon", "modeThick" ) :
+				self.__assertInstanced( name )
+
+			for name, minPixelWidth, mode in (
+				( "default", 0, "ribbon" ),
+				( "pixelWidth1", 1, "ribbon" ),
+				( "pixelWidth1Duplicate", 1, "ribbon" ),
+				( "pixelWidth2", 2, "ribbon" ),
+				( "modeRibbon", 0, "ribbon" ),
+				( "modeThick", 0, "thick" ),
+				( "pixelWidth0ModeRibbon", 0, "ribbon" ),
+			) :
+
+				instance = arnold.AiNodeLookUpByName( name )
+				self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( instance ) ), "ginstance" )
+
+				shape = arnold.AtNode.from_address( arnold.AiNodeGetPtr( instance, "node" ) )
+				self.assertEqual( arnold.AiNodeGetFlt( shape, "min_pixel_width" ), minPixelWidth )
+				self.assertEqual( arnold.AiNodeGetStr( shape, "mode" ), mode )
+
 	@staticmethod
 	def __m44f( m ) :
 
@@ -1142,6 +1220,24 @@ class RendererTest( GafferTest.TestCase ) :
 			result.append( node )
 
 		return result
+
+	def __assertInstanced( self, *names ) :
+
+		firstInstanceNode = arnold.AiNodeLookUpByName( names[0] )
+		for name in names :
+
+			instanceNode = arnold.AiNodeLookUpByName( name )
+			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( instanceNode ) ), "ginstance" )
+
+			nodePtr = arnold.AiNodeGetPtr( instanceNode, "node" )
+			self.assertEqual( nodePtr, arnold.AiNodeGetPtr( firstInstanceNode, "node" ) )
+			self.assertEqual( arnold.AiNodeGetInt( arnold.AtNode.from_address( nodePtr ), "visibility" ), 0 )
+
+	def __assertNotInstanced( self, *names ) :
+
+		for name in names :
+			node = arnold.AiNodeLookUpByName( name )
+			self.assertNotEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( node ) ), "ginstance" )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferArnoldUI/ArnoldAttributesUI.py
+++ b/python/GafferArnoldUI/ArnoldAttributesUI.py
@@ -86,6 +86,16 @@ def __subdivisionSummary( plug ) :
 
 	return ", ".join( info )
 
+def __curvesSummary( plug ) :
+
+	info = []
+	if plug["curvesMode"]["enabled"].getValue() :
+		info.append( string.capwords( plug["curvesMode"]["value"].getValue() ) )
+	if plug["curvesMinPixelWidth"]["enabled"].getValue() :
+		info.append( "Min Pixel Width %s" % GafferUI.NumericWidget.valueToString( plug["curvesMinPixelWidth"]["value"].getValue() ) )
+
+	return ", ".join( info )
+
 def __volumeSummary( plug ) :
 
 	info = []
@@ -112,6 +122,7 @@ Gaffer.Metadata.registerNode(
 			"layout:section:Visibility:summary", __visibilitySummary,
 			"layout:section:Shading:summary", __shadingSummary,
 			"layout:section:Subdivision:summary", __subdivisionSummary,
+			"layout:section:Curves:summary", __curvesSummary,
 			"layout:section:Volume:summary", __volumeSummary,
 
 		],
@@ -381,6 +392,57 @@ Gaffer.Metadata.registerNode(
 			"preset:Object", "object",
 
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
+		],
+
+		# Curves
+
+		"attributes.curvesMode" : [
+
+			"description",
+			"""
+			How the curves are rendered. Ribbon mode treats
+			the curves as flat ribbons facing the camera, and is
+			most suited for rendering of thin curves with a
+			dedicated hair shader. Thick mode treats the curves
+			as tubes, and is suited for use with a regular
+			surface shader.
+
+			> Note : To render using Arnold's "oriented" mode, set
+			> mode to "ribbon" and add per-vertex normals to the
+			> curves as a primitive variable named "N".
+			""",
+
+			"layout:section", "Curves",
+			"label", "Mode",
+
+		],
+
+		"attributes.curvesMode.value" : [
+
+			"preset:Ribbon", "ribbon",
+			"preset:Thick", "thick",
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
+		],
+
+		"attributes.curvesMinPixelWidth" : [
+
+			"description",
+			"""
+			The minimum thickness of the curves, measured
+			in pixels on the screen. When rendering very thin curves, a
+			large number of AA samples are required
+			to avoid aliasing. In these cases a minimum pixel
+			width may be specified to artificially thicken the curves,
+			meaning that fewer AA samples may be used. The additional width is
+			compensated for automatically by lowering the opacity
+			of the curves.
+			""",
+
+			"layout:section", "Curves",
+			"label", "Min Pixel Width",
 
 		],
 

--- a/src/GafferArnold/ArnoldAttributes.cpp
+++ b/src/GafferArnold/ArnoldAttributes.cpp
@@ -74,6 +74,11 @@ ArnoldAttributes::ArnoldAttributes( const std::string &name )
 	attributes->addOptionalMember( "ai:polymesh:subdiv_adaptive_metric", new StringPlug( "value", Plug::In, "auto" ), "subdivAdaptiveMetric", false );
 	attributes->addOptionalMember( "ai:polymesh:subdiv_adaptive_space", new StringPlug( "value", Plug::In, "raster" ), "subdivAdaptiveSpace", false );
 
+	// Curves parameters
+
+	attributes->addOptionalMember( "ai:curves:mode", new StringPlug( "value", Plug::In, "ribbon" ), "curvesMode", false );
+	attributes->addOptionalMember( "ai:curves:min_pixel_width", new FloatPlug( "value", Plug::In, 0.0f, 0.0f ), "curvesMinPixelWidth", false );
+
 	// Volume parameters
 
 	attributes->addOptionalMember( "ai:shape:step_size", new FloatPlug( "value", Plug::In, 0.0f, 0.0f ), "volumeStepSize", false );


### PR DESCRIPTION
This adds support for specifying min_pixel_width and mode via the ArnoldAttributes node. Note that they these cannot currently be edited during an interactive render, for similar reasons to the subdivision attributes. I have started working on making that work, but I'd like to get the basics merged and make a separate PR later.

Since both this and #1851 are at @boberfly's request (and #1851 requires some testing) perhaps it would make sense to put together a quick release containing both of these for him to play with?