### PR TITLE
OSLCode node round 2

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -715,7 +715,9 @@ libraries = {
 		"requiredOptions" : [ "APPLESEED_ROOT" ],
 	},
 
-	"GafferAppleseedTest" : {},
+	"GafferAppleseedTest" : {
+		"additionalFiles" : glob.glob( "python/GafferAppleseedTest/*/*" ),
+	},
 
 	"GafferAppleseedUI" : {},
 

--- a/apps/screengrab/screengrab-1.py
+++ b/apps/screengrab/screengrab-1.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import os
+import time
 
 import IECore
 
@@ -187,6 +188,12 @@ class screengrab( Gaffer.Application ) :
 					defaultValue = "",
 				),
 
+				IECore.FloatParameter(
+					name = "delay",
+					description = "A delay between setting up the script and grabbing the image.",
+					defaultValue = 0,
+				),
+
 			]
 
 		)
@@ -334,6 +341,12 @@ class screengrab( Gaffer.Application ) :
 
 		script.context()["ui:scene:expandedPaths"] = GafferScene.PathMatcherData( pathsToExpand )
 		script.context()["ui:scene:selectedPaths"] = args["scene"]["selectedPaths"]
+
+		# Add a delay.
+
+		t = time.time() + args["delay"].value
+		while time.time() < t :
+			self.__waitForIdle( 1 )
 
 		# Write the image, creating a directory for it if necessary.
 

