### PR TITLE
Support More OSL Metadata

### DIFF
--- a/python/GafferOSLTest/OSLShaderTest.py
+++ b/python/GafferOSLTest/OSLShaderTest.py
@@ -405,6 +405,22 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		self.assertEqual( n.parameterMetadata( n["parameters"]["a"], "aIntValues" ), IECore.IntVectorData( [ 1, 2 ] ) )
 		self.assertEqual( n.parameterMetadata( n["parameters"]["a"], "aFloatValues" ), IECore.FloatVectorData( [ 0.25, 0.5 ] ) )
 
+	def testParameterSplineMetadata( self ) :
+
+		s = self.compileShader( os.path.dirname( __file__ ) + "/shaders/splineMetadata.osl" )
+		n = GafferOSL.OSLShader()
+		n.loadShader( s )
+
+		# If the components of the spline all match, the metadata is registered to the spline plug
+		self.assertEqual( n.parameterMetadata( n["parameters"]["correctSpline"], "a" ), 1 )
+		self.assertEqual( n.parameterMetadata( n["parameters"]["correctSpline"], "b" ), 2 )
+		self.assertEqual( n.parameterMetadata( n["parameters"]["correctSpline"], "c" ), 3 )
+
+		# If the components don't match, the metadata is registered to the individual plugs
+		# Note that array plugs are not supported, so we can't test Values and Positions
+		self.assertEqual( n.parameterMetadata( n["parameters"]["incompleteSplineBasis"], "c" ), 3 )
+
+
 	def testMetadataReuse( self ) :
 
 		s = self.compileShader( os.path.dirname( __file__ ) + "/shaders/arrayMetadata.osl" )

--- a/python/GafferOSLTest/OSLShaderTest.py
+++ b/python/GafferOSLTest/OSLShaderTest.py
@@ -405,6 +405,29 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		self.assertEqual( n.parameterMetadata( n["parameters"]["a"], "aIntValues" ), IECore.IntVectorData( [ 1, 2 ] ) )
 		self.assertEqual( n.parameterMetadata( n["parameters"]["a"], "aFloatValues" ), IECore.FloatVectorData( [ 0.25, 0.5 ] ) )
 
+	def testParameterMinMaxMetadata( self ) :
+
+		s = self.compileShader( os.path.dirname( __file__ ) + "/shaders/metadataMinMax.osl" )
+		n = GafferOSL.OSLShader()
+		n.loadShader( s )
+
+		self.assertAlmostEqual( n["parameters"]["b"].minValue(), 2.3, delta = 0.00001 )
+		self.assertAlmostEqual( n["parameters"]["b"].maxValue(), 4.7, delta = 0.00001 )
+		self.assertEqual( n["parameters"]["c"].minValue(), 23 )
+		self.assertEqual( n["parameters"]["c"].maxValue(), 47 )
+		self.assertEqual( n["parameters"]["d"].minValue(), IECore.Color3f( 1, 2, 3 ) )
+		self.assertEqual( n["parameters"]["d"].maxValue(), IECore.Color3f( 4, 5, 6 ) )
+		self.assertEqual( n["parameters"]["e"].minValue(), IECore.V3f( 1, 2, 3 ) )
+		self.assertEqual( n["parameters"]["e"].maxValue(), IECore.V3f( 4, 5, 6 ) )
+		self.assertEqual( n["parameters"]["f"].minValue(), IECore.V3f( 1, 2, 3 ) )
+		self.assertEqual( n["parameters"]["f"].maxValue(), IECore.V3f( 4, 5, 6 ) )
+		self.assertEqual( n["parameters"]["g"].minValue(), IECore.V3f( 1, 2, 3 ) )
+		self.assertEqual( n["parameters"]["g"].maxValue(), IECore.V3f( 4, 5, 6 ) )
+
+		# Check default min/max if not specified
+		self.assertFalse( n["parameters"]["h"].hasMinValue() )
+		self.assertFalse( n["parameters"]["h"].hasMaxValue() )
+
 	def testParameterSplineMetadata( self ) :
 
 		s = self.compileShader( os.path.dirname( __file__ ) + "/shaders/splineMetadata.osl" )

