### PR TITLE
ArnoldOptions log verbosity

### DIFF
--- a/python/GafferArnoldUI/ArnoldOptionsUI.py
+++ b/python/GafferArnoldUI/ArnoldOptionsUI.py
@@ -48,6 +48,8 @@ def __renderingSummary( plug ) :
 		info.append( "Bucket Size %d" % plug["bucketSize"]["value"].getValue() )
 	if plug["bucketScanning"]["enabled"].getValue() :
 		info.append( "Bucket Scanning %s" % plug["bucketScanning"]["value"].getValue().capitalize() )
+	if plug["threads"]["enabled"].getValue() :
+		info.append( "Threads %d" % plug["threads"]["value"].getValue() )
 	return ", ".join( info )
 
 def __samplingSummary( plug ) :
@@ -109,13 +111,6 @@ def __featuresSummary( plug ) :
 
 	return ", ".join( info )
 
-def __performanceSummary( plug ) :
-
-	info = []
-	if plug["threads"]["enabled"].getValue() :
-		info.append( "Threads %d" % plug["threads"]["value"].getValue() )
-	return ", ".join( info )
-
 def __searchPathsSummary( plug ) :
 
 	info = []
@@ -175,7 +170,6 @@ Gaffer.Metadata.registerNode(
 			"layout:section:Sampling:summary", __samplingSummary,
 			"layout:section:Ray Depth:summary", __rayDepthSummary,
 			"layout:section:Features:summary", __featuresSummary,
-			"layout:section:Performance:summary", __performanceSummary,
 			"layout:section:Search Paths:summary", __searchPathsSummary,
 			"layout:section:Error Colors:summary", __errorColorsSummary,
 			"layout:section:Logging:summary", __loggingSummary,
@@ -220,6 +214,19 @@ Gaffer.Metadata.registerNode(
 			"plugValueWidget:type", 'GafferUI.PresetsPlugValueWidget',
 			"presetNames", IECore.StringVectorData( ["Top", "Bottom", "Left", "Right", "Random", "Woven", "Spiral", "Spiral"] ),
 			"presetValues", IECore.StringVectorData( ["top", "bottom", "left", "right", "random", "woven", "spiral", "spiral"] ),
+		],
+
+		"options.threads" : [
+
+			"description",
+			"""
+			Specifies the number of threads Arnold
+			is allowed to use. A value of 0 gives
+			Arnold access to all available threads.
+			""",
+
+			"layout:section", "Rendering",
+
 		],
 
 		# Sampling
@@ -539,21 +546,6 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"layout:section", "Features",
-
-		],
-
-		# Performance
-
-		"options.threads" : [
-
-			"description",
-			"""
-			Specifies the number of threads Arnold
-			is allowed to use. A value of 0 gives
-			Arnold access to all available threads.
-			""",
-
-			"layout:section", "Performance",
 
 		],
 

--- a/python/GafferArnoldUI/ArnoldOptionsUI.py
+++ b/python/GafferArnoldUI/ArnoldOptionsUI.py
@@ -134,6 +134,8 @@ def __loggingSummary( plug ) :
 	info = []
 	if plug["logFileName"]["enabled"].getValue() :
 		info.append( "File name" )
+	if plug["logMaxWarnings"]["enabled"].getValue() :
+		info.append( "Max Warnings %d" % plug["logMaxWarnings"]["value"].getValue() )
 
 	return ", ".join( info )
 
@@ -667,6 +669,18 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"options.logMaxWarnings" : [
+
+			"description",
+			"""
+			The maximum number of warnings that will be reported.
+			""",
+
+			"layout:section", "Logging",
+			"label", "Max Warnings",
+
+		],
+
 		# Licensing
 
 		"options.abortOnLicenseFail" : [
@@ -696,3 +710,44 @@ Gaffer.Metadata.registerNode(
 	}
 
 )
