### PR TITLE
OSLShaderUI : Fix support for "null" widget type

### DIFF
--- a/python/GafferOSLUI/OSLShaderUI.py
+++ b/python/GafferOSLUI/OSLShaderUI.py
@@ -116,7 +116,7 @@ __widgetTypes = {
 	"popup" : "GafferUI.PresetsPlugValueWidget",
 	"mapper" : "GafferUI.PresetsPlugValueWidget",
 	"filename" : "GafferUI.PathPlugValueWidget",
-	"null" : "None",
+	"null" : "",
 }
 
 def __plugWidgetType( plug ) :


### PR DESCRIPTION
As far as I know, we use the empty string to indicate no widget?

I don't see anything that supports the string "None"?

The previous code gave me the following stack trace, and the UI failed to load:

```
Traceback (most recent call last):
  File "/home/danield/apps/gaffer/0.28.2.0dev/cent7.x86_64/cortex/9/gaffer/python/GafferUI/Widget.py", line 887, in eventFilter
    self.__showHide( qObject, qEvent )
  File "/home/danield/apps/gaffer/0.28.2.0dev/cent7.x86_64/cortex/9/gaffer/python/GafferUI/Widget.py", line 953, in __showHide
    widget._visibilityChangedSignal( widget )
RuntimeError: Exception : Traceback (most recent call last):
  File "/home/danield/apps/gaffer/0.28.2.0dev/cent7.x86_64/cortex/9/gaffer/python/GafferUI/LazyMethod.py", line 140, in __visibilityChanged
    cls.__doPendingCalls( widget, method )
  File "/home/danield/apps/gaffer/0.28.2.0dev/cent7.x86_64/cortex/9/gaffer/python/GafferUI/LazyMethod.py", line 174, in __doPendingCalls
    method( widget, *pendingCall.args, **pendingCall.kw )
  File "/home/danield/apps/gaffer/0.28.2.0dev/cent7.x86_64/cortex/9/gaffer/python/GafferUI/PlugLayout.py", line 248, in __updateLazily
    self.__update()
  File "/home/danield/apps/gaffer/0.28.2.0dev/cent7.x86_64/cortex/9/gaffer/python/GafferUI/PlugLayout.py", line 253, in __update
    self.__updateLayout()
  File "/home/danield/apps/gaffer/0.28.2.0dev/cent7.x86_64/cortex/9/gaffer/python/GafferUI/PlugLayout.py", line 295, in __updateLayout
    widget = self.__createPlugWidget( item )
  File "/home/danield/apps/gaffer/0.28.2.0dev/cent7.x86_64/cortex/9/gaffer/python/GafferUI/PlugLayout.py", line 364, in __createPlugWidget
    result = GafferUI.PlugValueWidget.create( plug )
  File "/home/danield/apps/gaffer/0.28.2.0dev/cent7.x86_64/cortex/9/gaffer/python/GafferUI/PlugValueWidget.py", line 365, in create
    widgetClass = __import__( path[0] )
ImportError: No module named None
```
