### PR TITLE
OSLCode doc issue

### DIFF
--- a/doc/source/Tutorials/Scripting/UsingTheOSLCodeNode/scripts/blank.gfr
+++ b/doc/source/Tutorials/Scripting/UsingTheOSLCodeNode/scripts/blank.gfr
@@ -17,13 +17,11 @@ parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "name",
 parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "value", defaultValue = '$HOME/gaffer/projects/${project:name}', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
 __children["OSLCode"] = GafferOSL.OSLCode( "OSLCode" )
 parent.addChild( __children["OSLCode"] )
-__children["OSLCode"]["name"].setValue( '/home/john/gaffer/oslCode/oslCode6/0ca1740a/de7e8a48/019a23e3/a46ae35/oslCode60ca1740ade7e8a48019a23e3a46ae35' )
 __children["OSLCode"]["type"].setValue( 'osl:shader' )
 __children["OSLCode"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = IECore.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
 __children["OSLCode"]["__uiPosition"].setValue( IECore.V2f( -4.30000019, -4.10000086 ) )
 parent["variables"]["projectName"]["name"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
 parent["variables"]["projectRootDirectory"]["name"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
-__children["OSLCode"].loadShader( "/home/john/gaffer/oslCode/oslCode6/0ca1740a/de7e8a48/019a23e3/a46ae35/oslCode60ca1740ade7e8a48019a23e3a46ae35", keepExistingValues=True )
 
 
 del __children

--- a/doc/source/Tutorials/Scripting/UsingTheOSLCodeNode/scripts/coloredStripes.gfr
+++ b/doc/source/Tutorials/Scripting/UsingTheOSLCodeNode/scripts/coloredStripes.gfr
@@ -17,7 +17,6 @@ parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "name",
 parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "value", defaultValue = '$HOME/gaffer/projects/${project:name}', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
 __children["OSLCode"] = GafferOSL.OSLCode( "OSLCode" )
 parent.addChild( __children["OSLCode"] )
-__children["OSLCode"]["name"].setValue( '/home/john/gaffer/oslCode/oslCode6/2a70db9d/6970563a/ae48f4fe/f60be6a/oslCode62a70db9d6970563aae48f4fef60be6a' )
 __children["OSLCode"]["type"].setValue( 'osl:shader' )
 __children["OSLCode"]["parameters"].addChild( Gaffer.FloatPlug( "width", defaultValue = 0.0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
 __children["OSLCode"]["parameters"]["width"].setValue( 0.02500000037252903 )
@@ -31,7 +30,6 @@ __children["OSLCode"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = I
 __children["OSLCode"]["__uiPosition"].setValue( IECore.V2f( -6.90000153, 7.79999971 ) )
 parent["variables"]["projectName"]["name"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
 parent["variables"]["projectRootDirectory"]["name"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
-__children["OSLCode"].loadShader( "/home/john/gaffer/oslCode/oslCode6/2a70db9d/6970563a/ae48f4fe/f60be6a/oslCode62a70db9d6970563aae48f4fef60be6a", keepExistingValues=True )
 
 
 del __children

--- a/doc/source/Tutorials/Scripting/UsingTheOSLCodeNode/scripts/parameters.gfr
+++ b/doc/source/Tutorials/Scripting/UsingTheOSLCodeNode/scripts/parameters.gfr
@@ -17,7 +17,6 @@ parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "name",
 parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "value", defaultValue = '$HOME/gaffer/projects/${project:name}', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
 __children["OSLCode"] = GafferOSL.OSLCode( "OSLCode" )
 parent.addChild( __children["OSLCode"] )
-__children["OSLCode"]["name"].setValue( '/home/john/gaffer/oslCode/oslCode8/2992ebdf/e1e10b4a/bf061985/137110b/oslCode82992ebdfe1e10b4abf061985137110b' )
 __children["OSLCode"]["type"].setValue( 'osl:shader' )
 __children["OSLCode"]["parameters"].addChild( Gaffer.FloatPlug( "width", defaultValue = 0.0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
 __children["OSLCode"]["parameters"]["width"].setValue( 0.02500000037252903 )
@@ -26,7 +25,6 @@ __children["OSLCode"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = I
 __children["OSLCode"]["__uiPosition"].setValue( IECore.V2f( -6.90000153, 7.79999971 ) )
 parent["variables"]["projectName"]["name"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
 parent["variables"]["projectRootDirectory"]["name"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
-__children["OSLCode"].loadShader( "/home/john/gaffer/oslCode/oslCode8/2992ebdf/e1e10b4a/bf061985/137110b/oslCode82992ebdfe1e10b4abf061985137110b", keepExistingValues=True )
 
 
 del __children

--- a/doc/source/Tutorials/Scripting/UsingTheOSLCodeNode/scripts/simpleStripes.gfr
+++ b/doc/source/Tutorials/Scripting/UsingTheOSLCodeNode/scripts/simpleStripes.gfr
@@ -17,7 +17,6 @@ parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "name",
 parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "value", defaultValue = '$HOME/gaffer/projects/${project:name}', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
 __children["OSLCode"] = GafferOSL.OSLCode( "OSLCode" )
 parent.addChild( __children["OSLCode"] )
-__children["OSLCode"]["name"].setValue( '/home/john/gaffer/oslCode/oslCodec/68a2bbfd/8ce1ce0c/b536d449/e06dce4/oslCodec68a2bbfd8ce1ce0cb536d449e06dce4' )
 __children["OSLCode"]["type"].setValue( 'osl:shader' )
 __children["OSLCode"]["parameters"].addChild( Gaffer.FloatPlug( "width", defaultValue = 0.0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
 __children["OSLCode"]["parameters"]["width"].setValue( 0.02500000037252903 )
@@ -27,7 +26,6 @@ __children["OSLCode"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = I
 __children["OSLCode"]["__uiPosition"].setValue( IECore.V2f( -6.90000153, 7.79999971 ) )
 parent["variables"]["projectName"]["name"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
 parent["variables"]["projectRootDirectory"]["name"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
-__children["OSLCode"].loadShader( "/home/john/gaffer/oslCode/oslCodec/68a2bbfd/8ce1ce0c/b536d449/e06dce4/oslCodec68a2bbfd8ce1ce0cb536d449e06dce4", keepExistingValues=True )
 
 
 del __children

--- a/python/GafferOSLTest/OSLTestCase.py
+++ b/python/GafferOSLTest/OSLTestCase.py
@@ -43,6 +43,11 @@ class OSLTestCase( GafferSceneTest.SceneTestCase ) :
 	def compileShader( self, sourceFileName ) :
 
 		outputFileName = self.temporaryDirectory() + "/" + os.path.splitext( os.path.basename( sourceFileName ) )[0] + ".oso"
-		os.system( "oslc -q -o %s %s" % ( outputFileName, sourceFileName ) )
+
+		includes = os.environ.get( "OSL_SHADER_PATHS", "" )
+		if includes :
+			includes = "-I" + " -I".join( includes.split( ":" ) )
+
+		os.system( "oslc -q %s -o %s %s" % ( includes, outputFileName, sourceFileName ) )
 
 		return os.path.splitext( outputFileName )[0]

--- a/src/GafferOSL/OSLCode.cpp
+++ b/src/GafferOSL/OSLCode.cpp
@@ -363,6 +363,9 @@ OSLCode::OSLCode( const std::string &name )
 	/// again.
 	addChild( new StringPlug( "code", Plug::In, "", Plug::Default & ~Plug::AcceptsInputs ) );
 
+	// Must disable serialisation on the name because it might represent a local filepath
+	namePlug()->setFlags( Plug::Serialisable, false );
+
 	parametersPlug()->childAddedSignal().connect( boost::bind( &OSLCode::parameterAdded, this, ::_1, ::_2 ) );
 	parametersPlug()->childRemovedSignal().connect( boost::bind( &OSLCode::parameterRemoved, this, ::_1, ::_2 ) );
 

--- a/src/GafferOSLModule/GafferOSLModule.cpp
+++ b/src/GafferOSLModule/GafferOSLModule.cpp
@@ -68,7 +68,11 @@ class OSLShaderSerialiser : public GafferBindings::NodeSerialiser
 	{
 		const OSLShader *oslShader = static_cast<const OSLShader *>( graphComponent );
 		const std::string shaderName = oslShader->namePlug()->getValue();
-		if( shaderName.size() )
+		// we avoid serialising loadShader() for OSLCode
+		// because the current shader may be a local temp
+		// copy, and the shader will be recompiled on script
+		// load anyways.
+		if( shaderName.size() && oslShader->typeId() != OSLCode::staticTypeId() )
 		{
 			return boost::str( boost::format( "%s.loadShader( \"%s\", keepExistingValues=True )\n" ) % identifier % shaderName );
 		}


### PR DESCRIPTION
I can't `scons docs` right now because the `UsingTheOSLCodeNode` tutorial is trying to load .oso files out of `/home/john`. I attempted to fix that here, though I'm not sure what @johnhaddon will think of the approach.

Note that at IE I'm still not happy with this, because I'm getting red-error images for the tutorial instead of the proper stripe-y images. Oddly, when I run `gaffer env ./generate.sh` directly from my terminal I do get the right images output... is this something about the `config/ie/options` file?