+
+for plugPrefix in ( "log", "console" ) :
+
+	for plugSuffix, description in (
+		( "Info", "information messages" ),
+		( "Warnings", "warning messages" ),
+		( "Errors", "error messages" ),
+		( "Debug", "debug messages" ),
+		( "AssParse", "ass parsing" ),
+		( "Plugins", "plugin loading" ),
+		( "Progress", "progress messages" ),
+		( "NAN", "pixels with NaNs" ),
+		( "Timestamp", "timestamp prefixes" ),
+		( "Stats", "statistics" ),
+		( "Backtrace", "stack backtraces from crashes" ),
+		( "Memory", "memory usage prefixes" ),
+		( "Color", "coloured messages" ),
+	) :
+
+		Gaffer.Metadata.registerNode(
+
+			GafferArnold.ArnoldOptions,
+
+			plugs = {
+
+				"options." + plugPrefix + plugSuffix : [
+
+					"description",
+					"""
+					Whether or not {0} {1} included in the {2} output.
+					""".format( description, "are" if description.endswith( "s" ) else "is", plugPrefix ),
+
+					"label", plugSuffix,
+					"layout:section", "Logging." + ( "Console " if plugPrefix == "console" else "" ) + "Verbosity",
+
+				],
+
+			}
+
+		)
+

--- a/python/GafferUI/Collapsible.py
+++ b/python/GafferUI/Collapsible.py
@@ -50,6 +50,8 @@ class Collapsible( GafferUI.ContainerWidget ) :
 
 		GafferUI.ContainerWidget.__init__( self, QtGui.QWidget(), **kw )
 
+		self._qtWidget().setObjectName( "gafferCollapsible" )
+
 		layout = _VBoxLayout()
 		self._qtWidget().setLayout( layout )
 		layout.setSizeConstraint( QtGui.QLayout.SetMinAndMaxSize )

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -667,7 +667,14 @@ class _CollapsibleLayout( _Layout ) :
 			collapsible = self.__collapsibles.get( name )
 			if collapsible is None :
 
-				collapsible = GafferUI.Collapsible( name, _CollapsibleLayout( self.orientation() ), borderWidth = 2, collapsed = True )
+				collapsible = GafferUI.Collapsible( name, _CollapsibleLayout( self.orientation() ), collapsed = True )
+				# Hack to add margins at the top and bottom but not at the sides.
+				## \todo This is exposed in the public API via the borderWidth
+				# parameter to the Collapsible. That parameter sucks because a) it
+				# makes a margin rather than a border, and b) it doesn't allow per-edge
+				# control. Either make that make sense, or remove it and find a way
+				# of deferring all this to the style.
+				collapsible._qtWidget().layout().setContentsMargins( 0, 2, 0, 2 )
 
 				collapsible.setCornerWidget( GafferUI.Label(), True )
 				## \todo This is fighting the default sizing applied in the Label constructor. Really we need a standard

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -516,6 +516,13 @@ _styleSheet = string.Template(
 		font-weight: bold;
 	}
 
+	QWidget#gafferCollapsible QWidget#gafferCollapsible > QCheckBox#gafferCollapsibleToggle {
+
+		margin-left: 12px;
+		font-weight: normal;
+
+	}
+
 	QCheckBox#gafferCollapsibleToggle:disabled {
 
 		color: $foregroundFaded;