--- a/bin/gaffer
+++ b/bin/gaffer
@@ -93,6 +93,10 @@ export GAFFERUI_IMAGE_PATHS=$GAFFER_ROOT/graphics${GAFFERUI_IMAGE_PATHS:+:}${GAF
 export OSLHOME=$GAFFER_ROOT
 export OSL_SHADER_PATHS=$HOME/gaffer/shaders:$GAFFER_ROOT/shaders${OSL_SHADER_PATHS:+:}${OSL_SHADER_PATHS:-}
 
+if [[ -z $GAFFEROSL_CODE_DIRECTORY ]] ; then
+	export GAFFEROSL_CODE_DIRECTORY=$HOME/gaffer/oslCode
+fi
+
 # Get python set up properly
 ##########################################################################
 

--- a/bin/gaffer
+++ b/bin/gaffer
@@ -95,6 +95,7 @@ export OSL_SHADER_PATHS=$HOME/gaffer/shaders:$GAFFER_ROOT/shaders${OSL_SHADER_PA
 
 if [[ -z $GAFFEROSL_CODE_DIRECTORY ]] ; then
 	export GAFFEROSL_CODE_DIRECTORY=$HOME/gaffer/oslCode
+	export OSL_SHADER_PATHS=$OSL_SHADER_PATHS:$GAFFEROSL_CODE_DIRECTORY
 fi
 
 # Get python set up properly

--- a/doc/source/Tutorials/Scripting/UsingTheOSLCodeNode/generate.sh
+++ b/doc/source/Tutorials/Scripting/UsingTheOSLCodeNode/generate.sh
@@ -1,0 +1,31 @@
+#! /bin/bash
+
+set -e
+
+gaffer screengrab \
+ 	-script scripts/blank.gfr \
+	-selection OSLCode \
+	-editor GafferUI.NodeEditor \
+	-image images/blank.png
+
+gaffer screengrab \
+	-script scripts/parameters.gfr \
+	-selection OSLCode \
+	-editor GafferUI.NodeEditor \
+	-image images/parameters.png
+
+gaffer screengrab \
+	-script scripts/simpleStripes.gfr \
+	-selection OSLCode \
+	-delay 5 \
+	-editor GafferUI.Viewer \
+	-image images/shaderBallStripes.png
+
+gaffer screengrab \
+	-script scripts/coloredStripes.gfr \
+	-selection OSLCode \
+	-delay 5 \
+	-editor GafferUI.Viewer \
+	-image images/shaderBallColoredStripes.png
+
+cp $GAFFER_ROOT/graphics/plus.png images

--- a/doc/source/Tutorials/Scripting/UsingTheOSLCodeNode/index.md
+++ b/doc/source/Tutorials/Scripting/UsingTheOSLCodeNode/index.md
@@ -1,0 +1,70 @@
+Using The OSLCode Node
+======================
+
+Gaffer allows the creation of networks of predefined [OSL][1] shaders to be used in renderering and image and geometry processing, without any coding required. But sometimes the shader you want doesn't exist, or it's easier to express your ideas through a few lines of code. In these situations, the OSLCode node allows OSL source code to be entered directly, to create new shaders on the fly.
+
+A one line shader
+-----------------
+
+Start by creating an OSLCode node in the GraphEditor. With this selected, the NodeEditor will display a blank shader to be edited.
+
+![Blank Shader](images/blank.png)
+
+We'll start by adding some parameters (inputs and outputs) for the shader.
+
+- Click on the upper ![Plus icon](images/plus.png) and choose "Float" from the menu. This creates an input parameter which takes a floating point number.
+- Double click the "Input1" label that appears, and rename the parameter to `width`.
+- Enter the value `0.025` into the width field.
+- Click on the lower ![Plus Icon](images/plus.png) and choose "Color" from the menu. This creates an output color parameter.
+- Double click the "Output1" label, and rename the parameter to "stripes".
+
+![Parameters](images/parameters.png)
+
+We can now enter any OSL code we want to generate the output from the input. Start by entering the following :
+
+```
+stripes = aastep( 0, sin( v * M_PI / width ) )
+```
+
+Now hit _Control + Enter_ to update the shader. The Viewer will update to show a shader ball with the shader on it, and adjusting the width parameter will update the render interactively.
+
+![Shader ball](images/shaderBallStripes.png)
+
+> Tip : Enter the names for input and outputs into the code easily by dragging
+> their labels into the code editor. This is especially useful for color
+> spline inputs, where some special syntax is required to evaluate the spline.
+
+Adding some more features
+---------------------
+
+Let's add a bit of color and some wobble to our shader, to demonstrate a few more features of OSL :
+
+- Add a color input and rename it to `color1`.
+- Add another color input and rename it to `color2`.
+- Click on the colour swatches to pick some tasteful hues.
+
+Now update the code :
+
+```
+float vv = v + 0.05 * pnoise( u * 20, 4 );
+float m = aastep( 0, sin( vv * M_PI / width ) );
+stripes = mix( color1, color2, m );
+```
+
+And as before, hit _Control + Enter_ to update the shader.
+
+![Shader ball](images/shaderBallColoredStripes.png)
+
+No doubt you didn't come here to learn how to make blue and red wobbly stripes, but you are now armed with the ability to add inputs and outputs, edit code and view the results interactively, so are hopefully in a position to create the shader you _do_ want.
+
+> Tip : Explore the available functions in OSL and add them easily to the code by using the _/Insert_ menu items from the _Right Click_ popup menu.
+
+OSL Resources
+-------------
+
+This short tutorial has only scratched the surface of what can be done with Open Shading Language. The following resources are a good place to learn more :
+
+- The [language specification](https://github.com/imageworks/OpenShadingLanguage/blob/master/src/doc/osl-languagespec.pdf) (also available from the _/Help/OpenShadingLanguage/Language Reference_ menu item in Gaffer)
+- The [OSL mailing list](https://groups.google.com/forum/#!forum/osl-dev)
+
+[1]: https://github.com/imageworks/OpenShadingLanguage

--- a/doc/source/Tutorials/Scripting/UsingTheOSLCodeNode/scripts/blank.gfr
+++ b/doc/source/Tutorials/Scripting/UsingTheOSLCodeNode/scripts/blank.gfr
@@ -1,0 +1,30 @@
+import Gaffer
+import GafferOSL
+import IECore
+
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:majorVersion", 28, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:minorVersion", 2, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:patchVersion", 0, persistent=False )
+
+__children = {}
+
+parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "projectName", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectName"].addChild( Gaffer.StringPlug( "name", defaultValue = 'project:name', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectName"].addChild( Gaffer.StringPlug( "value", defaultValue = 'default', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "projectRootDirectory", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "name", defaultValue = 'project:rootDirectory', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "value", defaultValue = '$HOME/gaffer/projects/${project:name}', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["OSLCode"] = GafferOSL.OSLCode( "OSLCode" )
+parent.addChild( __children["OSLCode"] )
+__children["OSLCode"]["name"].setValue( '/home/john/gaffer/oslCode/oslCode6/0ca1740a/de7e8a48/019a23e3/a46ae35/oslCode60ca1740ade7e8a48019a23e3a46ae35' )
+__children["OSLCode"]["type"].setValue( 'osl:shader' )
+__children["OSLCode"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = IECore.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["OSLCode"]["__uiPosition"].setValue( IECore.V2f( -4.30000019, -4.10000086 ) )
+parent["variables"]["projectName"]["name"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
+parent["variables"]["projectRootDirectory"]["name"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
+__children["OSLCode"].loadShader( "/home/john/gaffer/oslCode/oslCode6/0ca1740a/de7e8a48/019a23e3/a46ae35/oslCode60ca1740ade7e8a48019a23e3a46ae35", keepExistingValues=True )
+
+
+del __children
+

--- a/doc/source/Tutorials/Scripting/UsingTheOSLCodeNode/scripts/coloredStripes.gfr
+++ b/doc/source/Tutorials/Scripting/UsingTheOSLCodeNode/scripts/coloredStripes.gfr
@@ -1,0 +1,38 @@
+import Gaffer
+import GafferOSL
+import IECore
+
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:majorVersion", 28, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:minorVersion", 2, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:patchVersion", 0, persistent=False )
+
+__children = {}
+
+parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "projectName", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectName"].addChild( Gaffer.StringPlug( "name", defaultValue = 'project:name', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectName"].addChild( Gaffer.StringPlug( "value", defaultValue = 'default', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "projectRootDirectory", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "name", defaultValue = 'project:rootDirectory', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "value", defaultValue = '$HOME/gaffer/projects/${project:name}', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["OSLCode"] = GafferOSL.OSLCode( "OSLCode" )
+parent.addChild( __children["OSLCode"] )
+__children["OSLCode"]["name"].setValue( '/home/john/gaffer/oslCode/oslCode6/2a70db9d/6970563a/ae48f4fe/f60be6a/oslCode62a70db9d6970563aae48f4fef60be6a' )
+__children["OSLCode"]["type"].setValue( 'osl:shader' )
+__children["OSLCode"]["parameters"].addChild( Gaffer.FloatPlug( "width", defaultValue = 0.0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["OSLCode"]["parameters"]["width"].setValue( 0.02500000037252903 )
+__children["OSLCode"]["parameters"].addChild( Gaffer.Color3fPlug( "color1", defaultValue = IECore.Color3f( 0, 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["OSLCode"]["parameters"]["color1"].setValue( IECore.Color3f( 0.814999998, 0.0401652865, 0 ) )
+__children["OSLCode"]["parameters"].addChild( Gaffer.Color3fPlug( "color2", defaultValue = IECore.Color3f( 0, 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["OSLCode"]["parameters"]["color2"].setValue( IECore.Color3f( 0.210374981, 0.581973732, 0.764999986 ) )
+__children["OSLCode"]["out"].addChild( Gaffer.Color3fPlug( "stripes", direction = Gaffer.Plug.Direction.Out, defaultValue = IECore.Color3f( 0, 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["OSLCode"]["code"].setValue( 'float vv = v + 0.05 * pnoise( u * 20, 4 );\nfloat m = aastep( 0, sin( vv * M_PI / width ) );\nstripes = mix( color1, color2, m );' )
+__children["OSLCode"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = IECore.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["OSLCode"]["__uiPosition"].setValue( IECore.V2f( -6.90000153, 7.79999971 ) )
+parent["variables"]["projectName"]["name"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
+parent["variables"]["projectRootDirectory"]["name"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
+__children["OSLCode"].loadShader( "/home/john/gaffer/oslCode/oslCode6/2a70db9d/6970563a/ae48f4fe/f60be6a/oslCode62a70db9d6970563aae48f4fef60be6a", keepExistingValues=True )
+
+
+del __children
+

--- a/doc/source/Tutorials/Scripting/UsingTheOSLCodeNode/scripts/parameters.gfr
+++ b/doc/source/Tutorials/Scripting/UsingTheOSLCodeNode/scripts/parameters.gfr
@@ -1,0 +1,33 @@
+import Gaffer
+import GafferOSL
+import IECore
+
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:majorVersion", 28, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:minorVersion", 2, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:patchVersion", 0, persistent=False )
+
+__children = {}
+
+parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "projectName", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectName"].addChild( Gaffer.StringPlug( "name", defaultValue = 'project:name', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectName"].addChild( Gaffer.StringPlug( "value", defaultValue = 'default', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "projectRootDirectory", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "name", defaultValue = 'project:rootDirectory', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "value", defaultValue = '$HOME/gaffer/projects/${project:name}', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["OSLCode"] = GafferOSL.OSLCode( "OSLCode" )
+parent.addChild( __children["OSLCode"] )
+__children["OSLCode"]["name"].setValue( '/home/john/gaffer/oslCode/oslCode8/2992ebdf/e1e10b4a/bf061985/137110b/oslCode82992ebdfe1e10b4abf061985137110b' )
+__children["OSLCode"]["type"].setValue( 'osl:shader' )
+__children["OSLCode"]["parameters"].addChild( Gaffer.FloatPlug( "width", defaultValue = 0.0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["OSLCode"]["parameters"]["width"].setValue( 0.02500000037252903 )
+__children["OSLCode"]["out"].addChild( Gaffer.Color3fPlug( "stripes", direction = Gaffer.Plug.Direction.Out, defaultValue = IECore.Color3f( 0, 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["OSLCode"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = IECore.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["OSLCode"]["__uiPosition"].setValue( IECore.V2f( -6.90000153, 7.79999971 ) )
+parent["variables"]["projectName"]["name"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
+parent["variables"]["projectRootDirectory"]["name"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
+__children["OSLCode"].loadShader( "/home/john/gaffer/oslCode/oslCode8/2992ebdf/e1e10b4a/bf061985/137110b/oslCode82992ebdfe1e10b4abf061985137110b", keepExistingValues=True )
+
+
+del __children
+

--- a/doc/source/Tutorials/Scripting/UsingTheOSLCodeNode/scripts/simpleStripes.gfr
+++ b/doc/source/Tutorials/Scripting/UsingTheOSLCodeNode/scripts/simpleStripes.gfr
@@ -1,0 +1,34 @@
+import Gaffer
+import GafferOSL
+import IECore
+
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:majorVersion", 28, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:minorVersion", 2, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:patchVersion", 0, persistent=False )
+
+__children = {}
+
+parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "projectName", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectName"].addChild( Gaffer.StringPlug( "name", defaultValue = 'project:name', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectName"].addChild( Gaffer.StringPlug( "value", defaultValue = 'default', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "projectRootDirectory", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "name", defaultValue = 'project:rootDirectory', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "value", defaultValue = '$HOME/gaffer/projects/${project:name}', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["OSLCode"] = GafferOSL.OSLCode( "OSLCode" )
+parent.addChild( __children["OSLCode"] )
+__children["OSLCode"]["name"].setValue( '/home/john/gaffer/oslCode/oslCodec/68a2bbfd/8ce1ce0c/b536d449/e06dce4/oslCodec68a2bbfd8ce1ce0cb536d449e06dce4' )
+__children["OSLCode"]["type"].setValue( 'osl:shader' )
+__children["OSLCode"]["parameters"].addChild( Gaffer.FloatPlug( "width", defaultValue = 0.0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["OSLCode"]["parameters"]["width"].setValue( 0.02500000037252903 )
+__children["OSLCode"]["out"].addChild( Gaffer.Color3fPlug( "stripes", direction = Gaffer.Plug.Direction.Out, defaultValue = IECore.Color3f( 0, 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["OSLCode"]["code"].setValue( 'stripes = aastep( 0, sin( v * M_PI / width ) )' )
+__children["OSLCode"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = IECore.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["OSLCode"]["__uiPosition"].setValue( IECore.V2f( -6.90000153, 7.79999971 ) )
+parent["variables"]["projectName"]["name"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
+parent["variables"]["projectRootDirectory"]["name"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
+__children["OSLCode"].loadShader( "/home/john/gaffer/oslCode/oslCodec/68a2bbfd/8ce1ce0c/b536d449/e06dce4/oslCodec68a2bbfd8ce1ce0cb536d449e06dce4", keepExistingValues=True )
+
+
+del __children
+

--- a/doc/source/Tutorials/Scripting/index.md
+++ b/doc/source/Tutorials/Scripting/index.md
@@ -9,3 +9,4 @@ There is a direct one to one correspondence between the C++ and Python APIs for 
 - [Creating Configuration Files](CreatingConfigurationFiles/index.md)
 - [Adding a Menu Item](AddingAMenuItem/index.md)
 - [Querying a Scene](QueryingAScene/index.md)
+- [Using the OSLCode Node](UsingTheOSLCodeNode/index.md)

--- a/include/GafferOSL/OSLCode.h
+++ b/include/GafferOSL/OSLCode.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2013, John Haddon. All rights reserved.
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,23 +34,53 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef GAFFEROSL_TYPEIDS_H
-#define GAFFEROSL_TYPEIDS_H
+#ifndef GAFFEROSL_OSLCODE_H
+#define GAFFEROSL_OSLCODE_H
+
+#include "GafferOSL/OSLShader.h"
 
 namespace GafferOSL
 {
 
-enum TypeId
+/// \todo It would be better if this node generated the .oso file
+/// on disk on demand, during shader network generation. Rejig the
+/// generation process to allow for this. Also bear in mind the related
+/// todo items in ArnoldDisplacement and ArnoldLight.
+class OSLCode : public OSLShader
 {
-	OSLShaderTypeId = 110975,
-	OSLRendererTypeId = 110976,
-	OSLImageTypeId = 110977,
-	OSLObjectTypeId = 110978,
-	OSLCodeTypeId = 110979,
 
-	LastTypeId = 110999
+	public :
+
+		OSLCode( const std::string &name=defaultName<OSLCode>() );
+		virtual ~OSLCode();
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferOSL::OSLCode, OSLCodeTypeId, OSLShader );
+
+		Gaffer::StringPlug *codePlug();
+		const Gaffer::StringPlug *codePlug() const;
+
+		typedef boost::signal<void ()> ShaderCompiledSignal;
+		/// Signal emitted when a shader is compiled successfully.
+		/// \todo This exists only so the UI knows when to clear
+		/// the error indicator. When we compile shaders on demand,
+		/// we can instead use the same `errorSignal()`/`plugDirtiedSignal()`
+		/// combo we use everywhere else.
+		ShaderCompiledSignal &shaderCompiledSignal();
+
+	private :
+
+		void updateShader();
+		void plugSet( const Gaffer::Plug *plug );
+		void parameterAddedOrRemoved( const Gaffer::GraphComponent *parent );
+
+		static size_t g_firstPlugIndex;
+
+		ShaderCompiledSignal m_shaderCompiledSignal;
+
 };
+
+IE_CORE_DECLAREPTR( OSLCode )
 
 } // namespace GafferOSL
 
-#endif // GAFFEROSL_TYPEIDS_H
+#endif // GAFFEROSL_OSLCODE_H

--- a/include/GafferOSL/OSLCode.h
+++ b/include/GafferOSL/OSLCode.h
@@ -59,6 +59,11 @@ class OSLCode : public OSLShader
 		Gaffer::StringPlug *codePlug();
 		const Gaffer::StringPlug *codePlug() const;
 
+		/// Returns the source to a complete OSL shader created
+		/// from this node, optionally specifying a specific name
+		/// to give to it.
+		std::string source( const std::string shaderName = "" ) const;
+
 		typedef boost::signal<void ()> ShaderCompiledSignal;
 		/// Signal emitted when a shader is compiled successfully.
 		/// \todo This exists only so the UI knows when to clear

--- a/include/GafferOSL/OSLCode.h
+++ b/include/GafferOSL/OSLCode.h
@@ -76,7 +76,9 @@ class OSLCode : public OSLShader
 
 		void updateShader();
 		void plugSet( const Gaffer::Plug *plug );
-		void parameterAddedOrRemoved( const Gaffer::GraphComponent *parent );
+		void parameterAdded( const Gaffer::GraphComponent *parent, Gaffer::GraphComponent *child );
+		void parameterRemoved( const Gaffer::GraphComponent *parent, Gaffer::GraphComponent *child );
+		void parameterNameChanged();
 
 		static size_t g_firstPlugIndex;
 

--- a/include/GafferOSL/Private/CapturingErrorHandler.h
+++ b/include/GafferOSL/Private/CapturingErrorHandler.h
@@ -1,0 +1,69 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFEROSL_PRIVATE_CAPTURINGERRORHANDLER_H
+#define GAFFEROSL_PRIVATE_CAPTURINGERRORHANDLER_H
+
+#include "OpenImageIO/errorhandler.h"
+
+namespace GafferOSL
+{
+
+namespace Private
+{
+
+class CapturingErrorHandler : public OIIO::ErrorHandler
+{
+
+	public :
+
+		CapturingErrorHandler();
+
+		virtual void operator()( int errorCode, const std::string &message );
+
+		const std::string &errors();
+
+	private :
+
+		std::string m_errors;
+
+};
+
+} // namespace Private
+
+} // namespace GafferOSL
+
+#endif // GAFFEROSL_PRIVATE_CAPTURINGERRORHANDLER_H

--- a/include/GafferSceneUI/ShaderView.h
+++ b/include/GafferSceneUI/ShaderView.h
@@ -92,15 +92,18 @@ class ShaderView : public GafferImageUI::ImageView
 		void viewportVisibilityChanged();
 
 		void plugSet( Gaffer::Plug *plug );
-		void plugInputChanged( Gaffer::Plug *plug );
+		void plugDirtied( Gaffer::Plug *plug );
 		void sceneRegistrationChanged( const PrefixAndName &prefixAndName );
 
+		void idleUpdate();
 		void updateRenderer();
 		void updateRendererContext();
 		void updateRendererState();
 		void updateScene();
 
 		Gaffer::BoxPtr m_imageConverter;
+
+		boost::signals::scoped_connection m_idleConnection;
 
 		Gaffer::NodePtr m_renderer;
 		std::string m_rendererShaderPrefix;

--- a/include/GafferSceneUI/ShaderView.h
+++ b/include/GafferSceneUI/ShaderView.h
@@ -100,7 +100,9 @@ class ShaderView : public GafferImageUI::ImageView
 		void updateRendererContext();
 		void updateRendererState();
 		void updateScene();
+		void preRender();
 
+		bool m_framed;
 		Gaffer::BoxPtr m_imageConverter;
 
 		boost::signals::scoped_connection m_idleConnection;

--- a/include/GafferUI/View.h
+++ b/include/GafferUI/View.h
@@ -144,10 +144,6 @@ class View : public Gaffer::Node
 		/// classes may block this temporarily if they want to prevent the triggering -
 		/// this can be useful when modifying the context.
 		boost::signals::connection &contextChangedConnection();
-		/// Called when a plug on this node or on the preprocessor is dirtied.
-		/// Derived classes should call the base class implementation if they
-		/// override this method.
-		virtual void plugDirtied( const Gaffer::Plug *plug );
 
 		/// May be overridden by derived classes to control the region that is framed
 		/// when "F" is pressed.
@@ -167,7 +163,6 @@ class View : public Gaffer::Node
 		Gaffer::ContextPtr m_context;
 		UnarySignal m_contextChangedSignal;
 		boost::signals::scoped_connection m_contextChangedConnection;
-		boost::signals::scoped_connection m_preprocessorPlugDirtiedConnection;
 
 		bool keyPress( GadgetPtr gadget, const KeyEvent &keyEvent );
 

--- a/python/GafferAppleseedTest/AppleseedShaderAdaptorTest.py
+++ b/python/GafferAppleseedTest/AppleseedShaderAdaptorTest.py
@@ -99,14 +99,14 @@ class AppleseedShaderAdaptorTest( GafferOSLTest.OSLTestCase ) :
 		self.assertEqual( adaptor["out"].attributes( "/sphere" ).keys(), [ "osl:surface" ] )
 
 		network = adaptor["out"].attributes( "/sphere" )["osl:surface"]
-		self.assertEqual( len( network ), 3 )
-		self.assertEqual( network[1].name, "surface/as_emission_surface" )
-		self.assertEqual( network[1].type, "osl:shader" )
-		self.assertEqual( network[1].parameters["Color"].value, IECore.Color3f( 1, 0, 0 ) )
+		self.assertEqual( len( network ), 2 )
+		self.assertEqual( network[0].name, "surface/as_emission_surface" )
+		self.assertEqual( network[0].type, "osl:shader" )
+		self.assertEqual( network[0].parameters["Color"].value, IECore.Color3f( 1, 0, 0 ) )
 
-		self.assertEqual( network[2].name, "material/as_material_builder" )
-		self.assertEqual( network[2].type, "osl:surface" )
-		self.assertEqual( network[2].parameters["BSDF"].value, "link:" + network[1].parameters["__handle"].value + ".BSDF" )
+		self.assertEqual( network[1].name, "material/as_material_builder" )
+		self.assertEqual( network[1].type, "osl:surface" )
+		self.assertEqual( network[1].parameters["BSDF"].value, "link:" + network[0].parameters["__handle"].value + ".BSDF" )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferAppleseedTest/shaders/empty.osl
+++ b/python/GafferAppleseedTest/shaders/empty.osl
@@ -1,0 +1,3 @@
+shader empty()
+{
+}

--- a/python/GafferDispatchUI/PythonCommandUI.py
+++ b/python/GafferDispatchUI/PythonCommandUI.py
@@ -58,7 +58,9 @@ Gaffer.Metadata.registerNode(
 			and the current context as `context`.
 			""",
 
-			"plugValueWidget:type", "GafferUI.PythonCommandUI._CommandPlugValueWidget",
+			"plugValueWidget:type", "GafferUI.MultiLineStringPlugValueWidget",
+			"multiLineStringPlugValueWidget:role", "code",
+			"layout:label", "",
 
 		),
 
@@ -109,16 +111,3 @@ Gaffer.Metadata.registerNode(
 	}
 
 )
-
-class _CommandPlugValueWidget( GafferUI.MultiLineStringPlugValueWidget ) :
-
-	def __init__( self, plug, **kw ) :
-
-		GafferUI.MultiLineStringPlugValueWidget.__init__( self, plug, **kw )
-
-	def hasLabel( self ) :
-
-		## \todo Maybe there should be some metadata we could use
-		# to disable the label, rather than having to tell this little
-		# porky pie?
-		return True

--- a/python/GafferOSLTest/OSLCodeTest.py
+++ b/python/GafferOSLTest/OSLCodeTest.py
@@ -241,6 +241,39 @@ class OSLCodeTest( GafferOSLTest.OSLTestCase ) :
 		s.redo()
 		self.assertEqual( self._osoFileName( s["o"] ), f3 )
 
+	def testSource( self ) :
+
+		# Make a shader using the OSLCode node.
+
+		oslCode = GafferOSL.OSLCode()
+
+		oslCode["parameters"]["i"] = Gaffer.Color3fPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		oslCode["out"]["o"] = Gaffer.Color3fPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		oslCode["code"].setValue( "o = i * color( u, v, 0 );")
+
+		# Export it to a .osl file and compile it.
+
+		oslFileName = os.path.join( self.temporaryDirectory(), "test.osl" )
+		with open( oslFileName, "w" ) as f :
+			f.write( oslCode.source( "test") )
+
+		shader = self.compileShader( oslFileName )
+
+		# Load that onto an OSLShader and check that
+		# it matches.
+
+		oslShader = GafferOSL.OSLShader()
+		oslShader.loadShader( shader )
+
+		self.assertEqual( oslShader["parameters"].keys(), oslCode["parameters"].keys() )
+		self.assertEqual( oslShader["out"].keys(), oslCode["out"].keys() )
+
+		for p in oslShader["parameters"].children() :
+			self.assertEqual( repr( p ), repr( oslCode["parameters"][p.getName()] ) )
+
+		for p in oslShader["out"].children() :
+			self.assertEqual( repr( p ), repr( oslCode["out"][p.getName()] ) )
+
 	def _osoFileName( self, oslCode ) :
 
 		# Right now we could get this information by

--- a/python/GafferOSLTest/OSLCodeTest.py
+++ b/python/GafferOSLTest/OSLCodeTest.py
@@ -165,13 +165,13 @@ class OSLCodeTest( GafferOSLTest.OSLTestCase ) :
 
 		oslCode = GafferOSL.OSLCode()
 		oslCode["out"]["out"] = Gaffer.FloatPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
-		oslCode["code"].setValue( 'out = inFloat( "s", 0 );' )
+		self.__assertNoError( oslCode, oslCode["code"].setValue, 'out = inFloat( "s", 0 );' )
 
 	def testImageProcessingFunctions( self ) :
 
 		oslCode = GafferOSL.OSLCode()
 		oslCode["out"]["out"] = Gaffer.FloatPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
-		oslCode["code"].setValue( 'out = inChannel( "R", 0 );' )
+		self.__assertNoError( oslCode, oslCode["code"].setValue, 'out = inChannel( "R", 0 );' )
 
 	def testColorSpline( self ) :
 
@@ -315,6 +315,15 @@ class OSLCodeTest( GafferOSLTest.OSLTestCase ) :
 		self.__osoFileName( oslCode )
 
 		self.assertEqual( len( cs ), 1 )
+
+	def __assertNoError( self, oslCode, fn, *args, **kw ) :
+
+		cs = GafferTest.CapturingSlot( oslCode.errorSignal() )
+
+		fn( *args, **kw )
+		self.__osoFileName( oslCode )
+
+		self.assertEqual( len( cs ), 0 )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferOSLTest/OSLCodeTest.py
+++ b/python/GafferOSLTest/OSLCodeTest.py
@@ -134,14 +134,21 @@ class OSLCodeTest( GafferOSLTest.OSLTestCase ) :
 
 	def testMissingSemiColon( self ) :
 
-		n = GafferOSL.OSLCode()
-		n["parameters"]["in"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
-		n["out"]["out"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		n1 = GafferOSL.OSLCode()
+		n1["parameters"]["in"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		n1["out"]["out"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		n2 = GafferOSL.OSLCode()
+		n2["parameters"]["in"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		n2["out"]["out"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 
 		# The OSLCode node will often be used to throw in a one-liner,
 		# and omitting a semicolon is an easy mistake that we should
 		# correct automatically.
-		n["code"].setValue( "out = in * 2;" )
+		n1["code"].setValue( "out = in * 2" )
+		n2["code"].setValue( "out = in * 2;" )
+
+		self.assertEqual( self.__osoFileName( n1 ), self.__osoFileName( n2 ) )
 
 	def testAddingAndRemovingPlugsUpdatesShader( self ) :
 

--- a/python/GafferOSLTest/OSLCodeTest.py
+++ b/python/GafferOSLTest/OSLCodeTest.py
@@ -293,6 +293,20 @@ class OSLCodeTest( GafferOSLTest.OSLTestCase ) :
 		source = oslCode.source( "test" )
 		self.assertTrue( "shader test" in source )
 
+	def testParameterRenaming( self ) :
+
+		oslCode = GafferOSL.OSLCode()
+		oslCode["parameters"]["i"] = Gaffer.Color3fPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		oslCode["out"]["o"] = Gaffer.Color3fPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		self.__assertError( oslCode, oslCode["code"].setValue, "o = in" )
+
+		cs = GafferTest.CapturingSlot( oslCode.plugDirtiedSignal() )
+		self.__assertNoError( oslCode, oslCode["parameters"]["i"].setName, "in" )
+		self.assertTrue( oslCode["out"] in [ x[0] for x in cs ] )
+
+		self.__assertError( oslCode, oslCode["parameters"]["in"].setName, "i" )
+
 	def __osoFileName( self, oslCode ) :
 
 		# Right now we could get this information by

--- a/python/GafferOSLTest/OSLCodeTest.py
+++ b/python/GafferOSLTest/OSLCodeTest.py
@@ -280,6 +280,12 @@ class OSLCodeTest( GafferOSLTest.OSLTestCase ) :
 		for p in oslShader["out"].children() :
 			self.assertEqual( repr( p ), repr( oslCode["out"][p.getName()] ) )
 
+	def testSourceUsesRequestedName( self ) :
+
+		oslCode = GafferOSL.OSLCode()
+		source = oslCode.source( "test" )
+		self.assertTrue( "shader test" in source )
+
 	def __osoFileName( self, oslCode ) :
 
 		# Right now we could get this information by

--- a/python/GafferOSLTest/OSLCodeTest.py
+++ b/python/GafferOSLTest/OSLCodeTest.py
@@ -1,0 +1,259 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import os
+import subprocess
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferTest
+import GafferOSL
+import GafferOSLTest
+
+class OSLCodeTest( GafferOSLTest.OSLTestCase ) :
+
+	def testPlugTypes( self ) :
+
+		oslCode = GafferOSL.OSLCode()
+		code = ""
+
+		for i, plugType in enumerate( [
+			Gaffer.IntPlug,
+			Gaffer.FloatPlug,
+			Gaffer.V3fPlug,
+			Gaffer.Color3fPlug,
+			Gaffer.M44fPlug,
+			Gaffer.StringPlug,
+			Gaffer.Plug,
+		] ) :
+
+			inName = "in%d" % i
+			outName = "out%d" % i
+
+			oslCode["parameters"][inName] = plugType( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+			oslCode["out"][outName] = plugType( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+			code += "%s = %s;\n" % ( outName, inName )
+
+		oslCode["code"].setValue( code )
+
+		# The OSLCode node will have generated a shader from
+		# the code and parameters we gave it. Load this onto
+		# a regular OSLShader node to check it.
+
+		oslShader = GafferOSL.OSLShader()
+		oslShader.loadShader( self._osoFileName( oslCode ) )
+
+		self.assertEqual( oslShader["parameters"].keys(), oslCode["parameters"].keys() )
+		self.assertEqual( oslShader["out"].keys(), oslCode["out"].keys() )
+
+		for p in oslShader["parameters"].children() :
+			self.assertEqual( repr( p ), repr( oslCode["parameters"][p.getName()] ) )
+
+		for p in oslShader["out"].children() :
+			self.assertEqual( repr( p ), repr( oslCode["out"][p.getName()] ) )
+
+	def testParseError( self ) :
+
+		n = GafferOSL.OSLCode()
+
+		cs = GafferTest.CapturingSlot( n.errorSignal() )
+		self.assertRaises( RuntimeError, n["code"].setValue, "oops" )
+		self.assertEqual( len( cs ), 1 )
+
+	def testParseErrorDoesntDestroyExistingPlugs( self ) :
+
+		n = GafferOSL.OSLCode()
+		n["parameters"]["in"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		n["out"]["out"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		originalPlugs = n["parameters"].children() + n["out"].children()
+
+	 	self.assertRaises( RuntimeError, n["code"].setValue, "oops" )
+
+	 	self.assertEqual( n["parameters"].children() + n["out"].children(), originalPlugs )
+
+	def testEmpty( self ) :
+
+		# We want empty shaders to still output a
+		# shader so that the ShaderView picks it
+		# up, ready to update when an output is
+		# added.
+
+		n = GafferOSL.OSLCode()
+		self.assertTrue( self._osoFileName( n ) )
+		self.assertEqual( n["type"].getValue(), "osl:shader" )
+
+		n["code"].setValue( "//" )
+		self.assertTrue( self._osoFileName( n ) )
+		self.assertEqual( n["type"].getValue(), "osl:shader" )
+
+		n["code"].setValue( "" )
+		self.assertTrue( self._osoFileName( n ) )
+		self.assertEqual( n["type"].getValue(), "osl:shader" )
+
+	def testMissingSemiColon( self ) :
+
+		n = GafferOSL.OSLCode()
+		n["parameters"]["in"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		n["out"]["out"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		# The OSLCode node will often be used to throw in a one-liner,
+		# and omitting a semicolon is an easy mistake that we should
+		# correct automatically.
+		n["code"].setValue( "out = in * 2;" )
+
+	def testAddingAndRemovingPlugsUpdatesShader( self ) :
+
+		oslCode = GafferOSL.OSLCode()
+		oslCode["parameters"]["in"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		oslCode["out"]["out"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		oslShader = GafferOSL.OSLShader()
+		oslShader.loadShader( self._osoFileName( oslCode ) )
+		self.assertTrue( "in" in oslShader["parameters"] )
+		self.assertTrue( "out" in oslShader["out"] )
+
+	def testObjectProcessingFunctions( self ) :
+
+		oslCode = GafferOSL.OSLCode()
+		oslCode["out"]["out"] = Gaffer.FloatPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		oslCode["code"].setValue( 'out = inFloat( "s", 0 );' )
+
+	def testImageProcessingFunctions( self ) :
+
+		oslCode = GafferOSL.OSLCode()
+		oslCode["out"]["out"] = Gaffer.FloatPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		oslCode["code"].setValue( 'out = inChannel( "R", 0 );' )
+
+	def testColorSpline( self ) :
+
+		oslCode = GafferOSL.OSLCode()
+		oslCode["parameters"]["sp"] = Gaffer.SplinefColor3fPlug(
+			defaultValue = IECore.SplinefColor3f(
+				IECore.CubicBasisf.catmullRom(),
+				(
+					( 0, IECore.Color3f( 0 ) ),
+					( 0, IECore.Color3f( 0 ) ),
+					( 1, IECore.Color3f( 1 ) ),
+					( 1, IECore.Color3f( 1 ) ),
+				)
+			),
+			flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+		)
+		oslCode["out"]["o"] = Gaffer.Color3fPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		oslCode["code"].setValue( "o = colorSpline( spPositions, spValues, spBasis, u );" )
+
+		# Load the generated shader onto an OSLShader
+		# node to verify it.
+
+		oslShader = GafferOSL.OSLShader()
+		oslShader.loadShader( self._osoFileName( oslCode ) )
+
+		self.assertEqual( repr( oslShader["parameters"]["sp"] ), repr( oslCode["parameters"]["sp"] ) )
+
+	def testShaderNameMatchesFileName( self ) :
+
+		oslCode = GafferOSL.OSLCode()
+		oslCode["out"]["o"] = Gaffer.Color3fPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		oslCode["code"].setValue( "o = color( 0, 1, 0 );" )
+
+		info = subprocess.check_output( [ "oslinfo", self._osoFileName( oslCode ) ] )
+		self.assertTrue(
+			info.startswith( "shader \"{0}\"".format( os.path.basename( self._osoFileName( oslCode ) ) ) )
+		)
+
+	def testSerialisation( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["o"] = GafferOSL.OSLCode()
+		s["o"]["parameters"]["i"] = Gaffer.Color3fPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["o"]["out"]["o"] = Gaffer.Color3fPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["o"]["code"].setValue( "o = i * color( u, v, 0 );")
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		self.assertEqual( self._osoFileName( s2["o"] ), self._osoFileName( s["o"] ) )
+
+	def testUndo( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["o"] = GafferOSL.OSLCode()
+
+		f1 = self._osoFileName( s["o"] )
+
+		with Gaffer.UndoContext( s ) :
+			s["o"]["parameters"]["i"] = Gaffer.Color3fPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+			s["o"]["out"]["o"] = Gaffer.Color3fPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		f2 = self._osoFileName( s["o"] )
+
+		with Gaffer.UndoContext( s ) :
+			s["o"]["code"].setValue( "o = i * color( u, v, 0 );")
+
+		f3 = self._osoFileName( s["o"] )
+
+		s.undo()
+		self.assertEqual( self._osoFileName( s["o"] ), f2 )
+
+		s.undo()
+		self.assertEqual( self._osoFileName( s["o"] ), f1 )
+
+		s.redo()
+		self.assertEqual( self._osoFileName( s["o"] ), f2 )
+
+		s.redo()
+		self.assertEqual( self._osoFileName( s["o"] ), f3 )
+
+	def _osoFileName( self, oslCode ) :
+
+		# Right now we could get this information by
+		# getting the value directly from the "name" plug
+		# on the OSLCode node, but we're getting it from
+		# the computed shader instead, in the hope that
+		# one day we can refactor things so that it's the
+		# generation of the shader network that also generates
+		# the file on disk. It might be that the
+		# `GafferScene::Shader` base class shouldn't even
+		# mandate the existence of "name" and "type" plugs.
+
+		return oslCode.attributes()["osl:shader"][0].name
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferOSLTest/__init__.py
+++ b/python/GafferOSLTest/__init__.py
@@ -41,6 +41,7 @@ from OSLImageTest import OSLImageTest
 from OSLObjectTest import OSLObjectTest
 from OSLExpressionEngineTest import OSLExpressionEngineTest
 from ModuleTest import ModuleTest
+from OSLCodeTest import OSLCodeTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferOSLUI/OSLCodeUI.py
+++ b/python/GafferOSLUI/OSLCodeUI.py
@@ -34,6 +34,7 @@
 #
 ##########################################################################
 
+import os
 import functools
 
 import IECore
@@ -433,6 +434,6 @@ def __exportOSLShader( nodeEditor, node ) :
 	with GafferUI.ErrorDialogue.ExceptionHandler( title = "Error Exporting Shader", parentWindow = nodeEditor.ancestor( GafferUI.Window ) ) :
 		with open( path, "w" ) as f :
 			with nodeEditor.getContext() :
-				f.write( node.source() )
+				f.write( node.source( os.path.splitext( os.path.basename( path ) )[0] ) )
 
 __nodeEditorToolMenuConnection = GafferUI.NodeEditor.toolMenuSignal().connect( __toolMenu )

--- a/python/GafferOSLUI/OSLCodeUI.py
+++ b/python/GafferOSLUI/OSLCodeUI.py
@@ -53,8 +53,12 @@ Gaffer.Metadata.registerNode(
 	""",
 
 	"layout:customWidget:error:widgetType", "GafferOSLUI.OSLCodeUI._ErrorWidget",
-	"layout:customWidget:error:section", "Settings",
+	"layout:customWidget:error:section", "Settings.Code",
 	"layout:customWidget:error:index", -1,
+
+	"layout:section:Settings.Inputs:collapsed", False,
+	"layout:section:Settings.Outputs:collapsed", False,
+	"layout:section:Settings.Code:collapsed", False,
 
 	plugs = {
 
@@ -92,6 +96,7 @@ Gaffer.Metadata.registerNode(
 
 			"layout:customWidget:footer:widgetType", "GafferOSLUI.OSLCodeUI._ParametersFooter",
 			"layout:customWidget:footer:index", -1,
+			"layout:section", "Settings.Inputs",
 
 		],
 
@@ -115,6 +120,7 @@ Gaffer.Metadata.registerNode(
 
 			"layout:customWidget:footer:widgetType", "GafferOSLUI.OSLCodeUI._ParametersFooter",
 			"layout:customWidget:footer:index", -1,
+			"layout:section", "Settings.Outputs",
 
 		],
 
@@ -136,6 +142,7 @@ Gaffer.Metadata.registerNode(
 			"plugValueWidget:type", "GafferOSLUI.OSLCodeUI._CodePlugValueWidget",
 			"multiLineStringPlugValueWidget:role", "code",
 			"layout:label", "",
+			"layout:section", "Settings.Code",
 
 		],
 

--- a/python/GafferOSLUI/OSLCodeUI.py
+++ b/python/GafferOSLUI/OSLCodeUI.py
@@ -1,0 +1,320 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import functools
+
+import IECore
+
+import Gaffer
+import GafferUI
+import GafferOSL
+
+Gaffer.Metadata.registerNode(
+
+	GafferOSL.OSLCode,
+
+	"description",
+	"""
+	Allows arbitrary OSL shaders to be written directly within
+	Gaffer.
+	""",
+
+	"layout:customWidget:error:widgetType", "GafferOSLUI.OSLCodeUI._ErrorWidget",
+	"layout:customWidget:error:section", "Settings",
+	"layout:customWidget:error:index", -1,
+
+	plugs = {
+
+		"name" : [
+
+			"description", "Generated automatically - do not edit.",
+			"plugValueWidget:type", "",
+
+		],
+
+		"type" : [
+
+			"description", "Generated automatically - do not edit.",
+			"plugValueWidget:type", "",
+
+		],
+
+		"parameters" : [
+
+			"description",
+			"""
+			The inputs to the shader. Any number of inputs may be created
+			by adding child plugs. Supported plug types and the corresponding
+			OSL types are :
+
+			- FloatPlug (`float`)
+			- IntPlug (`int`)
+			- ColorPlug (`color`)
+			- V3fPlug (`vector`)
+			- M44fPlug (`matrix`)
+			- StringPlug (`string`)
+			- Plug (`closure color`)
+			- SplinefColor3f ( triplet of `float [], color [], string` )
+			""",
+
+			"layout:customWidget:footer:widgetType", "GafferOSLUI.OSLCodeUI._ParametersFooter",
+			"layout:customWidget:footer:index", -1,
+
+		],
+
+		"parameters.*" : [
+
+			"labelPlugValueWidget:renameable", True,
+
+		],
+
+		"out" : [
+
+			"description",
+			"""
+			The outputs from the shader. Any number of outputs may be created
+			by adding child plugs. Supported plug types are as for the input
+			parameters, with the exception of SplinefColor3f, which cannot be
+			used as an output.
+			""",
+
+			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
+
+			"layout:customWidget:footer:widgetType", "GafferOSLUI.OSLCodeUI._ParametersFooter",
+			"layout:customWidget:footer:index", -1,
+
+		],
+
+		"out.*" : [
+
+			"labelPlugValueWidget:renameable", True,
+
+		],
+
+		"code" : [
+
+			"description",
+			"""
+			The code for the body of the OSL shader. This should read from the
+			input parameters and write to the output parameters.
+			""",
+
+			"nodule:type", "",
+			"plugValueWidget:type", "GafferOSLUI.OSLCodeUI._CodePlugValueWidget",
+			"multiLineStringPlugValueWidget:role", "code",
+			"layout:label", "",
+
+		],
+
+	}
+
+)
+
+##########################################################################
+# _ParametersFooter
+##########################################################################
+
+class _ParametersFooter( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plug ) :
+
+		row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal )
+
+		GafferUI.PlugValueWidget.__init__( self, row, plug )
+
+		with row :
+
+				GafferUI.Spacer( IECore.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
+
+				GafferUI.MenuButton(
+					image = "plus.png",
+					hasFrame = False,
+					menu = GafferUI.Menu(
+						Gaffer.WeakMethod( self.__menuDefinition ),
+						title = "Add " + ( "Input" if plug.direction() == plug.Direction.In else "Output" )
+					),
+					toolTip = "Add " + ( "Input" if plug.direction() == plug.Direction.In else "Output" )
+				)
+
+				GafferUI.Spacer( IECore.V2i( 1 ), IECore.V2i( 999999, 1 ), parenting = { "expand" : True } )
+
+	def _updateFromPlug( self ) :
+
+		self.setEnabled( self._editable() )
+
+	def __menuDefinition( self ) :
+
+		result = IECore.MenuDefinition()
+
+		labelsAndConstructors = [
+			( "Int", Gaffer.IntPlug ),
+			( "Float", Gaffer.FloatPlug ),
+			( "Vector", Gaffer.V3fPlug ),
+			( "Color", Gaffer.Color3fPlug ),
+			( "Matrix", Gaffer.M44fPlug ),
+			( "String", Gaffer.StringPlug ),
+			( "Closure", Gaffer.Plug )
+		]
+
+		if self.getPlug().direction() == Gaffer.Plug.Direction.In :
+
+			labelsAndConstructors.insert(
+				-1,
+				( "Color Spline",
+					functools.partial(
+						Gaffer.SplinefColor3fPlug,
+						defaultValue = IECore.SplinefColor3f(
+							IECore.CubicBasisf.catmullRom(),
+							(
+								( 0, IECore.Color3f( 0 ) ),
+								( 0, IECore.Color3f( 0 ) ),
+								( 1, IECore.Color3f( 1 ) ),
+								( 1, IECore.Color3f( 1 ) ),
+							)
+						)
+					)
+				)
+			)
+
+		for label, constructor in labelsAndConstructors :
+
+			result.append(
+				"/" + label,
+				{
+					"command" : functools.partial( Gaffer.WeakMethod( self.__addPlug ), constructor ),
+				}
+			)
+
+		return result
+
+	def __addPlug( self, plugConstructor ) :
+
+		direction = self.getPlug().direction()
+		plug = plugConstructor(
+			name = "input1" if direction == Gaffer.Plug.Direction.In else "output1",
+			direction = self.getPlug().direction(),
+			flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+		)
+
+		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+			self.getPlug().addChild( plug )
+
+##########################################################################
+# _CodePlugValueWidget
+##########################################################################
+
+class _CodePlugValueWidget( GafferUI.MultiLineStringPlugValueWidget ) :
+
+	def __init__( self, plug, **kw ) :
+
+		GafferUI.MultiLineStringPlugValueWidget.__init__( self, plug, **kw )
+
+		self.textWidget().setRole( GafferUI.MultiLineTextWidget.Role.Code )
+
+		self.__dropTextConnection = self.textWidget().dropTextSignal().connect( Gaffer.WeakMethod( self.__dropText ) )
+
+	def __dropText( self, widget, dragData ) :
+
+		if not isinstance( dragData, Gaffer.Plug ) :
+			return None
+
+		plug = dragData
+		node = plug.node()
+		if plug.parent() not in ( node["parameters"], node["out"] ) :
+			return None
+
+		if isinstance( plug, Gaffer.SplinefColor3fPlug ) :
+			return "colorSpline( {0}Positions, {0}Values, {0}Basis, u )".format( plug.getName() )
+
+		return plug.getName()
+
+##########################################################################
+# _ErrorWidget
+##########################################################################
+
+class _ErrorWidget( GafferUI.Widget ) :
+
+	def __init__( self, node, **kw ) :
+
+		self.__messageWidget = GafferUI.MessageWidget()
+		GafferUI.Widget.__init__( self, self.__messageWidget, **kw )
+
+		self.__errorConnection = node.errorSignal().connect( Gaffer.WeakMethod( self.__error ) )
+		self.__shaderCompiledConnection = node.shaderCompiledSignal().connect( Gaffer.WeakMethod( self.__shaderCompiled ) )
+
+		self.__messageWidget.setVisible( False )
+
+	def __error( self, plug, source, error ) :
+
+		self.__messageWidget.clear()
+		self.__messageWidget.messageHandler().handle( IECore.Msg.Level.Error, "Compilation error", error )
+		self.__messageWidget.setVisible( True )
+
+	def __shaderCompiled( self ) :
+
+		self.__messageWidget.setVisible( False )
+
+##########################################################################
+# Plug menu
+##########################################################################
+
+## \todo This functionality is duplicated in several places (NodeUI,
+#  BoxUI, CompoundDataPlugValueWidget). It would be better if we could
+#  just control it in one place with a "plugValueWidget:removeable"
+#  metadata value. This main reason we can't do that right now is that
+#  we'd want to register the metadata with "parameters.*", but that would
+#  match "parameters.vector.x" as well as "parameters.vector". This is
+#  a general problem we have with the metadata matching - we should make
+#  '.' unmatchable by '*'.
+def __deletePlug( plug ) :
+
+	with Gaffer.UndoContext( plug.ancestor( Gaffer.ScriptNode ) ) :
+		plug.parent().removeChild( plug )
+
+def __plugPopupMenu( menuDefinition, plugValueWidget ) :
+
+	plug = plugValueWidget.getPlug()
+	node = plug.node()
+	if not isinstance( node, GafferOSL.OSLCode ) :
+		return
+
+	if plug.parent() not in ( node["parameters"], node["out"] ) :
+		return
+
+	menuDefinition.append( "/DeleteDivider", { "divider" : True } )
+	menuDefinition.append( "/Delete", { "command" : IECore.curry( __deletePlug, plug ), "active" : not plugValueWidget.getReadOnly() } )
+
+__plugPopupMenuConnection = GafferUI.PlugValueWidget.popupMenuSignal().connect( __plugPopupMenu )

--- a/python/GafferOSLUI/OSLCodeUI.py
+++ b/python/GafferOSLUI/OSLCodeUI.py
@@ -311,10 +311,85 @@ def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 	if not isinstance( node, GafferOSL.OSLCode ) :
 		return
 
-	if plug.parent() not in ( node["parameters"], node["out"] ) :
-		return
+	if plug.parent() in ( node["parameters"], node["out"] ) :
 
-	menuDefinition.append( "/DeleteDivider", { "divider" : True } )
-	menuDefinition.append( "/Delete", { "command" : IECore.curry( __deletePlug, plug ), "active" : not plugValueWidget.getReadOnly() } )
+		menuDefinition.append( "/DeleteDivider", { "divider" : True } )
+		menuDefinition.append( "/Delete", { "command" : IECore.curry( __deletePlug, plug ), "active" : not plugValueWidget.getReadOnly() } )
+
+	elif plug.isSame( node["code"] ) :
+
+		for label, text in reversed( [
+
+			( "/Math/Constants/Pi", "M_PI" ),
+			( "/Math/Angles/Radians", "radians( angleInDegrees )" ),
+			( "/Math/Angles/Degrees", "degrees( angleInRadians )" ),
+			( "/Math/Trigonometry/Sin", "sin( angleInRadians )" ),
+			( "/Math/Trigonometry/Cosine", "cos( angleInRadians )" ),
+			( "/Math/Trigonometry/Tangent", "tan( angleInRadians )" ),
+			( "/Math/Trigonometry/Arc Sin", "asin( y )" ),
+			( "/Math/Trigonometry/Arc Cosine", "acos( x )" ),
+			( "/Math/Trigonometry/Arc Tangent", "atan( yOverX )" ),
+			( "/Math/Trigonometry/Arc Tangent 2", "atan2( y, x )" ),
+			( "/Math/Exponents/Pow", "pow( x, y )" ),
+			( "/Math/Exponents/Exp", "exp( x )" ),
+			( "/Math/Exponents/Log", "log( x )" ),
+			( "/Math/Exponents/Square Root", "sqrt( x )" ),
+			( "/Math/Utility/Abs", "abs( x )" ),
+			( "/Math/Utility/Sign", "sign( x )" ),
+			( "/Math/Utility/Floor", "floor( x )" ),
+			( "/Math/Utility/Ceil", "ceil( x )" ),
+			( "/Math/Utility/Round", "round( x )" ),
+			( "/Math/Utility/Trunc", "trunc( x )" ),
+			( "/Math/Utility/Mod", "mod( x )" ),
+			( "/Math/Utility/Min", "min( a, b )" ),
+			( "/Math/Utility/Max", "max( a, b )" ),
+			( "/Math/Utility/Clamp", "clamp( x, minValue, maxValue )" ),
+			( "/Math/Utility/Mix", "mix( a, b, alpha )" ),
+			( "/Math/Geometry/Dot", "dot( a, b )" ),
+
+			( "/Geometry/Cross", "cross( a, b )" ),
+			( "/Geometry/Length", "length( V )" ),
+			( "/Geometry/Length", "distance( p0, p1 )" ),
+			( "/Geometry/Normalize", "normalize( V )" ),
+			( "/Geometry/Face Forward", "faceforward( N, I )" ),
+			( "/Geometry/Reflect", "reflect( I, N )" ),
+			( "/Geometry/Refract", "refract( I, N, eta )" ),
+			( "/Geometry/Rotate", "rotate( p, angle, p0, p1 )" ),
+			( "/Geometry/Transform", "transform( toSpace, p )" ),
+			( "/Geometry/Transform", "transform( fromSpace, toSpace, p )" ),
+
+			( "/Color/Luminance", "luminance( c )" ),
+			( "/Color/BlackBody", "blackbody( degreesKelvin )" ),
+			( "/Color/Wavelength Color", "wavelength_color( wavelengthNm )" ),
+			( "/Color/Transform", "transformc( fromSpace, toSpace, c )" ),
+
+			( "/Pattern/Step", "step( edge, x )" ),
+			( "/Pattern/Linear Step", "linearstep( edge0, edge1, x )" ),
+			( "/Pattern/Smooth Step", "smoothstep( edge0, edge1, x )" ),
+			( "/Pattern/Noise", "noise( \"perlin\", p )" ),
+			( "/Pattern/Periodic Noise", "noise( \"perlin\", p, period )" ),
+			( "/Pattern/Cell Noise", "cellnoise( p )" ),
+
+			( "/String/Length", "length( str )" ),
+			( "/String/Format", "format( \"\", ... )" ),
+			( "/String/Join", "concat( str0, str1 )" ),
+			( "/String/Split", "split( str, results )" ),
+			( "/String/Starts With", "startswith( str, prefix )" ),
+			( "/String/Ends With", "endswith( str, suffix )" ),
+			( "/String/Substring", "substr( str, start, length )" ),
+			( "/String/Get Char", "getchar( str, n )" ),
+			( "/String/Hash", "hash( str )" ),
+
+			( "/Texture/Texture", "texture( filename, s, t )" ),
+			( "/Texture/Environment", "environment( filename, R )" ),
+
+		] ) :
+
+			menuDefinition.prepend( "/InsertDivider", { "divider" : True } )
+
+			menuDefinition.prepend(
+				"/Insert" + label,
+				{ "command" : functools.partial( plugValueWidget.textWidget().insertText, text ) },
+			)
 
 __plugPopupMenuConnection = GafferUI.PlugValueWidget.popupMenuSignal().connect( __plugPopupMenu )

--- a/python/GafferOSLUI/OSLCodeUI.py
+++ b/python/GafferOSLUI/OSLCodeUI.py
@@ -391,6 +391,9 @@ def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 			( "/Texture/Texture", "texture( filename, s, t )" ),
 			( "/Texture/Environment", "environment( filename, R )" ),
 
+			( "/Parameter/Is Connected", "isconnected( parameter )" ),
+			( "/Parameter/Is Constant", "isconstant( parameter )" ),
+
 		] ) :
 
 			menuDefinition.prepend( "/InsertDivider", { "divider" : True } )

--- a/python/GafferOSLUI/__init__.py
+++ b/python/GafferOSLUI/__init__.py
@@ -37,5 +37,6 @@
 import OSLShaderUI
 import OSLImageUI
 import OSLObjectUI
+import OSLCodeUI
 
 __import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", {}, subdirectory = "GafferOSLUI" )

--- a/python/GafferOSLUITest/OSLCodeUITest.py
+++ b/python/GafferOSLUITest/OSLCodeUITest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,9 +34,37 @@
 #
 ##########################################################################
 
-from DocumentationTest import DocumentationTest
-from OSLShaderUITest import OSLShaderUITest
-from OSLCodeUITest import OSLCodeUITest
+import Gaffer
+import GafferUI
+import GafferOSL
+import GafferOSLTest
+import GafferOSLUI
+
+class OSLCodeUITest( GafferOSLTest.OSLTestCase ) :
+
+	def testChangingOutputNodules( self ) :
+
+		node = GafferOSL.OSLCode()
+		nodeGadget1 = GafferUI.NodeGadget.create( node )
+
+		self.assertTrue( isinstance( nodeGadget1.nodule( node["out"] ), GafferUI.StandardNodule ) )
+
+		node["out"]["o"] = Gaffer.FloatPlug(
+			direction = Gaffer.Plug.Direction.Out,
+			flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+		)
+
+		nodeGadget2 = GafferUI.NodeGadget.create( node )
+
+		self.assertTrue( isinstance( nodeGadget1.nodule( node["out"] ), GafferUI.CompoundNodule ) )
+		self.assertTrue( isinstance( nodeGadget1.nodule( node["out"]["o"] ), GafferUI.StandardNodule ) )
+		self.assertTrue( isinstance( nodeGadget2.nodule( node["out"] ), GafferUI.CompoundNodule ) )
+		self.assertTrue( isinstance( nodeGadget2.nodule( node["out"]["o"] ), GafferUI.StandardNodule ) )
+		self.assertEqual( nodeGadget1.nodule( node["out"] ).bound(), nodeGadget2.nodule( node["out"] ).bound() )
+
+		del node["out"]["o"]
+		self.assertTrue( isinstance( nodeGadget1.nodule( node["out"] ), GafferUI.StandardNodule ) )
+		self.assertTrue( isinstance( nodeGadget2.nodule( node["out"] ), GafferUI.StandardNodule ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -209,10 +209,10 @@ def __nodeName( shaderName ) :
 
 def __loadFromFile( menu, extensions, nodeCreator ) :
 
-	path = Gaffer.FileSystemPath( os.getcwd() )
+	bookmarks = GafferUI.Bookmarks.acquire( menu, category = "shader" )
+	path = Gaffer.FileSystemPath( bookmarks.getDefault( menu ) )
 	path.setFilter( Gaffer.FileSystemPath.createStandardFilter( extensions ) )
 
-	bookmarks = GafferUI.Bookmarks.acquire( menu, category = "shader" )
 	dialogue = GafferUI.PathChooserDialogue( path, title="Load Shader", confirmLabel = "Load", valid=True, leaf=True, bookmarks = bookmarks )
 	path = dialogue.waitForPath( parentWindow = menu.ancestor( GafferUI.ScriptWindow ) )
 

--- a/python/GafferUI/BoxUI.py
+++ b/python/GafferUI/BoxUI.py
@@ -66,6 +66,12 @@ Gaffer.Metadata.registerNode(
 
 	plugs = {
 
+		"*" : [
+
+			"labelPlugValueWidget:renameable", True,
+
+		],
+
 		"user" : [
 
 			# Disable the + button added by NodeUI, since

--- a/python/GafferUI/ExpressionUI.py
+++ b/python/GafferUI/ExpressionUI.py
@@ -114,6 +114,9 @@ def __editExpression( plug ) :
 def __popupMenu( menuDefinition, plugValueWidget ) :
 
 	plug = plugValueWidget.getPlug()
+	if not isinstance( plug, Gaffer.ValuePlug ) :
+		return
+
 	node = plug.node()
 	if node is None or node.parent() is None :
 		return

--- a/python/GafferUI/ExpressionUI.py
+++ b/python/GafferUI/ExpressionUI.py
@@ -156,7 +156,7 @@ class _ExpressionWidget( GafferUI.Widget ) :
 				GafferUI.Label( "Language" )
 				self.__languageMenu = GafferUI.MenuButton( "", menu = GafferUI.Menu( Gaffer.WeakMethod( self.__languageMenuDefinition ) ) )
 
-			self.__textWidget = GafferUI.MultiLineTextWidget()
+			self.__textWidget = GafferUI.MultiLineTextWidget( role = GafferUI.MultiLineTextWidget.Role.Code )
 			self.__activatedConnection = self.__textWidget.activatedSignal().connect( Gaffer.WeakMethod( self.__activated ) )
 			self.__editingFinishedConnection = self.__textWidget.editingFinishedSignal().connect( Gaffer.WeakMethod( self.__editingFinished ) )
 			self.__dropTextConnection = self.__textWidget.dropTextSignal().connect( Gaffer.WeakMethod( self.__dropText ) )

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -41,6 +41,10 @@ QtGui = GafferUI._qtImport( "QtGui" )
 
 ## A simple PlugValueWidget which just displays the name of the plug,
 # with the popup action menu for the plug.
+#
+# Supported plug metadata :
+#
+#  - "labelPlugValueWidget:renameable"
 class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __init__( self, plug, horizontalAlignment=GafferUI.Label.HorizontalAlignment.Left, verticalAlignment=GafferUI.Label.VerticalAlignment.Center, **kw ) :
@@ -179,19 +183,10 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __updateDoubleClickConnection( self ) :
 
-		# If the plug is a user plug or the child of a box, then set things up so it can be
-		# renamed by double clicking on the label. Currently we only accept plugs immediately
-		# parented to the user plug, so as to avoid allowing the renaming of child plugs inside
-		# SplinePlugs and the like, where plug names have specific meanings.
-
 		self.__labelDoubleClickConnection = None
 
-		if self.getPlug() is None :
+		if self.getPlug() is None or not Gaffer.Metadata.plugValue( self.getPlug(), "labelPlugValueWidget:renameable" ) :
 			return
-
-		if not isinstance( self.getPlug().node(), Gaffer.Box ) :
-			if not self.getPlug().node()["user"].isSame( self.getPlug().parent() ) :
-				return
 
 		self.__labelDoubleClickConnection = self.__label.buttonDoubleClickSignal().connect( Gaffer.WeakMethod( self.__labelDoubleClicked ) )
 

--- a/python/GafferUI/MultiLineStringPlugValueWidget.py
+++ b/python/GafferUI/MultiLineStringPlugValueWidget.py
@@ -43,6 +43,7 @@ import GafferUI
 ## Supported Metadata :
 #
 # - "multiLineStringPlugValueWidget:continuousUpdate"
+# - "multiLineStringPlugValueWidget:role"
 class MultiLineStringPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __init__( self, plug, **kw ) :
@@ -80,6 +81,10 @@ class MultiLineStringPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 			fixedLineHeight = Gaffer.Metadata.plugValue( self.getPlug(), "fixedLineHeight" )
 			self.__textWidget.setFixedLineHeight( fixedLineHeight )
+
+			role = Gaffer.Metadata.plugValue( self.getPlug(), "multiLineStringPlugValueWidget:role" )
+			role = getattr( self.__textWidget.Role, role.capitalize() ) if role else self.__textWidget.Role.Text
+			self.__textWidget.setRole( role )
 
 			self.__textChangedConnection.block(
 				not Gaffer.Metadata.plugValue( self.getPlug(), "multiLineStringPlugValueWidget:continuousUpdate" )

--- a/python/GafferUI/MultiLineTextWidget.py
+++ b/python/GafferUI/MultiLineTextWidget.py
@@ -46,8 +46,9 @@ QtCore = GafferUI._qtImport( "QtCore" )
 class MultiLineTextWidget( GafferUI.Widget ) :
 
 	WrapMode = IECore.Enum.create( "None", "Word", "Character", "WordOrCharacter" )
+	Role = IECore.Enum.create( "Text", "Code" )
 
-	def __init__( self, text="", editable=True, wrapMode=WrapMode.WordOrCharacter, fixedLineHeight=None, **kw ) :
+	def __init__( self, text="", editable=True, wrapMode=WrapMode.WordOrCharacter, fixedLineHeight=None, role=Role.Text, **kw ) :
 
 		GafferUI.Widget.__init__( self, _PlainTextEdit(), **kw )
 
@@ -69,6 +70,7 @@ class MultiLineTextWidget( GafferUI.Widget ) :
 		self.setEditable( editable )
 		self.setWrapMode( wrapMode )
 		self.setFixedLineHeight( fixedLineHeight )
+		self.setRole( role )
 
 		self.__dragEnterConnection = self.dragEnterSignal().connect( Gaffer.WeakMethod( self.__dragEnter ) )
 		self.__dragMoveConnection = self.dragMoveSignal().connect( Gaffer.WeakMethod( self.__dragMove ) )
@@ -214,6 +216,22 @@ class MultiLineTextWidget( GafferUI.Widget ) :
 	def getFocussed( self ) :
 
 		return self._qtWidget().hasFocus()
+
+	def setRole( self, role ) :
+
+		if role == self.getRole() :
+			return
+
+		self._qtWidget().setProperty( "gafferRole", GafferUI._Variant.toVariant( str( role ) ) )
+		self._repolish()
+
+	def getRole( self ) :
+
+		role = GafferUI._Variant.fromVariant( self._qtWidget().property( "gafferRole" ) )
+		if role is None :
+			return self.Role.Text
+
+		return getattr( self.Role, role )
 
 	## A signal emitted when the widget loses focus.
 	def editingFinishedSignal( self ) :

--- a/python/GafferUI/NodeUI.py
+++ b/python/GafferUI/NodeUI.py
@@ -80,6 +80,12 @@ Gaffer.Metadata.registerNode(
 
 		),
 
+		"user.*" : (
+
+			"labelPlugValueWidget:renameable", True,
+
+		),
+
 		"*" : (
 
 			"layout:section", lambda plug : "Settings" if isinstance( plug.parent(), Gaffer.Node ) else ""

--- a/python/GafferUI/ScriptEditor.py
+++ b/python/GafferUI/ScriptEditor.py
@@ -59,8 +59,15 @@ class ScriptEditor( GafferUI.EditorWidget ) :
 
 		GafferUI.EditorWidget.__init__( self, self.__splittable, scriptNode, **kw )
 
-		self.__outputWidget = GafferUI.MultiLineTextWidget( editable = False, wrapMode = GafferUI.MultiLineTextWidget.WrapMode.None )
-		self.__inputWidget = GafferUI.MultiLineTextWidget( wrapMode = GafferUI.MultiLineTextWidget.WrapMode.None )
+		self.__outputWidget = GafferUI.MultiLineTextWidget(
+			editable = False,
+			wrapMode = GafferUI.MultiLineTextWidget.WrapMode.None,
+			role = GafferUI.MultiLineTextWidget.Role.Code,
+		)
+		self.__inputWidget = GafferUI.MultiLineTextWidget(
+			wrapMode = GafferUI.MultiLineTextWidget.WrapMode.None,
+			role = GafferUI.MultiLineTextWidget.Role.Code,
+		)
 
 		self.__splittable.append( self.__outputWidget )
 		self.__splittable.append( self.__inputWidget )

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -215,6 +215,12 @@ _styleSheet = string.Template(
 
 	}
 
+	QPlainTextEdit[gafferRole="Code"] {
+
+		font-family: monospace;
+
+	}
+
 	QLineEdit:focus, QPlainTextEdit[readOnly="false"]:focus, QLineEdit[gafferHighlighted=\"true\"] {
 
 		border: 2px solid $brightColor;

--- a/python/GafferUITest/MultiLineTextWidgetTest.py
+++ b/python/GafferUITest/MultiLineTextWidgetTest.py
@@ -131,7 +131,7 @@ class MultiLineTextWidgetTest( GafferUITest.TestCase ) :
 
 	def testErrored( self ) :
 
-		w = GafferUI.TextWidget()
+		w = GafferUI.MultiLineTextWidget()
 		self.assertEqual( w.getErrored(), False )
 
 		w.setErrored( True )
@@ -139,6 +139,20 @@ class MultiLineTextWidgetTest( GafferUITest.TestCase ) :
 
 		w.setErrored( False )
 		self.assertEqual( w.getErrored(), False )
+
+	def testRole( self ) :
+
+		w = GafferUI.MultiLineTextWidget()
+		self.assertEqual( w.getRole(), w.Role.Text )
+
+		w.setRole( w.Role.Code )
+		self.assertEqual( w.getRole(), w.Role.Code )
+
+		w.setRole( w.Role.Text )
+		self.assertEqual( w.getRole(), w.Role.Text )
+
+		w = GafferUI.MultiLineTextWidget( role = w.Role.Code)
+		self.assertEqual( w.getRole(), w.Role.Code )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/shaders/GafferOSL/Spline.h
+++ b/shaders/GafferOSL/Spline.h
@@ -34,20 +34,19 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "GafferOSL/Spline.h"
+#ifndef GAFFEROSL_SPLINE_H
+#define GAFFEROSL_SPLINE_H
 
-shader ColorSpline
-(
-
-	float splinePositions[] = { 0, 0, 1, 1 },
-	color splineValues[] = { 0, 0, 1, 1 },
-	string splineBasis = "catmull-rom",
-
-	float x = 0,
-
-	output color c = 0
-
-)
+float floatSpline( float positions[], float values[], string basis, float x )
 {
-	c = colorSpline( splinePositions, splineValues, splineBasis, x );
+	float t = splineinverse( basis, x, positions  );
+	return spline( basis, t, values );
 }
+
+color colorSpline( float positions[], color values[], string basis, float x )
+{
+	float t = splineinverse( basis, x, positions  );
+	return spline( basis, t, values );
+}
+
+#endif // GAFFEROSL_SPLINE_H

--- a/src/GafferAppleseed/AppleseedShaderAdaptor.cpp
+++ b/src/GafferAppleseed/AppleseedShaderAdaptor.cpp
@@ -156,6 +156,7 @@ IECore::ConstCompoundObjectPtr AppleseedShaderAdaptor::computeAttributes( const 
 
 	// Build an adapter network if we can.
 
+	bool prependInputNetwork = true;
 	vector<ShaderPtr> adapters;
 	if( firstOutput && firstOutput->isclosure )
 	{
@@ -232,17 +233,23 @@ IECore::ConstCompoundObjectPtr AppleseedShaderAdaptor::computeAttributes( const 
 
 		adapters.push_back( emission );
 		adapters.push_back( material );
+
+		prependInputNetwork = false; // We don't need the original shaders at all
 	}
 
 	// Make a new network with the adapter network
 	// appended onto the input network
 
 	ObjectVectorPtr adaptedNetwork = new ObjectVector();
-	adaptedNetwork->members() = shaderNetwork->members(); // Shallow copy for speed - do not modify in place!
 
-	ShaderPtr rootShaderCopy = rootShader->copy();
-	rootShaderCopy->parameters()[g_handleParameterName] = new StringData( "adapterInputHandle" );;
-	adaptedNetwork->members().back() = rootShaderCopy;
+	if( prependInputNetwork )
+	{
+		adaptedNetwork->members() = shaderNetwork->members(); // Shallow copy for speed - do not modify in place!
+
+		ShaderPtr rootShaderCopy = rootShader->copy();
+		rootShaderCopy->parameters()[g_handleParameterName] = new StringData( "adapterInputHandle" );;
+		adaptedNetwork->members().back() = rootShaderCopy;
+	}
 
 	std::copy( adapters.begin(), adapters.end(), back_inserter( adaptedNetwork->members() ) );
 

--- a/src/GafferOSL/CapturingErrorHandler.cpp
+++ b/src/GafferOSL/CapturingErrorHandler.cpp
@@ -1,0 +1,60 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferOSL/Private/CapturingErrorHandler.h"
+
+using namespace GafferOSL::Private;
+
+CapturingErrorHandler::CapturingErrorHandler()
+{
+}
+
+void CapturingErrorHandler::operator()( int errorCode, const std::string &message )
+{
+	if( errorCode >= EH_ERROR )
+	{
+		if( m_errors.size() && *m_errors.rbegin() != '\n' )
+		{
+			m_errors += "\n";
+		}
+		m_errors += message;
+	}
+}
+
+const std::string &CapturingErrorHandler::errors()
+{
+	return m_errors;
+}

--- a/src/GafferOSL/OSLCode.cpp
+++ b/src/GafferOSL/OSLCode.cpp
@@ -155,11 +155,15 @@ string generate( const OSLCode *shader, string &shaderName )
 	result += "\n}\n";
 
 	// The result so far uniquely characterises our shader,
-	// so generate the shader name from its hash.
+	// so generate the shader name from its hash (unless we've
+	// been given a name explicitly).
 
-	IECore::MurmurHash hash;
-	hash.append( result );
-	shaderName = "oslCode" + hash.toString();
+	if( shaderName.empty() )
+	{
+		IECore::MurmurHash hash;
+		hash.append( result );
+		shaderName = "oslCode" + hash.toString();
+	}
 
 	// Now we have the shader name, we can add on the header
 	// for the shader, consisting of a constant set of includes

--- a/src/GafferOSL/OSLCode.cpp
+++ b/src/GafferOSL/OSLCode.cpp
@@ -1,0 +1,416 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include <fstream>
+
+#include "boost/filesystem.hpp"
+#include "boost/bind.hpp"
+
+#include "OSL/oslcomp.h"
+
+#include "IECore/Exception.h"
+
+#include "Gaffer/StringAlgo.h"
+#include "Gaffer/StringPlug.h"
+#include "Gaffer/Metadata.h"
+#include "Gaffer/SplinePlug.h"
+#include "Gaffer/Process.h"
+
+#include "GafferOSL/Private/CapturingErrorHandler.h"
+#include "GafferOSL/OSLCode.h"
+
+using namespace std;
+using namespace IECore;
+using namespace OSL;
+using namespace Gaffer;
+using namespace GafferOSL;
+
+//////////////////////////////////////////////////////////////////////////
+// Code generation
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+string colorSplineParameter( const SplinefColor3fPlug *plug )
+{
+	string result;
+	result += "\tfloat " + plug->getName().string() + "Positions[] = { 0, 0, 1, 1 },\n";
+	result += "\tcolor " + plug->getName().string() + "Values[] = { 0, 0, 1, 1 },\n";
+	result += "\tstring " + plug->getName().string() + "Basis = \"catmull-rom\",\n";
+	return result;
+}
+
+string parameter( const Plug *plug )
+{
+	const Gaffer::TypeId plugType = (Gaffer::TypeId)plug->typeId();
+	if( plugType == SplinefColor3fPlugTypeId )
+	{
+		return colorSplineParameter( static_cast<const SplinefColor3fPlug *>( plug ) );
+	}
+
+	string type;
+	string defaultValue;
+	switch( plugType )
+	{
+		case FloatPlugTypeId :
+			defaultValue = "0.0";
+			type = "float";
+			break;
+		case IntPlugTypeId :
+			defaultValue = "0";
+			type = "int";
+			break;
+		case Color3fPlugTypeId :
+			defaultValue = "color( 0.0 )";
+			type = "color";
+			break;
+		case V3fPlugTypeId :
+			defaultValue = "vector( 0.0 )";
+			type = "vector";
+			break;
+		case M44fPlugTypeId :
+			defaultValue = "1";
+			type = "matrix";
+			break;
+		case StringPlugTypeId :
+			defaultValue = "\"\"";
+			type = "string";
+			break;
+		case PlugTypeId :
+			defaultValue = "0";
+			type = "closure color";
+			break;
+		default :
+			throw IECore::Exception( string( "Unsupported plug type \"" ) + plug->typeName() + "\"" );
+	}
+
+	string direction = plug->direction() == Plug::Out ? "output " : "";
+	return "\t" + direction + type + " " + plug->getName().string() + " = " + defaultValue + ",\n";
+}
+
+string generate( const OSLCode *shader, string &shaderName )
+{
+	// Start with parameters
+
+	string result;
+
+	for( PlugIterator it( shader->parametersPlug() ); !it.done(); ++it )
+	{
+		result += parameter( it->get() );
+	}
+
+	result += "\n";
+
+	for( PlugIterator it( shader->outPlug() ); !it.done(); ++it )
+	{
+		result += parameter( it->get() );
+	}
+
+	result += ")\n";
+
+	// Add on body
+
+	const std::string code = shader->codePlug()->getValue();
+	result += "{\n" + code;
+
+	if( code.size() && *code.rbegin() != ';' )
+	{
+		result += ";";
+	}
+
+	result += "\n}\n";
+
+	// The result so far uniquely characterises our shader,
+	// so generate the shader name from its hash.
+
+	IECore::MurmurHash hash;
+	hash.append( result );
+	shaderName = "oslCode" + hash.toString();
+
+	// Now we have the shader name, we can add on the header
+	// for the shader, consisting of a constant set of includes
+	// and the shader name itself.
+
+	string header;
+	header += "#include \"GafferOSL/ObjectProcessing.h\"\n";
+	header += "#include \"GafferOSL/ImageProcessing.h\"\n";
+	header += "#include \"GafferOSL/Spline.h\"\n\n";
+
+	header += "shader " + shaderName + "(\n";
+
+	result = header + result;
+	return result;
+}
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// Shader compilation
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+class ScopedDirectory : boost::noncopyable
+{
+
+	public :
+
+		ScopedDirectory( const boost::filesystem::path &p )
+			:	m_path( p )
+		{
+			boost::filesystem::create_directories( m_path );
+		}
+
+		~ScopedDirectory()
+		{
+			boost::filesystem::remove_all( m_path );
+		}
+
+	private :
+
+		boost::filesystem::path m_path;
+
+};
+
+boost::filesystem::path compile( const std::string &shaderName, const std::string &shaderSource )
+{
+
+	// We need to ensure the existence of a unique .oso file
+	// containing the compiled code. We allow the user to specify
+	// the base location for such files using the GAFFEROSL_CODE_DIRECTORY
+	// environment variable, but we must also assume that multiple processes
+	// on multiple machines will be concurrently trying to ensure the
+	// same .oso files exist (think renderfarm). We achieve this as follows :
+	//
+	// - Use a hash of the code itself to generate the final .oso filename.
+	//   This does nothing to resolve concurrent accesses, but ensures that
+	//   different code goes in different files.
+	// - If the required file does not exist yet, first generate it in a temporary
+	//   location unique to this process.
+	// - Finally, move the file into place using an atomic `rename()`.
+
+	// Start by generating our final desired filename.
+
+	boost::filesystem::path directory = boost::filesystem::temp_directory_path() / "gafferOSLCode";
+	if( const char *cd = getenv( "GAFFEROSL_CODE_DIRECTORY" ) )
+	{
+		directory = cd;
+	}
+
+	for( size_t i = 0; i < shaderName.length(); i += 8 )
+	{
+		// Split the name into multiple subdirectory names, to avoid
+		// creating lots of files in a single directory.
+		directory /= shaderName.substr( i, 8 );
+	}
+
+	const boost::filesystem::path osoFileName = directory / ( shaderName + ".oso" );
+
+	// If that exists, then someone else has done our work already.
+
+	if( boost::filesystem::exists( osoFileName ) )
+	{
+		return osoFileName.string();
+	}
+
+	// Make a temporary directory we can do our compilation in. The
+	// ScopedDirectory class will remove it for us automatically on
+	// destruction, so we don't need to worry about exception handling.
+
+	const boost::filesystem::path tempDirectory = directory / boost::filesystem::unique_path();
+	ScopedDirectory scopedTempDirectory( tempDirectory );
+
+	// Write the source code out.
+
+	const std::string tempOSLFileName = ( tempDirectory / ( shaderName + ".osl" ) ).string();
+	std::ofstream f( tempOSLFileName.c_str() );
+	if( !f.good() )
+	{
+		throw IECore::IOException( "Unable to open file \"" + tempOSLFileName + "\"" );
+	}
+	f << shaderSource;
+	if( !f.good() )
+	{
+		throw IECore::IOException( "Failed to write to \"" + tempOSLFileName + "\"" );
+	}
+	f.close();
+
+	// Compile.
+
+	GafferOSL::Private::CapturingErrorHandler errorHandler;
+	OSLCompiler compiler( &errorHandler );
+
+	vector<string> options;
+	if( const char *includePaths = getenv( "OSL_SHADER_PATHS" ) )
+	{
+		tokenize( includePaths, ':', options );
+		for( vector<string>::iterator it = options.begin(), eIt = options.end(); it != eIt; ++it )
+		{
+			it->insert( 0, "-I" );
+		}
+	}
+
+	const std::string tempOSOFileName = ( tempDirectory / ( shaderName + ".oso" ) ).string();
+	options.push_back( "-o" );
+	options.push_back( tempOSOFileName );
+
+	if( !compiler.compile( tempOSLFileName, options ) )
+	{
+		if( errorHandler.errors().size() )
+		{
+			throw IECore::Exception( errorHandler.errors() );
+		}
+		else
+		{
+			throw IECore::Exception( "Unknown compilation error" );
+		}
+	}
+
+	// Move temp file where we really want it, and clean up.
+
+	boost::filesystem::rename( tempOSOFileName, osoFileName );
+
+	return osoFileName;
+}
+
+class CompileProcess : public Gaffer::Process
+{
+
+	public :
+
+		CompileProcess( OSLCode *oslCode )
+			:	Process( g_type, oslCode->outPlug() )
+		{
+			try
+			{
+				string shaderName;
+				string shaderSource = generate( oslCode, shaderName );
+				boost::filesystem::path shaderFile = compile( shaderName, shaderSource );
+				oslCode->namePlug()->setValue( shaderFile.replace_extension().string() );
+				oslCode->typePlug()->setValue( "osl:shader" );
+			}
+			catch( ... )
+			{
+				handleException();
+			}
+		}
+
+		static InternedString g_type;
+
+};
+
+InternedString CompileProcess::g_type( "oslCode:compile" );
+
+};
+
+//////////////////////////////////////////////////////////////////////////
+// OSLCode
+//////////////////////////////////////////////////////////////////////////
+
+IE_CORE_DEFINERUNTIMETYPED( OSLCode );
+
+size_t OSLCode::g_firstPlugIndex;
+
+OSLCode::OSLCode( const std::string &name )
+	:	OSLShader( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+
+	addChild( new Plug( "out", Plug::Out ) );
+	// Must not accept inputs for now, because we need to use `plugSetSignal()`
+	// to do the code generation.
+	/// \todo Rejig the NetworkGenerator so there is a hook for us to do our
+	/// code generation on demand at network generation time, and allow inputs
+	/// again.
+	addChild( new StringPlug( "code", Plug::In, "", Plug::Default & ~Plug::AcceptsInputs ) );
+
+	parametersPlug()->childAddedSignal().connect( boost::bind( &OSLCode::parameterAddedOrRemoved, this, ::_1 ) );
+	parametersPlug()->childRemovedSignal().connect( boost::bind( &OSLCode::parameterAddedOrRemoved, this, ::_1 ) );
+
+	outPlug()->childAddedSignal().connect( boost::bind( &OSLCode::parameterAddedOrRemoved, this, ::_1 ) );
+	outPlug()->childRemovedSignal().connect( boost::bind( &OSLCode::parameterAddedOrRemoved, this, ::_1 ) );
+
+	plugSetSignal().connect( boost::bind( &OSLCode::plugSet, this, ::_1 ) );
+
+	updateShader();
+}
+
+OSLCode::~OSLCode()
+{
+}
+
+Gaffer::StringPlug *OSLCode::codePlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+}
+
+const Gaffer::StringPlug *OSLCode::codePlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+}
+
+OSLCode::ShaderCompiledSignal &OSLCode::shaderCompiledSignal()
+{
+	return m_shaderCompiledSignal;
+}
+
+void OSLCode::updateShader()
+{
+	CompileProcess compileProcess( this );
+	shaderCompiledSignal()();
+}
+
+void OSLCode::plugSet( const Gaffer::Plug *plug )
+{
+	if( plug == codePlug() )
+	{
+		updateShader();
+	}
+}
+
+void OSLCode::parameterAddedOrRemoved( const Gaffer::GraphComponent *parent )
+{
+	if( parent == outPlug() && ( parent->children().size() == 0 || parent->children().size() == 1 ) )
+	{
+		// OSLShaderUI registers a dynamic metadata entry which depends on whether or
+		// not the plug has children, so we must notify the world that the value will
+		// have changed.
+		Metadata::plugValueChangedSignal()( staticTypeId(), "out", "nodule:type", outPlug() );
+	}
+	updateShader();
+}

--- a/src/GafferOSL/OSLCode.cpp
+++ b/src/GafferOSL/OSLCode.cpp
@@ -384,6 +384,12 @@ const Gaffer::StringPlug *OSLCode::codePlug() const
 	return getChild<StringPlug>( g_firstPlugIndex + 1 );
 }
 
+std::string OSLCode::source( const std::string shaderName ) const
+{
+	string shaderNameCopy = shaderName;
+	return generate( this, shaderNameCopy );
+}
+
 OSLCode::ShaderCompiledSignal &OSLCode::shaderCompiledSignal()
 {
 	return m_shaderCompiledSignal;

--- a/src/GafferOSL/OSLExpressionEngine.cpp
+++ b/src/GafferOSL/OSLExpressionEngine.cpp
@@ -50,6 +50,8 @@
 #include "Gaffer/CompoundNumericPlug.h"
 #include "Gaffer/StringPlug.h"
 
+#include "GafferOSL/Private/CapturingErrorHandler.h"
+
 using namespace std;
 using namespace boost;
 using namespace Imath;
@@ -59,43 +61,6 @@ using namespace Gaffer;
 
 namespace
 {
-
-//////////////////////////////////////////////////////////////////////////
-// Error handler. We use this to capture error messages when
-// compiling the OSL shader.
-//////////////////////////////////////////////////////////////////////////
-
-class CapturingErrorHandler : public OIIO::ErrorHandler
-{
-
-	public :
-
-		CapturingErrorHandler()
-		{
-		}
-
-		virtual void operator()( int errorCode, const std::string &message )
-		{
-			if( errorCode >= EH_ERROR )
-			{
-				if( m_errors.size() && *m_errors.rbegin() != '\n' )
-				{
-					m_errors += "\n";
-				}
-				m_errors += message;
-			}
-		}
-
-		const std::string &errors()
-		{
-			return m_errors;
-		}
-
-	private :
-
-		string m_errors;
-
-};
 
 //////////////////////////////////////////////////////////////////////////
 // RenderState. OSL would think of this as representing the object
@@ -820,7 +785,7 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 
 			// Compile the shader source into an in-memory oso buffer.
 
-			CapturingErrorHandler errorHandler;
+			GafferOSL::Private::CapturingErrorHandler errorHandler;
 			OSLCompiler compiler( &errorHandler );
 
 			vector<string> options;

--- a/src/GafferOSLModule/GafferOSLModule.cpp
+++ b/src/GafferOSLModule/GafferOSLModule.cpp
@@ -38,15 +38,19 @@
 
 #include "OSL/oslversion.h"
 
+#include "IECorePython/ScopedGILRelease.h"
+
 #include "Gaffer/StringPlug.h"
 
 #include "GafferBindings/DependencyNodeBinding.h"
 #include "GafferBindings/DataBinding.h"
+#include "GafferBindings/SignalBinding.h"
 
 #include "GafferOSL/OSLShader.h"
 #include "GafferOSL/ShadingEngine.h"
 #include "GafferOSL/OSLImage.h"
 #include "GafferOSL/OSLObject.h"
+#include "GafferOSL/OSLCode.h"
 
 using namespace boost::python;
 using namespace GafferBindings;
@@ -62,8 +66,8 @@ class OSLShaderSerialiser : public GafferBindings::NodeSerialiser
 
 	virtual std::string postScript( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const
 	{
-		const OSLShader *shader = static_cast<const OSLShader *>( graphComponent );
-		std::string shaderName = shader->namePlug()->getValue();
+		const OSLShader *oslShader = static_cast<const OSLShader *>( graphComponent );
+		const std::string shaderName = oslShader->namePlug()->getValue();
 		if( shaderName.size() )
 		{
 			return boost::str( boost::format( "%s.loadShader( \"%s\", keepExistingValues=True )\n" ) % identifier % shaderName );
@@ -129,5 +133,11 @@ BOOST_PYTHON_MODULE( _GafferOSL )
 		.def( init<const IECore::ObjectVector *>() )
 		.def( "shade", &ShadingEngine::shade )
 	;
+
+	scope s = GafferBindings::DependencyNodeClass<OSLCode>()
+		.def( "shaderCompiledSignal", &OSLCode::shaderCompiledSignal, return_internal_reference<1>() )
+	;
+
+	SignalClass<OSLCode::ShaderCompiledSignal>( "ShaderCompiledSignal" );
 
 }

--- a/src/GafferOSLModule/GafferOSLModule.cpp
+++ b/src/GafferOSLModule/GafferOSLModule.cpp
@@ -108,6 +108,12 @@ int oslLibraryVersionCode()
 	return OSL_LIBRARY_VERSION_CODE;
 }
 
+std::string oslCodeSource( const OSLCode &oslCode, const std::string &shaderName )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return oslCode.source( shaderName );
+}
+
 } // namespace
 
 BOOST_PYTHON_MODULE( _GafferOSL )
@@ -135,6 +141,7 @@ BOOST_PYTHON_MODULE( _GafferOSL )
 	;
 
 	scope s = GafferBindings::DependencyNodeClass<OSLCode>()
+		.def( "source", &oslCodeSource, ( arg_( "shaderName" ) = "" ) )
 		.def( "shaderCompiledSignal", &OSLCode::shaderCompiledSignal, return_internal_reference<1>() )
 	;
 

--- a/src/GafferUI/CompoundNodule.cpp
+++ b/src/GafferUI/CompoundNodule.cpp
@@ -98,9 +98,6 @@ CompoundNodule::CompoundNodule( Gaffer::PlugPtr plug, LinearContainer::Orientati
 	m_row = new LinearContainer( "row", orientation, LinearContainer::Centre, spacing, direction );
 	addChild( m_row );
 
-	plug->childAddedSignal().connect( boost::bind( &CompoundNodule::childAdded, this, ::_1,  ::_2 ) );
-	plug->childRemovedSignal().connect( boost::bind( &CompoundNodule::childRemoved, this, ::_1,  ::_2 ) );
-
 	for( Gaffer::PlugIterator it( plug.get() ); !it.done(); ++it )
 	{
 		NodulePtr nodule = Nodule::create( *it );
@@ -109,6 +106,9 @@ CompoundNodule::CompoundNodule( Gaffer::PlugPtr plug, LinearContainer::Orientati
 			m_row->addChild( nodule );
 		}
 	}
+
+	plug->childAddedSignal().connect( boost::bind( &CompoundNodule::childAdded, this, ::_1,  ::_2 ) );
+	plug->childRemovedSignal().connect( boost::bind( &CompoundNodule::childRemoved, this, ::_1,  ::_2 ) );
 }
 
 CompoundNodule::~CompoundNodule()
@@ -152,6 +152,11 @@ void CompoundNodule::childAdded( Gaffer::GraphComponent *parent, Gaffer::GraphCo
 {
 	Gaffer::Plug *plug = IECore::runTimeCast<Gaffer::Plug>( child );
 	if( !plug )
+	{
+		return;
+	}
+
+	if( nodule( plug ) )
 	{
 		return;
 	}

--- a/src/GafferUI/View.cpp
+++ b/src/GafferUI/View.cpp
@@ -59,7 +59,6 @@ View::View( const std::string &name, Gaffer::PlugPtr inPlug )
 
 	setContext( new Context() );
 
-	plugDirtiedSignal().connect( boost::bind( &View::plugDirtied, this, ::_1 ) );
 	viewportGadget()->keyPressSignal().connect( boost::bind( &View::keyPress, this, ::_1, ::_2 ) );
 }
 
@@ -107,7 +106,6 @@ void View::setPreprocessor( Gaffer::NodePtr preprocessor )
 {
 	setChild( "__preprocessor", preprocessor );
 	preprocessor->getChild<Plug>( "in" )->setInput( inPlug<Plug>() );
-	m_preprocessorPlugDirtiedConnection = preprocessor->plugDirtiedSignal().connect( boost::bind( &View::plugDirtied, this, ::_1 ) );
 }
 
 void View::contextChanged( const IECore::InternedString &name )
@@ -117,10 +115,6 @@ void View::contextChanged( const IECore::InternedString &name )
 boost::signals::connection &View::contextChangedConnection()
 {
 	return m_contextChangedConnection;
-}
-
-void View::plugDirtied( const Gaffer::Plug *plug )
-{
 }
 
 bool View::keyPress( GadgetPtr gadget, const KeyEvent &keyEvent )

--- a/startup/gui/bookmarks.py
+++ b/startup/gui/bookmarks.py
@@ -45,3 +45,15 @@ bookmarks.add( "Desktop", os.path.expandvars( "$HOME/Desktop" ) )
 
 fontBookmarks = GafferUI.Bookmarks.acquire( application, category="font" )
 fontBookmarks.add( "Gaffer Fonts", os.path.expandvars( "$GAFFER_ROOT/fonts" ) )
+
+shaderBookmarks = GafferUI.Bookmarks.acquire( application, category="shader" )
+defaultShaderDirectory = os.path.expandvars( "$HOME/gaffer/shaders" )
+try :
+	os.makedirs( defaultShaderDirectory )
+except OSError :
+	# makedirs very unhelpfully raises an exception if
+	# the directory already exists, but it might also
+	# raise if it fails. we reraise only in the latter case.
+	if not os.path.isdir( defaultShaderDirectory ) :
+		raise
+shaderBookmarks.setDefault( defaultShaderDirectory )

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -333,16 +333,28 @@ if moduleSearchPath.find( "GafferOSL" ) :
 		# Appleseed comes with a library of OSL shaders which we put
 		# on the OSL_SHADER_PATHS, but we don't want to show them in
 		# this menu, because we show them in the Appleseed menu instead.
-		# This match expression filters them out :
+		#
+		# The OSLCode node also generates a great many shaders behind
+		# the scenes that we don't want to place in the menus. Typically
+		# these aren't on the OSL_SHADER_PATHS anyway because they are
+		# given to the renderer via absolute paths, but at the time of
+		# writing it is necessary to place them on the OSL_SHADER_PATHS
+		# in order to use them in Arnold. We don't enable this by default
+		# because it causes Arnold to potentially load a huge number of
+		# shader plugins at startup, but we hide any oslCode shaders here
+		# in case someone else enables it.
+		#
+		# This match expression filters both categories of shader out :
 		#
 		# - (^|.*/) matches any number (including zero) of directory
 		#   names preceding the shader name.
-		# - (?!as_) is a negative lookahead, asserting that the shader
+		# - (?!as_|oslCode) is a negative lookahead, asserting that the shader
 		#   name does not start with "as_", the prefix for all
-		#   Appleseed shaders.
+		#   Appleseed shaders, or "oslCode", the prefix for all OSLCode
+		#   shaders.
 		# - [^/]*$ matches the rest of the shader name, ensuring it
 		#   doesn't include any directory separators.
-		matchExpression = re.compile( "(^|.*/)(?!as_)[^/]*$"),
+		matchExpression = re.compile( "(^|.*/)(?!as_|oslCode)[^/]*$"),
 		searchTextPrefix = "osl",
 	)
 

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -346,6 +346,7 @@ if moduleSearchPath.find( "GafferOSL" ) :
 		searchTextPrefix = "osl",
 	)
 
+	nodeMenu.append( "/OSL/Code", GafferOSL.OSLCode, searchText = "OSLCode" )
 	nodeMenu.append( "/OSL/Image", GafferOSL.OSLImage, searchText = "OSLImage" )
 	nodeMenu.append( "/OSL/Object", GafferOSL.OSLObject, searchText = "OSLObject" )
 


### PR DESCRIPTION
This reimplements the prototype OSLCode node from #1843 based on our discussion there. It is now focussed totally on making little OSL utility shaders/snippets, and parameter creation is handled through the UI rather than the code. The full shader is synthesized by taking the body of the code as entered by the user and inserting it into an autogenerated template containing the parameter definitions generated from the UI. It looks a lot like Andrew's mockup :

![oslcode](https://cloud.githubusercontent.com/assets/1133871/18842512/234733a2-840d-11e6-96f0-59a3bf44ed92.png)

I haven't added the "see the full shader" tab as showing the guts of the generated code seemed a bit at odds with the "make snippets feel easy" goal, but instead I've provided a menu item in the tool menu to export the full .osl source code.

This PR also contains minor improvements to code editors (why we haven't used a monospaced font until now I don't know), a bunch of UI fixes to deal with the new problems thrown up by the OSLCode node, and a basic tutorial in the documentation.