### PR TITLE
Geometry attribute edits in InteractiveRenders

### DIFF
--- a/include/GafferScene/Private/IECoreScenePreview/Renderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/Renderer.h
@@ -148,8 +148,12 @@ class Renderer : public IECore::RefCounted
 				virtual void transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times ) = 0;
 				/// Assigns a new block of attributes to the object, replacing any
 				/// previously assigned attributes. This may only be used in Interactive
-				/// mode, and then only when the renderer is paused.
-				virtual void attributes( const AttributesInterface *attributes ) = 0;
+				/// mode, and then only when the renderer is paused. Returns true on
+				/// success and false if the entire object must be replaced in order
+				/// to produce the requested update - this is necessary for renderers
+				/// such as Arnold where the attributes are not orthogonal to the
+				/// geometric representation.
+				virtual bool attributes( const AttributesInterface *attributes ) = 0;
 
 			protected :
 

--- a/python/GafferArnoldUI/ArnoldAttributesUI.py
+++ b/python/GafferArnoldUI/ArnoldAttributesUI.py
@@ -74,7 +74,7 @@ def __subdivisionSummary( plug ) :
 
 	info = []
 	if plug["subdividePolygons"]["enabled"].getValue() :
-		info.append( "Subdivide Polygons " + "On" if plug["subdividePolygons"]["value"].getValue() else "Off" )
+		info.append( "Subdivide Polygons " + ( "On" if plug["subdividePolygons"]["value"].getValue() else "Off" ) )
 	if plug["subdivIterations"]["enabled"].getValue() :
 		info.append( "Iterations %d" % plug["subdivIterations"]["value"].getValue() )
 	if plug["subdivAdaptiveError"]["enabled"].getValue() :


### PR DESCRIPTION
Certain attributes (like "ai:polymesh:subdiv_iterations" and "ai:curves:mode") modify the geometric properties of an object, and therefore can't be edited after creation. In the case of things like subdiv_iterations, this is because Arnold has thrown away the base mesh when doing the subdivision, but there's a more fundamental problem anyway - we can't modify the geometry because we share it between instances automatically.

This PR introduces the concept of a failed attribute edit, signifying that the renderer client should delete and resend the object if they really want to see the edit succeed. This allows us to make interactive edits to all GafferArnold's geometry attributes and see the results immediately without a restart, which is nice, since it was a bit confusing otherwise (it confused me when I was adding the curves attributes, and I wrote it).