--- a/src/GafferArnold/ArnoldOptions.cpp
+++ b/src/GafferArnold/ArnoldOptions.cpp
@@ -121,18 +121,18 @@ ArnoldOptions::ArnoldOptions( const std::string &name )
 	options->addOptionalMember( "ai:log:color", new IECore::BoolData( true ), "logColor", Gaffer::Plug::Default, false );
 
 	options->addOptionalMember( "ai:console:info", new IECore::BoolData( false ), "consoleInfo", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "ai:console:warnings", new IECore::BoolData( false ), "consoleWarnings", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "ai:console:errors", new IECore::BoolData( false ), "consoleErrors", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:console:warnings", new IECore::BoolData( true ), "consoleWarnings", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:console:errors", new IECore::BoolData( true ), "consoleErrors", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:console:debug", new IECore::BoolData( false ), "consoleDebug", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:console:ass_parse", new IECore::BoolData( false ), "consoleAssParse", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:console:plugins", new IECore::BoolData( false ), "consolePlugins", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:console:progress", new IECore::BoolData( false ), "consoleProgress", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:console:nan", new IECore::BoolData( false ), "consoleNAN", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "ai:console:timestamp", new IECore::BoolData( false ), "consoleTimestamp", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:console:timestamp", new IECore::BoolData( true ), "consoleTimestamp", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:console:stats", new IECore::BoolData( false ), "consoleStats", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "ai:console:backtrace", new IECore::BoolData( false ), "consoleBacktrace", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "ai:console:memory", new IECore::BoolData( false ), "consoleMemory", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "ai:console:color", new IECore::BoolData( false ), "consoleColor", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:console:backtrace", new IECore::BoolData( true ), "consoleBacktrace", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:console:memory", new IECore::BoolData( true ), "consoleMemory", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:console:color", new IECore::BoolData( true ), "consoleColor", Gaffer::Plug::Default, false );
 
 	// Licensing
 

