### PR TITLE
Sets context fixes

### DIFF
--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -661,6 +661,29 @@ class ArnoldRenderTest( GafferTest.TestCase ) :
 			self.assertEqual( self.__arrayToSet( arnold.AiNodeGetArray( firstSphere, "trace_sets" ) ), { "firstSphere", "group", "bothSpheres" } )
 			self.assertEqual( self.__arrayToSet( arnold.AiNodeGetArray( secondSphere, "trace_sets" ) ), { "secondSphere", "group", "bothSpheres" } )
 
+	def testSetsNeedContextEntry( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["light"] = GafferArnold.ArnoldLight()
+		script["light"].loadShader( "point_light" )
+
+		script["expression"] = Gaffer.Expression()
+		script["expression"].setExpression(
+			"""parent["light"]["name"] = context["lightName"]"""
+		)
+
+		script["render"] = GafferArnold.ArnoldRender()
+		script["render"]["in"].setInput( script["light"]["out"] )
+		script["render"]["mode"].setValue( script["render"].Mode.SceneDescriptionMode )
+		script["render"]["fileName"].setValue( self.temporaryDirectory() + "/test.ass" )
+
+		for i in range( 0, 100 ) :
+
+			with Gaffer.Context() as context :
+				context["lightName"] = "light%d" % i
+				script["render"]["task"].execute()
+
 	def __arrayToSet( self, a ) :
 
 		result = set()

--- a/python/GafferSceneTest/SceneAlgoTest.py
+++ b/python/GafferSceneTest/SceneAlgoTest.py
@@ -38,6 +38,7 @@ import unittest
 
 import IECore
 
+import Gaffer
 import GafferScene
 import GafferSceneTest
 
@@ -193,6 +194,22 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 		o["options"]["renderCamera"]["enabled"].setValue( True )
 		c2 = GafferScene.camera( o["out"] )
 		self.assertEqual( c1, c2 )
+
+	def testSetsNeedContextEntry( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["light"] = GafferSceneTest.TestLight()
+		script["light"]["sets"].setValue( "A B C" )
+
+		script["expression"] = Gaffer.Expression()
+		script["expression"].setExpression(
+			"""parent["light"]["name"] = context["lightName"]"""
+		)
+
+		for i in range( 0, 100 ) :
+			with Gaffer.Context() as context :
+				context["lightName"] = "light%d" % i
+				GafferScene.sets( script["light"]["out"] )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -444,13 +444,14 @@ namespace
 struct Sets
 {
 
-	Sets( const ScenePlug *scene, const std::vector<InternedString> &names, std::vector<GafferScene::ConstPathMatcherDataPtr> &sets )
-		:	m_scene( scene ), m_names( names ), m_sets( sets )
+	Sets( const ScenePlug *scene, const Context *context, const std::vector<InternedString> &names, std::vector<GafferScene::ConstPathMatcherDataPtr> &sets )
+		:	m_scene( scene ), m_context( context ), m_names( names ), m_sets( sets )
 	{
 	}
 
 	void operator()( const tbb::blocked_range<size_t> &r ) const
 	{
+		Context::Scope scopedContext( m_context );
 		for( size_t i=r.begin(); i!=r.end(); ++i )
 		{
 			m_sets[i] = m_scene->set( m_names[i] );
@@ -460,6 +461,7 @@ struct Sets
 	private :
 
 		const ScenePlug *m_scene;
+		const Context *m_context;
 		const std::vector<InternedString> &m_names;
 		std::vector<GafferScene::ConstPathMatcherDataPtr> &m_sets;
 
@@ -478,7 +480,7 @@ IECore::ConstCompoundDataPtr GafferScene::sets( const ScenePlug *scene, const st
 	std::vector<GafferScene::ConstPathMatcherDataPtr> setsVector;
 	setsVector.resize( setNames.size(), NULL );
 
-	Sets setsCompute( scene, setNames, setsVector );
+	Sets setsCompute( scene, Context::current(), setNames, setsVector );
 	parallel_for( tbb::blocked_range<size_t>( 0, setsVector.size() ), setsCompute );
 
 	CompoundDataPtr result = new CompoundData;


### PR DESCRIPTION
This fixes two identical context handling bugs when computing sets in parallel. When spawning tasks in other threads, it is the responsibility of those tasks to correctly transfer the context from the originating thread.