### PR TITLE
SceneView precision fixes

### DIFF
--- a/include/GafferUI/ButtonEvent.h
+++ b/include/GafferUI/ButtonEvent.h
@@ -48,6 +48,10 @@ namespace GafferUI
 /// A class to represent events involving mouse buttons.
 /// \todo Now this is being used to represent mouse movement and the scroll wheel,
 /// it should be called MouseEvent.
+/// \todo Add a `V2f point` field containing the Widget-relative position.
+/// This will be convenient for 2d-only Widgets but also allow Gadgets to
+/// get the original raster position for an event without jumping through
+/// hoops and running the gauntlet of precision issues.
 struct ButtonEvent : public ModifiableEvent
 {
 	/// An enum to represent the mouse buttons.

--- a/src/GafferSceneUI/CropWindowTool.cpp
+++ b/src/GafferSceneUI/CropWindowTool.cpp
@@ -374,7 +374,7 @@ class CropWindowTool::Rectangle : public GafferUI::Gadget
 		V2f eventPosition( const ButtonEvent &event ) const
 		{
 			const ViewportGadget *viewportGadget = ancestor<ViewportGadget>();
-			return viewportGadget->gadgetToRasterSpace( event.line.p0, this );
+			return viewportGadget->gadgetToRasterSpace( event.line.p1, this );
 		}
 
 		Imath::Box2f m_rectangle;

--- a/src/GafferSceneUI/SelectionTool.cpp
+++ b/src/GafferSceneUI/SelectionTool.cpp
@@ -229,8 +229,8 @@ IECore::RunTimeTypedPtr SelectionTool::dragBegin( GafferUI::Gadget *gadget, cons
 	if( !sg->objectAt( event.line, objectUnderMouse ) )
 	{
 		// drag to select
-		m_dragOverlay->setStartPosition( event.line.p0 );
-		m_dragOverlay->setEndPosition( event.line.p0 );
+		m_dragOverlay->setStartPosition( event.line.p1 );
+		m_dragOverlay->setEndPosition( event.line.p1 );
 		m_dragOverlay->setVisible( true );
 		return gadget;
 	}
@@ -256,7 +256,7 @@ bool SelectionTool::dragEnter( const GafferUI::Gadget *gadget, const GafferUI::D
 
 bool SelectionTool::dragMove( const GafferUI::DragDropEvent &event )
 {
-	m_dragOverlay->setEndPosition( event.line.p0 );
+	m_dragOverlay->setEndPosition( event.line.p1 );
 	return true;
 }
 

--- a/src/GafferUI/ViewportGadget.cpp
+++ b/src/GafferUI/ViewportGadget.cpp
@@ -275,7 +275,7 @@ IECore::LineSegment3f ViewportGadget::rasterToGadgetSpace( const Imath::V2f &pos
 {
 	LineSegment3f result;
 	/// \todo The CameraController::unproject() method should be const.
-	const_cast<IECore::CameraController &>( m_cameraController ).unproject( V2i( (int)position.x, (int)position.y ), result.p0, result.p1 );
+	const_cast<IECore::CameraController &>( m_cameraController ).unproject( position, result.p0, result.p1 );
 	if( gadget )
 	{
 		M44f m = gadget->fullTransform();
@@ -296,7 +296,7 @@ IECore::LineSegment3f ViewportGadget::rasterToWorldSpace( const Imath::V2f &rast
 {
 	LineSegment3f result;
 	/// \todo The CameraController::unproject() method should be const.
-	const_cast<IECore::CameraController &>( m_cameraController ).unproject( V2i( (int)rasterPosition.x, (int)rasterPosition.y ), result.p0, result.p1 );
+	const_cast<IECore::CameraController &>( m_cameraController ).unproject( rasterPosition, result.p0, result.p1 );
 	return result;
 }
 
@@ -837,10 +837,10 @@ bool ViewportGadget::wheel( GadgetPtr gadget, const ButtonEvent &event )
 		return true;
 	}
 
-	V2i position( (int)event.line.p0.x, (int)event.line.p0.y );
+	V2f position( event.line.p0.x, event.line.p0.y );
 
 	m_cameraController.motionStart( CameraController::Dolly, position );
-	position.x += (int)(event.wheelRotation * getViewport().x / 140.0f);
+	position.x += event.wheelRotation * getViewport().x / 140.0f;
 	m_cameraController.motionUpdate( position );
 	m_cameraController.motionEnd( position );
 

--- a/src/GafferUI/ViewportGadget.cpp
+++ b/src/GafferUI/ViewportGadget.cpp
@@ -325,7 +325,7 @@ void ViewportGadget::doRender( const Style *style ) const
 	// Set up the camera to world matrix in gl_TextureMatrix[0] so that we can
 	// reference world space positions in shaders
 	// This should be more appropriately named in a uniform buffer, but the
-	// easiest time to get this right is probably when we switch everything 
+	// easiest time to get this right is probably when we switch everything
 	// away from using fixed function stuff
 	glActiveTexture( GL_TEXTURE0 );
 	glMatrixMode( GL_TEXTURE );
@@ -918,7 +918,7 @@ ViewportGadget::SelectionScope::SelectionScope( const IECore::LineSegment3f &lin
 	:	m_selection( selection )
 {
 	const ViewportGadget *viewportGadget = gadget->ancestor<ViewportGadget>();
-	V2f rasterPosition = viewportGadget->gadgetToRasterSpace( lineInGadgetSpace.p0, gadget );
+	V2f rasterPosition = viewportGadget->gadgetToRasterSpace( lineInGadgetSpace.p1, gadget );
 	begin( viewportGadget, rasterPosition, gadget->fullTransform(), mode );
 }
 


### PR DESCRIPTION
This fixes precision problems that affected the SelectionTool and CropWindow tool when operating far from the origin. The first V2i->V2f commit isn't necessary for fixing that issue, but seemed worth doing while I was looking at this part of the codebase. I've also suggested an improved approach in the comments, which I suspect will be worth doing at some point (unless you think now is the time?).

@danieldresser, would be great to get your eyes on this, because you have a better handle on this sort of thing than I do.