### PR TITLE
Dealing with dynamic compound plugs with child plugs with the same name

### DIFF
--- a/python/GafferUI/CompoundPlugValueWidget.py
+++ b/python/GafferUI/CompoundPlugValueWidget.py
@@ -199,13 +199,14 @@ class CompoundPlugValueWidget( GafferUI.PlugValueWidget ) :
 	def __updateChildPlugUIs( self ) :
 
 		# ditch child uis we don't need any more
+		childPlugs = self._childPlugs()
 		for childPlug in self.__childPlugUIs.keys() :
-			if childPlug not in self._childPlugs() :
+			if childPlug not in childPlugs :
 				del self.__childPlugUIs[childPlug]
 
 		# make (or reuse existing) uis for each child plug
 		orderedChildUIs = []
-		for childPlug in self._childPlugs() :
+		for childPlug in childPlugs :
 			if childPlug.getName().startswith( "__" ) :
 				continue
 			if childPlug not in self.__childPlugUIs :

--- a/python/GafferUI/CompoundPlugValueWidget.py
+++ b/python/GafferUI/CompoundPlugValueWidget.py
@@ -103,7 +103,7 @@ class CompoundPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		self.__visibilityChangedConnection = self.__column.visibilityChangedSignal().connect( Gaffer.WeakMethod( self.__visibilityChanged ) )
 
-		self.__childPlugUIs = {} # mapping from child plug name to PlugWidget
+		self.__childPlugUIs = {} # mapping from child plug to PlugWidget
 
 		self.__summary = summary
 
@@ -118,7 +118,7 @@ class CompoundPlugValueWidget( GafferUI.PlugValueWidget ) :
 		if not lazy and len( self.__childPlugUIs ) == 0 :
 			self.__updateChildPlugUIs()
 
-		w = self.__childPlugUIs.get( childPlug.getName(), None )
+		w = self.__childPlugUIs.get( childPlug, None )
 		if w is None :
 			return w
 		elif isinstance( w, GafferUI.PlugValueWidget ) :
@@ -199,20 +199,19 @@ class CompoundPlugValueWidget( GafferUI.PlugValueWidget ) :
 	def __updateChildPlugUIs( self ) :
 
 		# ditch child uis we don't need any more
-		childNames = set( self.getPlug().keys() )
-		for childName in self.__childPlugUIs.keys() :
-			if childName not in childNames :
-				del self.__childPlugUIs[childName]
+		for childPlug in self.__childPlugUIs.keys() :
+			if childPlug not in self._childPlugs() :
+				del self.__childPlugUIs[childPlug]
 
 		# make (or reuse existing) uis for each child plug
 		orderedChildUIs = []
 		for childPlug in self._childPlugs() :
 			if childPlug.getName().startswith( "__" ) :
 				continue
-			if childPlug.getName() not in self.__childPlugUIs :
+			if childPlug not in self.__childPlugUIs :
 				widget = self._childPlugWidget( childPlug )
 				assert( isinstance( widget, ( GafferUI.PlugValueWidget, type( None ) ) ) or hasattr( widget, "plugValueWidget" ) )
-				self.__childPlugUIs[childPlug.getName()] = widget
+				self.__childPlugUIs[childPlug] = widget
 				if widget is not None :
 					if isinstance( widget, GafferUI.PlugValueWidget ) :
 						widget.setReadOnly( self.getReadOnly() )
@@ -222,7 +221,7 @@ class CompoundPlugValueWidget( GafferUI.PlugValueWidget ) :
 					else :
 						widget.plugValueWidget().setReadOnly( self.getReadOnly() )
 			else :
-				widget = self.__childPlugUIs[childPlug.getName()]
+				widget = self.__childPlugUIs[childPlug]
 			if widget is not None :
 				orderedChildUIs.append( widget )
 				if Gaffer.Metadata.plugValue( childPlug, "divider" ) :

--- a/src/GafferCortex/CompoundParameterHandler.cpp
+++ b/src/GafferCortex/CompoundParameterHandler.cpp
@@ -35,6 +35,8 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
+#include "boost/container/flat_set.hpp"
+
 #include "IECore/MessageHandler.h"
 #include "IECore/SimpleTypedData.h"
 
@@ -107,11 +109,15 @@ Gaffer::Plug *CompoundParameterHandler::setupPlug( Gaffer::GraphComponent *plugP
 
 	// loop through the handlers and remove any that are not linked to a new parameter
 	const CompoundParameter::ParameterVector &children = m_parameter->orderedParameters();
+
+	// using a flat_set for fast searches
+	boost::container::flat_set<IECore::ParameterPtr> searchParameters(children.begin(), children.end());
+
 	std::vector<Gaffer::PlugPtr> toRemove;
 	for( HandlerMap::iterator it = m_handlers.begin(), eIt = m_handlers.end(); it!=eIt; )
 	{
 		HandlerMap::iterator nextIt = it; nextIt++; // increment now because removing will invalidate iterator
-		if( std::find( children.begin(), children.end(), it->first ) == children.end() )
+		if( searchParameters.find( it->first ) == searchParameters.end() )
 		{
 			toRemove.push_back( it->second->plug() );
 			m_handlers.erase( it );


### PR DESCRIPTION
When using dynamic compound plugs, where the child plugs had the same name but different attributes, like default value or presets, the widget was reusing the plug widget even though we needed a new one, because the name was the same.

This PR makes it so that the `CompoundPlugValueWidget` uses the plug object itself instead of its name when trying to determine if the widget should be reused.

A similar issue had to be addressed in the `CompoundParameterHandler`, since plugs were being reused if they matched the same name, even if the parameters were different.