--- a/src/GafferArnold/ArnoldOptions.cpp
+++ b/src/GafferArnold/ArnoldOptions.cpp
@@ -104,6 +104,35 @@ ArnoldOptions::ArnoldOptions( const std::string &name )
 	// Logging
 
 	options->addOptionalMember( "ai:log:filename", new IECore::StringData( "" ), "logFileName", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:log:max_warnings", new IECore::IntData( 100 ), "logMaxWarnings", Gaffer::Plug::Default, false );
+
+	options->addOptionalMember( "ai:log:info", new IECore::BoolData( true ), "logInfo", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:log:warnings", new IECore::BoolData( true ), "logWarnings", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:log:errors", new IECore::BoolData( true ), "logErrors", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:log:debug", new IECore::BoolData( true ), "logDebug", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:log:ass_parse", new IECore::BoolData( true ), "logAssParse", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:log:plugins", new IECore::BoolData( true ), "logPlugins", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:log:progress", new IECore::BoolData( true ), "logProgress", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:log:nan", new IECore::BoolData( true ), "logNAN", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:log:timestamp", new IECore::BoolData( true ), "logTimestamp", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:log:stats", new IECore::BoolData( true ), "logStats", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:log:backtrace", new IECore::BoolData( true ), "logBacktrace", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:log:memory", new IECore::BoolData( true ), "logMemory", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:log:color", new IECore::BoolData( true ), "logColor", Gaffer::Plug::Default, false );
+
+	options->addOptionalMember( "ai:console:info", new IECore::BoolData( false ), "consoleInfo", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:console:warnings", new IECore::BoolData( false ), "consoleWarnings", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:console:errors", new IECore::BoolData( false ), "consoleErrors", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:console:debug", new IECore::BoolData( false ), "consoleDebug", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:console:ass_parse", new IECore::BoolData( false ), "consoleAssParse", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:console:plugins", new IECore::BoolData( false ), "consolePlugins", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:console:progress", new IECore::BoolData( false ), "consoleProgress", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:console:nan", new IECore::BoolData( false ), "consoleNAN", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:console:timestamp", new IECore::BoolData( false ), "consoleTimestamp", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:console:stats", new IECore::BoolData( false ), "consoleStats", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:console:backtrace", new IECore::BoolData( false ), "consoleBacktrace", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:console:memory", new IECore::BoolData( false ), "consoleMemory", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:console:color", new IECore::BoolData( false ), "consoleColor", Gaffer::Plug::Default, false );
 
 	// Licensing
 

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -1232,6 +1232,9 @@ IECore::InternedString g_shaderSearchPathOptionName( "ai:shader_searchpath" );
 std::string g_logFlagsOptionPrefix( "ai:log:" );
 std::string g_consoleFlagsOptionPrefix( "ai:console:" );
 
+const int g_logFlagsDefault = AI_LOG_ALL;
+const int g_consoleFlagsDefault = AI_LOG_WARNINGS | AI_LOG_ERRORS | AI_LOG_TIMESTAMP | AI_LOG_BACKTRACE | AI_LOG_MEMORY | AI_LOG_COLOR;
+
 class ArnoldRenderer : public IECoreScenePreview::Renderer
 {
 
@@ -1242,8 +1245,8 @@ class ArnoldRenderer : public IECoreScenePreview::Renderer
 				m_universeBlock( boost::make_shared<UniverseBlock>(  /* writable = */ true ) ),
 				m_shaderCache( new ShaderCache ),
 				m_instanceCache( new InstanceCache ),
-				m_logFileFlags( AI_LOG_ALL ),
-				m_consoleFlags( AI_LOG_NONE ),
+				m_logFileFlags( g_logFlagsDefault ),
+				m_consoleFlags( g_consoleFlagsDefault ),
 				m_assFileName( fileName )
 		{
 			loadOSLShaders();
@@ -1600,9 +1603,7 @@ class ArnoldRenderer : public IECoreScenePreview::Renderer
 			bool turnOn = false;
 			if( value == NULL )
 			{
-				// All console flags default off, and all
-				// log flags default on.
-				turnOn = console == false;
+				turnOn = flagToModify & ( console == false ? g_logFlagsDefault : g_consoleFlagsDefault );
 			}
 			else if( const IECore::BoolData *d = reportedCast<const IECore::BoolData>( value, "option", name ) )
 			{

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -1226,7 +1226,11 @@ namespace
 /// Or maybe be in a utility header somewhere?
 IECore::InternedString g_cameraOptionName( "camera" );
 IECore::InternedString g_logFileNameOptionName( "ai:log:filename" );
+IECore::InternedString g_logMaxWarningsOptionName( "ai:log:max_warnings" );
 IECore::InternedString g_shaderSearchPathOptionName( "ai:shader_searchpath" );
+
+std::string g_logFlagsOptionPrefix( "ai:log:" );
+std::string g_consoleFlagsOptionPrefix( "ai:console:" );
 
 class ArnoldRenderer : public IECoreScenePreview::Renderer
 {
@@ -1238,11 +1242,13 @@ class ArnoldRenderer : public IECoreScenePreview::Renderer
 				m_universeBlock( boost::make_shared<UniverseBlock>(  /* writable = */ true ) ),
 				m_shaderCache( new ShaderCache ),
 				m_instanceCache( new InstanceCache ),
+				m_logFileFlags( AI_LOG_ALL ),
+				m_consoleFlags( AI_LOG_NONE ),
 				m_assFileName( fileName )
 		{
 			loadOSLShaders();
-			/// \todo Control with an option.
-			AiMsgSetConsoleFlags( AI_LOG_ALL );
+			AiMsgSetLogFileFlags( m_logFileFlags );
+			AiMsgSetConsoleFlags( m_consoleFlags );
 		}
 
 		virtual ~ArnoldRenderer()
@@ -1278,6 +1284,32 @@ class ArnoldRenderer : public IECoreScenePreview::Renderer
 
 				}
 				return;
+			}
+			else if( name == g_logMaxWarningsOptionName )
+			{
+				if( value == NULL )
+				{
+					AiMsgSetMaxWarnings( 100 );
+				}
+				else if( const IECore::IntData *d = reportedCast<const IECore::IntData>( value, "option", name ) )
+				{
+					AiMsgSetMaxWarnings( d->readable() );
+				}
+				return;
+			}
+			else if( boost::starts_with( name.c_str(), g_logFlagsOptionPrefix ) )
+			{
+				if( updateLogFlags( name.string().substr( g_logFlagsOptionPrefix.size() ), value, /* console = */ false ) )
+				{
+					return;
+				}
+			}
+			else if( boost::starts_with( name.c_str(), g_consoleFlagsOptionPrefix ) )
+			{
+				if( updateLogFlags( name.string().substr( g_consoleFlagsOptionPrefix.size() ), value, /* console = */ true ) )
+				{
+					return;
+				}
 			}
 			else if( name == g_shaderSearchPathOptionName )
 			{
@@ -1505,6 +1537,105 @@ class ArnoldRenderer : public IECoreScenePreview::Renderer
 			option( g_shaderSearchPathOptionName, NULL );
 		}
 
+		bool updateLogFlags( const std::string name, const IECore::Data *value, bool console )
+		{
+			int flagToModify = AI_LOG_NONE;
+			if( name == "info" )
+			{
+				flagToModify = AI_LOG_INFO;
+			}
+			else if( name == "warnings" )
+			{
+				flagToModify = AI_LOG_WARNINGS;
+			}
+			else if( name == "errors" )
+			{
+				flagToModify = AI_LOG_ERRORS;
+			}
+			else if( name == "debug" )
+			{
+				flagToModify = AI_LOG_DEBUG;
+			}
+			else if( name == "stats" )
+			{
+				flagToModify = AI_LOG_STATS;
+			}
+			else if( name == "ass_parse" )
+			{
+				flagToModify = AI_LOG_ASS_PARSE;
+			}
+			else if( name == "plugins" )
+			{
+				flagToModify = AI_LOG_PLUGINS;
+			}
+			else if( name == "progress" )
+			{
+				flagToModify = AI_LOG_PROGRESS;
+			}
+			else if( name == "nan" )
+			{
+				flagToModify = AI_LOG_NAN;
+			}
+			else if( name == "timestamp" )
+			{
+				flagToModify = AI_LOG_TIMESTAMP;
+			}
+			else if( name == "backtrace" )
+			{
+				flagToModify = AI_LOG_BACKTRACE;
+			}
+			else if( name == "memory" )
+			{
+				flagToModify = AI_LOG_MEMORY;
+			}
+			else if( name == "color" )
+			{
+				flagToModify = AI_LOG_COLOR;
+			}
+			else
+			{
+				return false;
+			}
+
+			bool turnOn = false;
+			if( value == NULL )
+			{
+				// All console flags default off, and all
+				// log flags default on.
+				turnOn = console == false;
+			}
+			else if( const IECore::BoolData *d = reportedCast<const IECore::BoolData>( value, "option", name ) )
+			{
+				turnOn = d->readable();
+			}
+			else
+			{
+				return true;
+			}
+
+			int &flags = console ? m_consoleFlags : m_logFileFlags;
+			if( turnOn )
+			{
+				flags |= flagToModify;
+			}
+			else
+			{
+				flags = flags & ~flagToModify;
+			}
+
+			if( console )
+			{
+				AiMsgSetConsoleFlags( flags );
+			}
+			else
+			{
+				AiMsgSetLogFileFlags( flags );
+			}
+
+			return true;
+		}
+
+
 		ObjectInterfacePtr store( ObjectInterface *objectInterface )
 		{
 			if( m_renderType != Interactive )
@@ -1635,6 +1766,9 @@ class ArnoldRenderer : public IECoreScenePreview::Renderer
 
 		ShaderCachePtr m_shaderCache;
 		InstanceCachePtr m_instanceCache;
+
+		int m_logFileFlags;
+		int m_consoleFlags;
 
 		// Members used by batch renders
 


### PR DESCRIPTION
This adds verbosity controls to the ArnoldOptions node. There's a slight change of behaviour in that now by default all logging to the console is turned off - this is the default at the Arnold library level. @andrewkaufman, I believe that's what you wanted for the ShaderView, but I don't know if it'll be non-ideal for interactive renders and batch renders?