### PR TITLE
Accessory widgets

### DIFF
--- a/python/GafferImageUI/ImageReaderUI.py
+++ b/python/GafferImageUI/ImageReaderUI.py
@@ -81,6 +81,10 @@ Gaffer.Metadata.registerNode(
 			be loaded via Gaffer's cache.
 			""",
 
+			"plugValueWidget:type", "GafferUI.RefreshPlugValueWidget",
+			"layout:label", "",
+			"layout:accessory", True,
+
 		],
 
 		"missingFrameMode" : [
@@ -190,8 +194,6 @@ Gaffer.Metadata.registerNode(
 	}
 
 )
-
-GafferUI.PlugValueWidget.registerCreator( GafferImage.ImageReader, "refreshCount", GafferUI.IncrementingPlugValueWidget, label = "Refresh", undoable = False )
 
 class _FrameMaskPlugValueWidget( GafferUI.PlugValueWidget ) :
 

--- a/python/GafferImageUI/OpenImageIOReaderUI.py
+++ b/python/GafferImageUI/OpenImageIOReaderUI.py
@@ -81,6 +81,10 @@ Gaffer.Metadata.registerNode(
 			be loaded via Gaffer's cache.
 			""",
 
+			"plugValueWidget:type", "GafferUI.RefreshPlugValueWidget",
+			"layout:label", "",
+			"layout:accessory", True,
+
 		],
 
 		"missingFrameMode" : [
@@ -121,5 +125,3 @@ Gaffer.Metadata.registerNode(
 	}
 
 )
-
-GafferUI.PlugValueWidget.registerCreator( GafferImage.OpenImageIOReader, "refreshCount", GafferUI.IncrementingPlugValueWidget, label = "Refresh", undoable = False )

--- a/python/GafferSceneUI/AlembicSourceUI.py
+++ b/python/GafferSceneUI/AlembicSourceUI.py
@@ -84,20 +84,12 @@ Gaffer.Metadata.registerNode(
 			changed on disk.
 			""",
 
+			"plugValueWidget:type", "GafferUI.RefreshPlugValueWidget",
+			"layout:label", "",
+			"layout:accessory", True,
+
 		],
 
 	}
 
-)
-
-##########################################################################
-# PlugValueWidgets
-##########################################################################
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.AlembicSource,
-	"refreshCount",
-	GafferUI.IncrementingPlugValueWidget,
-	label = "Refresh",
-	undoable = False
 )

--- a/python/GafferSceneUI/SceneReaderUI.py
+++ b/python/GafferSceneUI/SceneReaderUI.py
@@ -89,6 +89,10 @@ Gaffer.Metadata.registerNode(
 			be loaded via Gaffer's cache.
 			""",
 
+			"plugValueWidget:type", "GafferUI.RefreshPlugValueWidget",
+			"layout:label", "",
+			"layout:accessory", True,
+
 		],
 
 		"tags" : [
@@ -104,20 +108,6 @@ Gaffer.Metadata.registerNode(
 	}
 
 )
-
-##########################################################################
-# Widgets
-##########################################################################
-
-GafferUI.PlugValueWidget.registerCreator(
-	GafferScene.SceneReader,
-	"refreshCount",
-	GafferUI.IncrementingPlugValueWidget,
-	label = "Refresh",
-	undoable = False
-)
-
-## \todo Once it's possible to register Widgets to go on the right of a PlugWidget, place the refresh button there.
 
 ##########################################################################
 # Right click menu for tags

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -54,6 +54,7 @@ QtGui = GafferUI._qtImport( "QtGui" )
 #	- "<layoutName>:divider" specifies whether or not a plug should be followed by a divider
 #	- "<layoutName>:activator" the name of an activator to control editability
 #	- "<layoutName>:visibilityActivator" the name of an activator to control visibility
+#	- "<layoutName>:accessory" groups as an accessory to the previous widget
 #
 # Per-parent metadata support :
 #
@@ -306,7 +307,14 @@ class PlugLayout( GafferUI.Widget ) :
 			for sectionName in self.__sectionPath( item )[rootSectionDepth:] :
 				section = section.subsection( sectionName )
 