--- a/python/GafferOSLTest/shaders/metadataMinMax.osl
+++ b/python/GafferOSLTest/shaders/metadataMinMax.osl
@@ -1,0 +1,72 @@
+//////////////////////////////////////////////////////////////////////////
+//  
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//  
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//  
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//  
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//  
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  
+//////////////////////////////////////////////////////////////////////////
+
+surface metadataMinMax
+(
+	// Ignored for non-numeric parameters
+	string a = "" [[
+		string min = "foo",
+		string max = "baz",
+	]],
+	float b = 3 [[
+		float min = 2.3,
+		float max = 4.7
+	]],
+	int c = 30 [[
+		int min = 23,
+		int max = 47
+	]],
+	color d = 0 [[
+		color min = color( 1, 2, 3 ),
+		color max = color( 4, 5, 6 )
+	]],
+	vector e = 0 [[
+		vector min = vector( 1, 2, 3 ),
+		vector max = vector( 4, 5, 6 )
+	]],
+	point f = 0 [[
+		point min = point( 1, 2, 3 ),
+		point max = point( 4, 5, 6 )
+	]],
+	normal g = 0 [[
+		normal min = normal( 1, 2, 3 ),
+		normal max = normal( 4, 5, 6 )
+	]],
+	float h = 0,
+)
+{
+	Ci = emission();
+}

--- a/python/GafferOSLTest/shaders/splineMetadata.osl
+++ b/python/GafferOSLTest/shaders/splineMetadata.osl
@@ -1,0 +1,55 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+shader splineMetadata
+(
+	color correctSplineValues[] = { 0, 0, 1, 1 }[[
+		int a = 1,
+		string page = "foo"
+	]],
+	float correctSplinePositions[] = { 0, 0, 1, 1 }[[
+		int b = 2
+	]],
+	string correctSplineBasis = "bspline"[[
+		int c = 3
+	]],
+
+	string incompleteSplineBasis = "bspline"[[
+		int c = 3
+	]],
+)
+{
+}

--- a/python/GafferOSLUI/OSLShaderUI.py
+++ b/python/GafferOSLUI/OSLShaderUI.py
@@ -53,6 +53,9 @@ def __nodeDescription( node ) :
 	description = node.shaderMetadata( "help" )
 	return description or __defaultDescription
 
+def __nodeUrl( node ) :
+	return node.shaderMetadata( "URL" )
+
 def __plugDescription( plug ) :
 
 	return plug.node().parameterMetadata( plug, "help" ) or ""
@@ -135,6 +138,7 @@ Gaffer.Metadata.registerNode(
 	GafferOSL.OSLShader,
 
 	"description", __nodeDescription,
+	"documentation:url", __nodeUrl,
 
 	plugs = {
 

--- a/python/GafferOSLUI/OSLShaderUI.py
+++ b/python/GafferOSLUI/OSLShaderUI.py
@@ -122,6 +122,10 @@ def __plugWidgetType( plug ) :
 		plug.node().parameterMetadata( plug, "widget" )
 	)
 
+def __plugNoduleType( plug ) :
+
+	return "" if plug.node().parameterMetadata( plug, "connectable" ) == 0 else "GafferUI::StandardNodule"
+
 def __outPlugNoduleType( plug ) :
 
 	return "GafferUI::CompoundNodule" if len( plug ) else "GafferUI::StandardNodule"
@@ -143,6 +147,7 @@ Gaffer.Metadata.registerNode(
 			"presetNames", __plugPresetNames,
 			"presetValues", __plugPresetValues,
 			"plugValueWidget:type", __plugWidgetType,
+			"nodule:type", __plugNoduleType,
 
 		],
 

--- a/python/GafferOSLUI/OSLShaderUI.py
+++ b/python/GafferOSLUI/OSLShaderUI.py
@@ -65,6 +65,10 @@ def __plugDivider( plug ) :
 
 	return plug.node().parameterMetadata( plug, "divider" ) or False
 
+def __plugPage( plug ) :
+
+	return plug.node().parameterMetadata( plug, "page" ) or None
+
 def __plugPresetNames( plug ) :
 
 	options = plug.node().parameterMetadata( plug, "options" )
@@ -135,6 +139,7 @@ Gaffer.Metadata.registerNode(
 			"description", __plugDescription,
 			"label", __plugLabel,
 			"layout:divider", __plugDivider,
+			"layout:section", __plugPage,
 			"presetNames", __plugPresetNames,
 			"presetValues", __plugPresetValues,
 			"plugValueWidget:type", __plugWidgetType,


### PR DESCRIPTION
Most of these changes are really simple.

"connectable" you should double check how I've implemented it, and also that we're OK with the name.  It does sort of seem to suggest that it would make parameters impossible to connect, instead of just controlling UI.  But maybe it's OK in context because all metadata is UI specific?  ( On the other hand, when we later allow dynamic hiding of nodules when they are not relevant based on other parameters, "connectableActivation" is a really weird name ).

For metadata on spline, do we need to worry about what happens if someone specifies contradictory metadata on splinePositions and splineValues?