### PR TITLE
added home shortcut for image view

### DIFF
--- a/src/GafferImageUI/ImageView.cpp
+++ b/src/GafferImageUI/ImageView.cpp
@@ -394,6 +394,19 @@ bool ImageView::keyPress( const GafferUI::KeyEvent &event )
 				return true;
 			}
 		}
+		if(event.key == "Home")
+		{
+			V2i viewport = viewportGadget()->getViewport();
+			V3f halfViewportSize(viewport.x / 2, viewport.y / 2, 0);
+			V3f imageCenter = m_imageGadget->bound().center();
+			viewportGadget()->frame(
+				Box3f(
+					V3f(imageCenter.x - halfViewportSize.x, imageCenter.y - halfViewportSize.y, 0),
+					V3f(imageCenter.x + halfViewportSize.x, imageCenter.y + halfViewportSize.y, 0)
+				)
+			);
+			return true;
+		}
 	}
 
 	return false;


### PR DESCRIPTION
#### GafferImageUI
[#1877]
- 2d Viewer:

 - "home" key sets 2d Image Viewer ratio to 1:1 .