### PR TITLE
Arnold shader reload fix

### DIFF
--- a/python/GafferArnoldTest/ArnoldShaderTest.py
+++ b/python/GafferArnoldTest/ArnoldShaderTest.py
@@ -415,7 +415,7 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 		for p in n["parameters"] :
 			self.assertTrue( isinstance( p, Gaffer.Color4fPlug ) )
 
-		self.addCleanup( setattr, os.environ, "ARNOLD_PLUGIN_PATH", os.environ["ARNOLD_PLUGIN_PATH"] )
+		self.addCleanup( os.environ.__setitem__, "ARNOLD_PLUGIN_PATH", os.environ["ARNOLD_PLUGIN_PATH"] )
 		os.environ["ARNOLD_PLUGIN_PATH"] = os.environ["ARNOLD_PLUGIN_PATH"] + ":" + os.path.join( os.path.dirname( __file__ ), "metadata" )
 
 		n = GafferArnold.ArnoldShader()


### PR DESCRIPTION
This fixes a nasty bug introduced in 0.28.2.0, whereby output parameters on ArnoldShader nodes could end up with the wrong default value, which in turn triggered a bug upon reloading.