-			section.widgets.append( widget )
+			if len( section.widgets ) and self.__itemMetadataValue( item, "accessory" ) :
+				row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 )
+				row.append( section.widgets[-1] )
+				row.append( widget )
+				section.widgets[-1] = row
+			else :
+				section.widgets.append( widget )
+
 			if self.__itemMetadataValue( item, "divider" ) :
 				section.widgets.append( GafferUI.Divider(
 					GafferUI.Divider.Orientation.Horizontal if self.__layout.orientation() == GafferUI.ListContainer.Orientation.Vertical else GafferUI.Divider.Orientation.Vertical
@@ -483,6 +491,7 @@ class PlugLayout( GafferUI.Widget ) :
 			self.__layoutName + ":divider",
 			self.__layoutName + ":index",
 			self.__layoutName + ":section",
+			self.__layoutName + ":accessory",
 			"plugValueWidget:type"
 		) :
 			# we often see sequences of several metadata changes - so

--- a/python/GafferUI/RefreshPlugValueWidget.py
+++ b/python/GafferUI/RefreshPlugValueWidget.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -39,19 +39,15 @@ from __future__ import with_statement
 import Gaffer
 import GafferUI
 
-## \deprecated The extra arguments to the constructor force this widget
-# to be used by the deprecated `PlugValueWidget.registerCreator()`. Use
-# `RefreshPlugValueWidget` instead.
-class IncrementingPlugValueWidget( GafferUI.PlugValueWidget ) :
+## PlugValueWidget suitable for incrementing a plug to trigger a refresh
+# of nodes which access the filesystem.
+class RefreshPlugValueWidget( GafferUI.PlugValueWidget ) :
 
-	def __init__( self, plug, label, increment = 1, undoable = True, **kw ) :
+	def __init__( self, plug, **kw ) :
 
-		self.__button = GafferUI.Button( label )
+		self.__button = GafferUI.Button( image = "refresh.png", hasFrame = False )
 
 		GafferUI.PlugValueWidget.__init__( self, self.__button, plug, **kw )
-
-		self.__increment = increment
-		self.__undoable = undoable
 
 		self.__clickedConnection = self.__button.clickedSignal().connect( Gaffer.WeakMethod( self.__clicked ) )
 
@@ -59,15 +55,8 @@ class IncrementingPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		pass
 
-	def hasLabel( self ) :
-
-		return True
-
 	def __clicked( self, widget ) :
 
-		assert( widget is self.__button )
-
-		undoState = Gaffer.UndoContext.State.Enabled if self.__undoable else Gaffer.UndoContext.State.Disabled
-
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ), undoState ) :
-			self.getPlug().setValue( self.getPlug().getValue() + self.__increment )
+		# Deliberately not making this undoable, as once we've refreshed
+		# a loaded file, there's no going back.
+		self.getPlug().setValue( self.getPlug().getValue() + 1 )

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -252,6 +252,7 @@ from CompoundDataPlugValueWidget import CompoundDataPlugValueWidget
 from LayoutPlugValueWidget import LayoutPlugValueWidget
 import ScriptNodeUI
 from IncrementingPlugValueWidget import IncrementingPlugValueWidget
+from RefreshPlugValueWidget import RefreshPlugValueWidget
 import PreferencesUI
 from SplinePlugValueWidget import SplinePlugValueWidget
 from RampPlugValueWidget import RampPlugValueWidget


### PR DESCRIPTION
This introduces a new "layout:accessory" metadata that can be used to group a widget with the previous one, and uses it to tidy up those ugly refresh buttons in all the file readers.

![refresh](https://cloud.githubusercontent.com/assets/1133871/18966848/ce46b9fc-867a-11e6-8d4c-10f227fdabf3.png)

It also gets rid of half the uses we had for the deprecated `PlugValueWidget.registerCreator()` method we're working towards removing.

Because the "accessory" metadata can be applied to custom widgets as well as plugs, this also gives us a mechanism for inserting arbitrary little chunks of UI alongside plug widgets anywhere we might need to.